### PR TITLE
Allow passing Box Props to Progress Bar Component

### DIFF
--- a/apps/storybook/src/feedback/Progress.stories.tsx
+++ b/apps/storybook/src/feedback/Progress.stories.tsx
@@ -1,16 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Button, Flex, ProgressBar } from "@optiaxiom/react";
+import { Button, Flex, Progress } from "@optiaxiom/react";
 import { userEvent, within } from "@storybook/test";
 import { useState } from "react";
 
-const meta: Meta<typeof ProgressBar> = {
-  component: ProgressBar,
+const meta: Meta<typeof Progress> = {
+  component: Progress,
 };
 
 export default meta;
 
-type Story = StoryObj<typeof ProgressBar>;
+type Story = StoryObj<typeof Progress>;
 
 export const Primary: Story = {
   args: {
@@ -43,7 +43,7 @@ export const CompletionStages: Story = {
         </Flex>
 
         {values.map(({ max, value }, index) => (
-          <ProgressBar
+          <Progress
             bg="bg.brand.subtle"
             key={index}
             max={max}

--- a/apps/storybook/src/feedback/ProgressBar.stories.tsx
+++ b/apps/storybook/src/feedback/ProgressBar.stories.tsx
@@ -45,6 +45,7 @@ export const CompletionStages: Story = {
             key={index}
             max={max}
             value={typeof value !== "undefined" ? value * scale : undefined}
+            w="1/2"
           />
         ))}
       </Flex>

--- a/apps/storybook/src/feedback/ProgressBar.stories.tsx
+++ b/apps/storybook/src/feedback/ProgressBar.stories.tsx
@@ -17,6 +17,7 @@ export const Primary: Story = {
     h: "12",
     max: 60,
     value: 30,
+    bg: "bg.brand.subtle",
   },
 };
 
@@ -44,6 +45,7 @@ export const CompletionStages: Story = {
         {values.map(({ max, value }, index) => (
           <ProgressBar
             key={index}
+            bg="bg.brand.subtle"
             max={max}
             value={typeof value !== "undefined" ? value * scale : undefined}
             w="1/2"

--- a/apps/storybook/src/feedback/ProgressBar.stories.tsx
+++ b/apps/storybook/src/feedback/ProgressBar.stories.tsx
@@ -14,10 +14,10 @@ type Story = StoryObj<typeof ProgressBar>;
 
 export const Primary: Story = {
   args: {
+    bg: "bg.brand.subtle",
     h: "12",
     max: 60,
     value: 30,
-    bg: "bg.brand.subtle",
   },
 };
 
@@ -44,8 +44,8 @@ export const CompletionStages: Story = {
 
         {values.map(({ max, value }, index) => (
           <ProgressBar
-            key={index}
             bg="bg.brand.subtle"
+            key={index}
             max={max}
             value={typeof value !== "undefined" ? value * scale : undefined}
             w="1/2"

--- a/apps/storybook/src/feedback/ProgressBar.stories.tsx
+++ b/apps/storybook/src/feedback/ProgressBar.stories.tsx
@@ -14,6 +14,7 @@ type Story = StoryObj<typeof ProgressBar>;
 
 export const Primary: Story = {
   args: {
+    h: "12",
     max: 60,
     value: 30,
   },

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,7 +9,7 @@ export * from "./heading";
 export * from "./input";
 export * from "./kbd";
 export * from "./paper";
-export * from "./progress-bar";
+export * from "./progress";
 export * from "./separator";
 export * from "./skeleton";
 export * from "./sprinkles";

--- a/packages/react/src/progress-bar/ProgressBar.tsx
+++ b/packages/react/src/progress-bar/ProgressBar.tsx
@@ -13,24 +13,32 @@ export const ProgressBar = forwardRef<
   ElementRef<typeof ProgressPrimitive.Root>,
   ProgressBarProps
 >((props, ref) => {
-  const widthPercentage = ((props.value ?? 0) / (props.max ?? 100)) * 100;
+  const widthPercentage =
+    ((props.value ?? 0) / (props.max ?? DEFAULT_MAX)) * 100;
+  const isValidValue =
+    props.value &&
+    props.value >= 0 &&
+    props.value <= (props.max ?? DEFAULT_MAX);
 
   return (
     <Box asChild h="6" rounded="lg" {...props}>
       <ProgressPrimitive.Root ref={ref}>
-        <Box
-          asChild
-          bg="bg.brand.solid"
-          h="full"
-          rounded="lg"
-          style={{ width: `${widthPercentage}%` }}
-          transition="all"
-        >
-          <ProgressPrimitive.Indicator />
-        </Box>
+        {isValidValue && (
+          <Box
+            asChild
+            bg="bg.brand.solid"
+            h="full"
+            rounded="lg"
+            style={{ width: `${widthPercentage}%` }}
+            transition="all"
+          >
+            <ProgressPrimitive.Indicator />
+          </Box>
+        )}
       </ProgressPrimitive.Root>
     </Box>
   );
 });
 
+const DEFAULT_MAX = 100;
 ProgressBar.displayName = "@optiaxiom/react/ProgressBar";

--- a/packages/react/src/progress-bar/ProgressBar.tsx
+++ b/packages/react/src/progress-bar/ProgressBar.tsx
@@ -16,8 +16,8 @@ export const ProgressBar = forwardRef<
   const widthPercentage = ((props.value ?? 0) / (props.max ?? 100)) * 100;
 
   return (
-    <Box asChild border="1" h="6" overflow="hidden" {...props}>
-      <ProgressPrimitive.Root ref={ref} {...props}>
+    <Box asChild h="6" rounded="lg" {...props}>
+      <ProgressPrimitive.Root ref={ref}>
         <Box
           asChild
           bg="bg.brand.solid"

--- a/packages/react/src/progress-bar/ProgressBar.tsx
+++ b/packages/react/src/progress-bar/ProgressBar.tsx
@@ -6,17 +6,17 @@ import { type ExtendProps } from "../utils";
 
 type ProgressBarProps = ExtendProps<
   ComponentPropsWithRef<typeof ProgressPrimitive.Root>,
-  Pick<ComponentPropsWithRef<typeof Box>, "w">
+  ComponentPropsWithRef<typeof Box>
 >;
 
 export const ProgressBar = forwardRef<
   ElementRef<typeof ProgressPrimitive.Root>,
   ProgressBarProps
->(({ w = "2/3", ...props }, ref) => {
+>((props, ref) => {
   const widthPercentage = ((props.value ?? 0) / (props.max ?? 100)) * 100;
 
   return (
-    <Box asChild border="1" h="6" overflow="hidden" w={w}>
+    <Box asChild border="1" h="6" overflow="hidden" {...props}>
       <ProgressPrimitive.Root ref={ref} {...props}>
         <Box
           asChild

--- a/packages/react/src/progress-bar/ProgressBar.tsx
+++ b/packages/react/src/progress-bar/ProgressBar.tsx
@@ -2,23 +2,27 @@ import * as ProgressPrimitive from "@radix-ui/react-progress";
 import { type ComponentPropsWithRef, type ElementRef, forwardRef } from "react";
 
 import { Box } from "../box";
+import { type ExtendProps } from "../utils";
 
-type ProgressBarProps = ComponentPropsWithRef<typeof ProgressPrimitive.Root>;
+type ProgressBarProps = ExtendProps<
+  ComponentPropsWithRef<typeof ProgressPrimitive.Root>,
+  Pick<ComponentPropsWithRef<typeof Box>, "w">
+>;
 
 export const ProgressBar = forwardRef<
   ElementRef<typeof ProgressPrimitive.Root>,
   ProgressBarProps
->((props, ref) => {
+>(({ w = "2/3", ...props }, ref) => {
   const widthPercentage = ((props.value ?? 0) / (props.max ?? 100)) * 100;
 
   return (
-    <Box asChild border="1" h="6" overflow="hidden" w="1/2">
+    <Box asChild border="1" h="6" overflow="hidden" w={w}>
       <ProgressPrimitive.Root ref={ref} {...props}>
         <Box
           asChild
           bg="bg.brand.solid"
           h="full"
-          rounded="md"
+          rounded="lg"
           style={{ width: `${widthPercentage}%` }}
           transition="all"
         >

--- a/packages/react/src/progress-bar/index.ts
+++ b/packages/react/src/progress-bar/index.ts
@@ -1,1 +1,0 @@
-export * from "./ProgressBar";

--- a/packages/react/src/progress/Progress.tsx
+++ b/packages/react/src/progress/Progress.tsx
@@ -4,14 +4,14 @@ import { type ComponentPropsWithRef, type ElementRef, forwardRef } from "react";
 import { Box } from "../box";
 import { type ExtendProps } from "../utils";
 
-type ProgressBarProps = ExtendProps<
+type ProgressProps = ExtendProps<
   ComponentPropsWithRef<typeof ProgressPrimitive.Root>,
   ComponentPropsWithRef<typeof Box>
 >;
 
-export const ProgressBar = forwardRef<
+export const Progress = forwardRef<
   ElementRef<typeof ProgressPrimitive.Root>,
-  ProgressBarProps
+  ProgressProps
 >((props, ref) => {
   const widthPercentage =
     ((props.value ?? 0) / (props.max ?? DEFAULT_MAX)) * 100;
@@ -41,4 +41,4 @@ export const ProgressBar = forwardRef<
 });
 
 const DEFAULT_MAX = 100;
-ProgressBar.displayName = "@optiaxiom/react/ProgressBar";
+Progress.displayName = "@optiaxiom/react/Progress";

--- a/packages/react/src/progress/index.ts
+++ b/packages/react/src/progress/index.ts
@@ -1,0 +1,1 @@
+export * from "./Progress";


### PR DESCRIPTION
Issue: #68 

Allows the `Box` Component's props to be passed to the Progress Bar Component.  