### PR TITLE
fork recipes to support sprinkles natively

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
     "editor.wordWrap": "bounded",
     "editor.wordWrapColumn": 80
   },
+  "cSpell.enableFiletypes": ["markdown", "mdx"],
   "cSpell.words": ["clsx", "optiaxiom", "optimizely"],
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"

--- a/apps/docs/pages/getting-started/css-layers.mdx
+++ b/apps/docs/pages/getting-started/css-layers.mdx
@@ -44,7 +44,7 @@ If you are importing a third party library then you can include the layer in the
 
 Because Axiom components import their own CSS files, depending on how your bundler is configured, in certain cases you might end up loading vendor styles before any of your application styles. This will force `optiaxiom` layer to always come first and prevent you from adding any other layer before it.
 
-In these cases you can use the built-in `optiaxiom.base` layer to palce your own styles before any of Axiom's other styles.
+In these cases you can use the built-in `optiaxiom.base` layer to place your own styles before any of Axiom's other styles.
 
 ```css
 @layer optiaxiom.base {

--- a/apps/storybook/src/forms/Button.stories.tsx
+++ b/apps/storybook/src/forms/Button.stories.tsx
@@ -85,6 +85,13 @@ export const Preset: Story = {
   ),
 };
 
+export const Link: Story = {
+  args: {
+    asChild: true,
+    children: <a href="/">Sample Link</a>,
+  },
+};
+
 export const StandaloneIcon: Story = {
   args: {
     children: <IconHelicopterLanding />,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,6 @@
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@reach/auto-id": "^0.18.0",
-    "@vanilla-extract/recipes": "^0.5.3",
     "@vanilla-extract/sprinkles": "^1.6.2",
     "clsx": "^2.1.1",
     "inter-ui": "^4.0.2"

--- a/packages/react/src/avatar/Avatar.css.ts
+++ b/packages/react/src/avatar/Avatar.css.ts
@@ -1,16 +1,20 @@
-import { sprinkles } from "../sprinkles";
 import { mapValues } from "../utils";
+import { style } from "../vanilla-extract";
 import { type RecipeVariants, recipe } from "../vanilla-extract";
 
 export const avatar = recipe({
-  base: {
-    alignItems: "center",
-    borderRadius: "100%",
-    display: "inline-flex",
-    justifyContent: "center",
-    overflow: "hidden",
-    userSelect: "none",
-  },
+  base: [
+    {
+      alignItems: "center",
+      display: "inline-flex",
+      justifyContent: "center",
+      overflow: "hidden",
+      rounded: "full",
+    },
+    style({
+      userSelect: "none",
+    }),
+  ],
 
   variants: {
     colorScheme: mapValues(
@@ -28,18 +32,17 @@ export const avatar = recipe({
         slate: "slate",
         yellow: "yellow",
       } as const,
-      (color) =>
-        sprinkles({
-          bg: `${color}.50`,
-          color: `${color}.500`,
-        }),
+      (color) => ({
+        bg: `${color}.50`,
+        color: `${color}.500`,
+      }),
     ),
     size: {
-      xs: sprinkles({ fontSize: "xs", size: "xs" }),
-      sm: sprinkles({ fontSize: "sm", size: "sm" }),
-      md: sprinkles({ fontSize: "md", size: "md" }),
-      lg: sprinkles({ fontSize: "lg", size: "lg" }),
-      xl: sprinkles({ fontSize: "xl", size: "xl" }),
+      xs: { fontSize: "xs", size: "xs" },
+      sm: { fontSize: "sm", size: "sm" },
+      md: { fontSize: "md", size: "md" },
+      lg: { fontSize: "lg", size: "lg" },
+      xl: { fontSize: "xl", size: "xl" },
     },
   },
 });
@@ -47,22 +50,22 @@ export const avatar = recipe({
 export type AvatarVariants = RecipeVariants<typeof avatar>;
 
 export const fallback = recipe({
-  base: sprinkles({
+  base: {
     alignItems: "center",
     display: "flex",
     justifyContent: "center",
     rounded: "inherit",
     size: "full",
     textTransform: "uppercase",
-  }),
+  },
 
   variants: {
     size: {
-      xs: sprinkles({ px: "4" }),
-      sm: sprinkles({ px: "6" }),
-      md: sprinkles({ px: "8" }),
-      lg: sprinkles({ px: "10" }),
-      xl: sprinkles({ px: "20" }),
+      xs: { px: "4" },
+      sm: { px: "6" },
+      md: { px: "8" },
+      lg: { px: "10" },
+      xl: { px: "20" },
     },
   },
 });

--- a/packages/react/src/avatar/Avatar.tsx
+++ b/packages/react/src/avatar/Avatar.tsx
@@ -1,5 +1,4 @@
 import * as RadixAvatar from "@radix-ui/react-avatar";
-import clsx from "clsx";
 import { type ComponentPropsWithRef, forwardRef } from "react";
 
 import type { ExtendProps } from "../utils";
@@ -46,14 +45,14 @@ export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
     return (
       <Box
         asChild
-        className={clsx(styles.avatar({ colorScheme, size }), className)}
+        {...styles.avatar({ colorScheme, size }, className)}
         {...props}
       >
         <RadixAvatar.Root ref={ref}>
           <Box asChild objectFit="cover" rounded="inherit" size="full">
             <RadixAvatar.Image alt={name} src={src} />
           </Box>
-          <Box asChild className={styles.fallback({ size })}>
+          <Box asChild {...styles.fallback({ size })}>
             <RadixAvatar.Fallback delayMs={FALLBACK_DELAY_IN_MS}>
               {/* TODO: Add a generic user icon, if `children` is `undefined` */}
               {icon ? icon : name ? getInitialsFromName(name) : children}

--- a/packages/react/src/box/Box.css.ts
+++ b/packages/react/src/box/Box.css.ts
@@ -2,172 +2,175 @@
 import { style } from "@vanilla-extract/css";
 
 import { layers, theme } from "../styles";
+import { recipe } from "../vanilla-extract";
 
-export const base = style({
-  "@layer": {
-    [layers.reset]: {
-      border: `0 solid ${theme.colors["border.default"]}`,
-      boxSizing: "border-box",
-      fontFamily: theme.fontFamily.sans,
-      fontFeatureSettings: '"cv02", "cv03", "cv04", "cv11"',
-      margin: 0,
-      padding: 0,
-      selectors: {
-        ...{
-          /**
-           * 1. Add the correct height in Firefox.
-           * 2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
-           * 3. Ensure horizontal rules are visible by default.
-           */
-          "&:is(hr)": {
-            borderTopWidth: "1px" /* 3 */,
-            color: "inherit" /* 2 */,
-            height: 0 /* 1 */,
-          },
-        },
-
-        ...{
-          /**
-           * Remove the default font size and weight for headings.
-           */
-          "&:is(h1, h2, h3, h4, h5, h6)": {
-            fontSize: "inherit",
-            fontWeight: "inherit",
-          },
-        },
-
-        ...{
-          /**
-           * Add the correct font weight in Edge and Safari.
-           */
-          "&:is(b, strong)": {
-            fontWeight: "bolder",
-          },
-        },
-
-        ...{
-          /**
-           * 1. Use the user's configured `mono` font-family by default.
-           * 2. Use the user's configured `mono` font-feature-settings by default.
-           * 4. Correct the odd `em` font sizing in all browsers.
-           */
-          "&:is(code, kbd, samp, pre)": {
-            fontFamily: theme.fontFamily.mono /* 1 */,
-            fontFeatureSettings: "normal" /* 2 */,
-            fontSize: "1em" /* 4 */,
-          },
-        },
-
-        ...{
-          /**
-           * 1. Change the font styles in all browsers.
-           */
-          "&:is(button, input, optgroup, select, textarea)": {
-            color: "inherit" /* 1 */,
-            fontSize: "100%" /* 1 */,
-            letterSpacing: "inherit" /* 1 */,
-          },
-        },
-
-        ...{
-          /**
-           * 1. Correct the inability to style clickable types in iOS and Safari.
-           * 2. Remove default button styles.
-           */
-          "&:is(button, input:where([type=button], [type=reset], [type=submit]))":
-            {
-              WebkitAppearance: "button",
-              backgroundColor: "transparent" /* 2 */,
-              backgroundImage: "none" /* 2 */,
+export const box = recipe({
+  base: style({
+    "@layer": {
+      [layers.reset]: {
+        border: `0 solid ${theme.colors["border.default"]}`,
+        boxSizing: "border-box",
+        fontFamily: theme.fontFamily.sans,
+        fontFeatureSettings: '"cv02", "cv03", "cv04", "cv11"',
+        margin: 0,
+        padding: 0,
+        selectors: {
+          ...{
+            /**
+             * 1. Add the correct height in Firefox.
+             * 2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+             * 3. Ensure horizontal rules are visible by default.
+             */
+            "&:is(hr)": {
+              borderTopWidth: "1px" /* 3 */,
+              color: "inherit" /* 2 */,
+              height: 0 /* 1 */,
             },
-        },
-
-        ...{
-          /**
-           * 1. Correct the odd appearance in Chrome and Safari.
-           * 2. Correct the outline style in Safari.
-           */
-          "&:is([type=search])": {
-            WebkitAppearance: "textfield" /* 1 */,
-            outlineOffset: "-2px" /* 2 */,
           },
-        },
 
-        ...{
-          /**
-           * 1. Correct the inability to style clickable types in iOS and Safari.
-           * 2. Change font properties to `inherit` in Safari.
-           */
-          "&::-webkit-file-upload-button": {
-            WebkitAppearance: "button" /* 1 */,
-            font: "inherit" /* 2 */,
+          ...{
+            /**
+             * Remove the default font size and weight for headings.
+             */
+            "&:is(h1, h2, h3, h4, h5, h6)": {
+              fontSize: "inherit",
+              fontWeight: "inherit",
+            },
           },
-        },
 
-        ...{
-          "&:is(ol, ul, menu)": {
-            listStyle: "none",
+          ...{
+            /**
+             * Add the correct font weight in Edge and Safari.
+             */
+            "&:is(b, strong)": {
+              fontWeight: "bolder",
+            },
           },
-        },
 
-        ...{
-          "&:is(textarea)": {
-            resize: "vertical",
+          ...{
+            /**
+             * 1. Use the user's configured `mono` font-family by default.
+             * 2. Use the user's configured `mono` font-feature-settings by default.
+             * 4. Correct the odd `em` font sizing in all browsers.
+             */
+            "&:is(code, kbd, samp, pre)": {
+              fontFamily: theme.fontFamily.mono /* 1 */,
+              fontFeatureSettings: "normal" /* 2 */,
+              fontSize: "1em" /* 4 */,
+            },
           },
-        },
 
-        ...{
-          /**
-           * 1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
-           * 2. Set the default placeholder color to the user's configured gray 400 color.
-           */
-          "&:is(input, textarea)::placeholder": {
-            color: theme.colors["neutral.600"] /* 2 */,
-            opacity: 1 /* 1 */,
+          ...{
+            /**
+             * 1. Change the font styles in all browsers.
+             */
+            "&:is(button, input, optgroup, select, textarea)": {
+              color: "inherit" /* 1 */,
+              fontSize: "100%" /* 1 */,
+              letterSpacing: "inherit" /* 1 */,
+            },
           },
-        },
 
-        ...{
-          /**
-           * Set the default cursor for buttons.
-           */
-          "&:is(button, [role=button])": {
-            cursor: "pointer",
+          ...{
+            /**
+             * 1. Correct the inability to style clickable types in iOS and Safari.
+             * 2. Remove default button styles.
+             */
+            "&:is(button, input:where([type=button], [type=reset], [type=submit]))":
+              {
+                WebkitAppearance: "button",
+                backgroundColor: "transparent" /* 2 */,
+                backgroundImage: "none" /* 2 */,
+              },
           },
-        },
 
-        ...{
-          /**
-           * Make sure disabled buttons don't get the pointer cursor.
-           */
-          "&:is(:disabled)": {
-            cursor: "default",
+          ...{
+            /**
+             * 1. Correct the odd appearance in Chrome and Safari.
+             * 2. Correct the outline style in Safari.
+             */
+            "&:is([type=search])": {
+              WebkitAppearance: "textfield" /* 1 */,
+              outlineOffset: "-2px" /* 2 */,
+            },
           },
-        },
 
-        ...{
-          /**
-           * Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
-           */
-          "&:is(img, svg, video, canvas, audio, iframe, embed, object)": {
-            display: "block",
+          ...{
+            /**
+             * 1. Correct the inability to style clickable types in iOS and Safari.
+             * 2. Change font properties to `inherit` in Safari.
+             */
+            "&::-webkit-file-upload-button": {
+              WebkitAppearance: "button" /* 1 */,
+              font: "inherit" /* 2 */,
+            },
           },
-        },
 
-        ...{
-          /**
-           * Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14)
-           */
-          "&:is(img, video)": {
-            height: "auto",
-            maxWidth: "100%",
+          ...{
+            "&:is(ol, ul, menu)": {
+              listStyle: "none",
+            },
           },
-        },
 
-        "&:is(select)": {
-          appearance: "none",
+          ...{
+            "&:is(textarea)": {
+              resize: "vertical",
+            },
+          },
+
+          ...{
+            /**
+             * 1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
+             * 2. Set the default placeholder color to the user's configured gray 400 color.
+             */
+            "&:is(input, textarea)::placeholder": {
+              color: theme.colors["neutral.600"] /* 2 */,
+              opacity: 1 /* 1 */,
+            },
+          },
+
+          ...{
+            /**
+             * Set the default cursor for buttons.
+             */
+            "&:is(button, [role=button])": {
+              cursor: "pointer",
+            },
+          },
+
+          ...{
+            /**
+             * Make sure disabled buttons don't get the pointer cursor.
+             */
+            "&:is(:disabled)": {
+              cursor: "default",
+            },
+          },
+
+          ...{
+            /**
+             * Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
+             */
+            "&:is(img, svg, video, canvas, audio, iframe, embed, object)": {
+              display: "block",
+            },
+          },
+
+          ...{
+            /**
+             * Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14)
+             */
+            "&:is(img, video)": {
+              height: "auto",
+              maxWidth: "100%",
+            },
+          },
+
+          "&:is(select)": {
+            appearance: "none",
+          },
         },
       },
     },
-  },
+  }),
 });

--- a/packages/react/src/box/Box.tsx
+++ b/packages/react/src/box/Box.tsx
@@ -23,8 +23,8 @@ export const Box = forwardRef<HTMLDivElement, BoxProps>(
 
     return (
       <Comp
-        className={clsx(className, styles.base, sprinkles(sprinkleProps))}
         ref={ref}
+        {...styles.box({}, clsx(className, sprinkles(sprinkleProps)))}
         {...restProps}
       />
     );

--- a/packages/react/src/button-group/ButtonGroup.css.ts
+++ b/packages/react/src/button-group/ButtonGroup.css.ts
@@ -1,73 +1,73 @@
-import { type RecipeVariants, recipe } from "../vanilla-extract";
+import { type RecipeVariants, recipe, style } from "../vanilla-extract";
 
 export const button = recipe({
-  base: {
+  base: style({
     selectors: {
       "&:not(:first-child):not(:last-child)": {
         borderRadius: 0,
       },
     },
-  },
-  compoundVariants: [
-    {
-      style: {
-        selectors: {
-          ["&:not(:first-child)"]: {
-            borderLeft: "none",
-          },
-        },
-      },
-      variants: {
-        orientation: "horizontal",
-        spacing: false,
-      },
-    },
-    {
-      style: {
-        selectors: {
-          ["&:not(:first-child)"]: {
-            borderTop: "none",
-          },
-        },
-      },
-      variants: {
-        orientation: "vertical",
-        spacing: false,
-      },
-    },
-  ],
+  }),
   variants: {
     orientation: {
-      horizontal: {
+      horizontal: style({
         selectors: {
-          [`&:first-child`]: {
+          "&:first-child": {
             borderBottomRightRadius: 0,
             borderTopRightRadius: 0,
           },
-          [`&:last-child`]: {
+          "&:last-child": {
             borderBottomLeftRadius: 0,
             borderTopLeftRadius: 0,
           },
         },
-      },
-      vertical: {
+      }),
+      vertical: style({
         selectors: {
-          [`&:first-child`]: {
+          "&:first-child": {
             borderBottomLeftRadius: 0,
             borderBottomRightRadius: 0,
           },
-          [`&:last-child`]: {
+          "&:last-child": {
             borderTopLeftRadius: 0,
             borderTopRightRadius: 0,
           },
         },
-      },
+      }),
     },
     spacing: {
       false: {},
       true: {},
     },
   },
+  variantsCompounded: [
+    {
+      style: style({
+        selectors: {
+          "&:not(:first-child)": {
+            borderLeft: "none",
+          },
+        },
+      }),
+      variants: {
+        orientation: "horizontal",
+        spacing: false,
+      },
+    },
+    {
+      style: style({
+        selectors: {
+          "&:not(:first-child)": {
+            borderTop: "none",
+          },
+        },
+      }),
+      variants: {
+        orientation: "vertical",
+        spacing: false,
+      },
+    },
+  ],
 });
 
 export type ButtonGroupVariants = RecipeVariants<typeof button>;

--- a/packages/react/src/button-group/ButtonGroup.tsx
+++ b/packages/react/src/button-group/ButtonGroup.tsx
@@ -46,7 +46,7 @@ export const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
         return (
           <Box
             asChild
-            className={styles.button({ orientation, spacing: gap !== "0" })}
+            {...styles.button({ orientation, spacing: gap !== "0" })}
           >
             {cloneElement(child, {
               colorScheme: child.props.colorScheme || colorScheme,

--- a/packages/react/src/button/Button.css.ts
+++ b/packages/react/src/button/Button.css.ts
@@ -1,5 +1,5 @@
 import { theme } from "../styles";
-import { createVar } from "../vanilla-extract";
+import { createVar, style } from "../vanilla-extract";
 import { type RecipeVariants, recipe } from "../vanilla-extract";
 
 const accentColorVar = createVar();
@@ -7,51 +7,39 @@ const solidAccentColorVar = createVar();
 const subtleAccentColorVar = createVar();
 
 export const button = recipe({
-  base: {
-    alignItems: "center",
-    border: "0",
-    borderRadius: theme.borderRadius.sm,
-    cursor: "pointer",
-    display: "inline-flex",
-    flexDirection: "row",
-    gap: theme.spacing.xs,
-    justifyContent: "center",
-    overflow: "hidden",
-    position: "relative",
-    transitionDuration: "150ms",
-    transitionProperty: "background-color, border-color, color",
-    transitionTimingFunction: "ease",
-
-    selectors: {
-      '&:active:not([data-disabled="true"])': {
-        boxShadow: theme.boxShadow.inner,
-      },
-      "&:focus-visible": {
-        outlineOffset: "1px",
-        outlineStyle: "solid",
-        outlineWidth: "1px",
-      },
-      '&[data-disabled="true"]': {
-        cursor: "not-allowed",
-      },
-    },
-  },
-
-  compoundVariants: [
+  base: [
     {
-      style: {
-        borderColor: theme.colors["border.default"],
-      },
-      variants: {
-        colorScheme: "secondary",
-        variant: "outline",
-      },
+      alignItems: "center",
+      display: "inline-flex",
+      flexDirection: "row",
+      gap: "xs",
+      justifyContent: "center",
+      overflow: "hidden",
+      transition: "colors",
     },
-  ],
+    style({
+      borderRadius: theme.borderRadius.sm,
+      cursor: "pointer",
+      position: "relative",
 
+      selectors: {
+        '&:active:not([data-disabled="true"])': {
+          boxShadow: theme.boxShadow.inner,
+        },
+        "&:focus-visible": {
+          outlineOffset: "1px",
+          outlineStyle: "solid",
+          outlineWidth: "1px",
+        },
+        '&[data-disabled="true"]': {
+          cursor: "not-allowed",
+        },
+      },
+    }),
+  ],
   variants: {
     colorScheme: {
-      danger: {
+      danger: style({
         vars: {
           [accentColorVar]: theme.colors["bg.error.solid"],
           [solidAccentColorVar]: theme.colors["bg.error.solid.hover"],
@@ -63,8 +51,8 @@ export const button = recipe({
             outlineColor: "red.200",
           },
         },
-      },
-      primary: {
+      }),
+      primary: style({
         vars: {
           [accentColorVar]: theme.colors["bg.brand.solid"],
           [solidAccentColorVar]: theme.colors["bg.brand.solid.hover"],
@@ -76,8 +64,8 @@ export const button = recipe({
             outlineColor: theme.colors["brand.300"],
           },
         },
-      },
-      secondary: {
+      }),
+      secondary: style({
         vars: {
           [accentColorVar]: theme.colors["fg.secondary"],
           [solidAccentColorVar]: theme.colors["fg.secondary.hover"],
@@ -89,30 +77,27 @@ export const button = recipe({
             outlineColor: theme.colors["neutral.500"],
           },
         },
-      },
+      }),
     },
     size: {
       sm: {
-        fontSize: theme.fontSize["sm"].fontSize,
-        height: "24px",
-        lineHeight: theme.fontSize["sm"].lineHeight,
-        paddingInline: "10px",
+        fontSize: "sm",
+        h: "24",
+        px: "10",
       },
       md: {
-        fontSize: theme.fontSize["md"].fontSize,
-        height: "32px",
-        lineHeight: theme.fontSize["md"].lineHeight,
-        paddingInline: "12px",
+        fontSize: "md",
+        h: "32",
+        px: "12",
       },
       lg: {
-        fontSize: theme.fontSize["lg"].fontSize,
-        height: "40px",
-        lineHeight: theme.fontSize["lg"].lineHeight,
-        paddingInline: "16px",
+        fontSize: "lg",
+        h: "40",
+        px: "16",
       },
     },
     variant: {
-      ghost: {
+      ghost: style({
         backgroundColor: "transparent",
         color: accentColorVar,
 
@@ -125,8 +110,8 @@ export const button = recipe({
             color: theme.colors["fg.disabled"],
           },
         },
-      },
-      outline: {
+      }),
+      outline: style({
         backgroundColor: "transparent",
         border: `1px solid ${accentColorVar}`,
         color: accentColorVar,
@@ -140,8 +125,8 @@ export const button = recipe({
             color: theme.colors["fg.disabled"],
           },
         },
-      },
-      solid: {
+      }),
+      solid: style({
         backgroundColor: accentColorVar,
         color: theme.colors["fg.default.inverse"],
 
@@ -155,9 +140,20 @@ export const button = recipe({
             color: theme.colors["fg.disabled"],
           },
         },
-      },
+      }),
     },
   },
+  variantsCompounded: [
+    {
+      style: style({
+        borderColor: theme.colors["border.default"],
+      }),
+      variants: {
+        colorScheme: "secondary",
+        variant: "outline",
+      },
+    },
+  ],
 });
 
 export type ButtonVariants = RecipeVariants<typeof button>;

--- a/packages/react/src/button/Button.css.ts
+++ b/packages/react/src/button/Button.css.ts
@@ -21,6 +21,7 @@ export const button = recipe({
       borderRadius: theme.borderRadius.sm,
       cursor: "pointer",
       position: "relative",
+      textDecoration: "none",
 
       selectors: {
         '&:active:not([data-disabled="true"])': {

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -1,5 +1,4 @@
 import { Slot, Slottable } from "@radix-ui/react-slot";
-import clsx from "clsx";
 import {
   type ComponentPropsWithRef,
   type ReactNode,
@@ -80,16 +79,16 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <Box
         aria-disabled={isDisabled}
         asChild
-        className={clsx(
-          styles.button({
+        data-disabled={isDisabled}
+        onClick={isDisabled ? undefined : onClick}
+        {...styles.button(
+          {
             colorScheme: finalColorScheme,
             size,
             variant: finalVariant,
-          }),
+          },
           className,
         )}
-        data-disabled={isDisabled}
-        onClick={isDisabled ? undefined : onClick}
         {...props}
       >
         <Comp ref={ref}>

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -1,16 +1,9 @@
 import { Slot, Slottable } from "@radix-ui/react-slot";
-import {
-  type ComponentPropsWithRef,
-  type ReactNode,
-  cloneElement,
-  forwardRef,
-  isValidElement,
-} from "react";
+import { type ComponentPropsWithRef, type ReactNode, forwardRef } from "react";
 
 import type { ExtendProps } from "../utils";
 
 import { Box } from "../box";
-import { Text } from "../text";
 import * as styles from "./Button.css";
 
 const presets = {
@@ -54,20 +47,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ref,
   ) => {
     const Comp = asChild ? Slot : "button";
-    children =
-      asChild && isValidElement(children) ? (
-        cloneElement(
-          children,
-          undefined,
-          <Text as="span" fontSize="inherit">
-            {children.props.children}
-          </Text>,
-        )
-      ) : (
-        <Text as="span" fontSize="inherit">
-          {children}
-        </Text>
-      );
 
     const presetProps = presets[preset];
     const finalColorScheme = colorScheme ?? presetProps.colorScheme;
@@ -92,11 +71,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       >
         <Comp ref={ref}>
-          <>
-            {leftSection}
-            <Slottable>{children}</Slottable>
-            {rightSection}
-          </>
+          {leftSection}
+          <Slottable>{children}</Slottable>
+          {rightSection}
         </Comp>
       </Box>
     );

--- a/packages/react/src/code/Code.css.ts
+++ b/packages/react/src/code/Code.css.ts
@@ -1,6 +1,8 @@
-import { style } from "../vanilla-extract";
+import { recipe, style } from "../vanilla-extract";
 
-export const base = style({
-  WebkitFontSmoothing: "auto",
-  fontSize: "0.875em",
+export const code = recipe({
+  base: style({
+    WebkitFontSmoothing: "auto",
+    fontSize: "0.875em",
+  }),
 });

--- a/packages/react/src/code/Code.tsx
+++ b/packages/react/src/code/Code.tsx
@@ -1,5 +1,4 @@
 import { Slot } from "@radix-ui/react-slot";
-import clsx from "clsx";
 import { type ComponentPropsWithRef, forwardRef } from "react";
 
 import type { ExtendProps } from "../utils";
@@ -19,10 +18,10 @@ export const Code = forwardRef<HTMLElement, CodeProps>(
       <Box
         asChild
         bg="bg.neutral"
-        className={clsx(className, styles.base)}
         display="inline-block"
         px="4"
         rounded="sm"
+        {...styles.code({}, className)}
         {...props}
       >
         <Comp ref={ref}>{children}</Comp>

--- a/packages/react/src/input/Input.css.ts
+++ b/packages/react/src/input/Input.css.ts
@@ -1,63 +1,64 @@
 import { theme } from "../styles";
-import { type RecipeVariants, recipe } from "../vanilla-extract";
+import { type RecipeVariants, recipe, style } from "../vanilla-extract";
 
 export const wrapper = recipe({
-  base: {
-    alignItems: "center",
-    border: "1px",
-    borderColor: theme.colors["border.default"],
-    borderRadius: theme.borderRadius.sm,
-    borderStyle: "solid",
-    color: theme.colors["fg.default"],
-    display: "flex",
-    flexDirection: "row",
-    selectors: {
-      '&:focus-within:is([data-invalid="true"])': {
-        outlineColor: theme.colors["red.200"],
-        outlineOffset: "1px",
-        outlineStyle: "solid",
-        outlineWidth: "2px",
-      },
-      '&:focus-within:not([data-invalid="true"])': {
-        outlineColor: theme.colors["brand.200"],
-        outlineOffset: "1px",
-        outlineStyle: "solid",
-        outlineWidth: "2px",
-      },
-      "&:hover": {
-        borderColor: theme.colors["border.brand"],
-      },
-      '&[data-disabled="true"]': {
-        backgroundColor: theme.colors["bg.disabled"],
-        borderColor: theme.colors["border.secondary"],
-        pointerEvents: "none",
-      },
-      '&[data-invalid="true"]': {
-        borderColor: theme.colors["border.error"],
-      },
+  base: [
+    {
+      alignItems: "center",
+      border: "1",
+      borderColor: "border.default",
+      color: "fg.default",
+      display: "flex",
+      flexDirection: "row",
+      rounded: "sm",
     },
-  },
+    style({
+      selectors: {
+        '&:focus-within:is([data-invalid="true"])': {
+          outlineColor: theme.colors["red.200"],
+          outlineOffset: "1px",
+          outlineStyle: "solid",
+          outlineWidth: "2px",
+        },
+        '&:focus-within:not([data-invalid="true"])': {
+          outlineColor: theme.colors["brand.200"],
+          outlineOffset: "1px",
+          outlineStyle: "solid",
+          outlineWidth: "2px",
+        },
+        "&:hover": {
+          borderColor: theme.colors["border.brand"],
+        },
+        '&[data-disabled="true"]': {
+          backgroundColor: theme.colors["bg.disabled"],
+          borderColor: theme.colors["border.secondary"],
+          pointerEvents: "none",
+        },
+        '&[data-invalid="true"]': {
+          borderColor: theme.colors["border.error"],
+        },
+      },
+    }),
+  ],
 
   variants: {
     size: {
       sm: {
-        fontSize: theme.fontSize["sm"].fontSize,
-        height: "24px",
-        lineHeight: theme.fontSize["sm"].lineHeight,
-        padding: "8px 8px",
+        fontSize: "sm",
+        h: "24",
+        p: "8",
       },
       md: {
-        fontSize: theme.fontSize["md"].fontSize,
-        height: "32px",
-        lineHeight: theme.fontSize["md"].lineHeight,
-        padding: "8px 8px",
+        fontSize: "md",
+        h: "32",
+        p: "8",
       },
 
       lg: {
-        fontSize: theme.fontSize["lg"].fontSize,
-        height: "40px",
-        lineHeight: theme.fontSize["lg"].lineHeight,
-        padding: "4px 8px",
+        fontSize: "lg",
+        h: "40",
+        px: "8",
+        py: "4",
       },
     },
     variant: {
@@ -68,16 +69,19 @@ export const wrapper = recipe({
 });
 
 export const input = recipe({
-  base: {
-    background: theme.colors["transparent"],
-    width: "100%",
-
-    selectors: {
-      "&:focus-visible": {
-        outlineWidth: "0px",
-      },
+  base: [
+    {
+      bg: "transparent",
+      w: "full",
     },
-  },
+    style({
+      selectors: {
+        "&:focus-visible": {
+          outlineWidth: "0px",
+        },
+      },
+    }),
+  ],
   variants: {
     variant: {
       default: {

--- a/packages/react/src/input/Input.tsx
+++ b/packages/react/src/input/Input.tsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import { type ComponentPropsWithRef, type ReactNode, forwardRef } from "react";
 
 import { Box } from "../box";
@@ -38,9 +37,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       <Box
         aria-disabled={disabled}
         aria-invalid={error}
-        className={clsx(styles.wrapper({ size, variant }), className)}
         data-disabled={disabled}
         data-invalid={error}
+        {...styles.wrapper({ size, variant }, className)}
         {...sprinkleProps}
       >
         {leftSection && (
@@ -48,7 +47,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             {leftSection}
           </Flex>
         )}
-        <Box asChild className={styles.input({ variant })}>
+        <Box asChild {...styles.input({ variant })}>
           <input id={id} readOnly={disabled} ref={ref} {...restProps} />
         </Box>
         {rightSection && (

--- a/packages/react/src/kbd/Kbd.css.ts
+++ b/packages/react/src/kbd/Kbd.css.ts
@@ -1,11 +1,15 @@
-import { style } from "../vanilla-extract";
+import { recipe, style } from "../vanilla-extract";
 
-export const base = style({
-  borderBottomWidth: "2px",
+export const kbd = recipe({
+  base: style({
+    borderBottomWidth: "2px",
+  }),
 });
 
-export const keys = style({
-  fontSize: "1.2em",
-  lineHeight: "1",
-  textDecoration: "none",
+export const keys = recipe({
+  base: style({
+    fontSize: "1.2em",
+    lineHeight: "1",
+    textDecoration: "none",
+  }),
 });

--- a/packages/react/src/kbd/Kbd.tsx
+++ b/packages/react/src/kbd/Kbd.tsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import { type ComponentPropsWithRef, forwardRef } from "react";
 
 import { Code } from "../code";
@@ -31,18 +30,18 @@ export const Kbd = forwardRef<HTMLElement, KbdProps>(
         alignItems="center"
         asChild
         border="1"
-        className={clsx(styles.base, className)}
         display="inline-flex"
         flexDirection="row"
         fontWeight="600"
         gap="4"
         whiteSpace="nowrap"
+        {...styles.kbd({}, className)}
         {...props}
       >
         <kbd ref={ref}>
           {keys &&
             (Array.isArray(keys) ? keys : [keys]).map((key) => (
-              <abbr className={styles.keys} key={key} title={key}>
+              <abbr key={key} title={key} {...styles.keys()}>
                 {mapKeyToCode[key]}
               </abbr>
             ))}

--- a/packages/react/src/separator/Separator.css.ts
+++ b/packages/react/src/separator/Separator.css.ts
@@ -1,11 +1,12 @@
 import { createSprinkles, defineProperties } from "@vanilla-extract/sprinkles";
 
-import { theme } from "../styles";
 import { conditions } from "../utils";
-import { style } from "../vanilla-extract";
+import { recipe } from "../vanilla-extract";
 
-export const base = style({
-  backgroundColor: theme.colors["border.default"],
+export const base = recipe({
+  base: {
+    bg: "border.default",
+  },
 });
 
 const props = defineProperties({

--- a/packages/react/src/separator/Separator.tsx
+++ b/packages/react/src/separator/Separator.tsx
@@ -17,12 +17,8 @@ export const Separator = forwardRef<HTMLHRElement, SeparatorProps>(
     return (
       <Box
         asChild
-        className={clsx(
-          styles.base,
-          styles.separator({ orientation }),
-          className,
-        )}
         ref={ref}
+        {...styles.base({}, clsx(styles.separator({ orientation }), className))}
         {...props}
       >
         <RadixSeparator.Root />

--- a/packages/react/src/skeleton/Skeleton.css.ts
+++ b/packages/react/src/skeleton/Skeleton.css.ts
@@ -1,7 +1,9 @@
-import { style } from "../vanilla-extract";
+import { recipe, style } from "../vanilla-extract";
 
-export const base = style({
-  selectors: {
-    "&:empty:before": { content: '"\\00a0"' },
-  },
+export const skeleton = recipe({
+  base: style({
+    selectors: {
+      "&:empty:before": { content: '"\\00a0"' },
+    },
+  }),
 });

--- a/packages/react/src/skeleton/Skeleton.tsx
+++ b/packages/react/src/skeleton/Skeleton.tsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import { type ComponentPropsWithRef, forwardRef } from "react";
 
 import type { Sprinkles } from "../sprinkles";
@@ -28,7 +27,7 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
         animation="pulse"
         asChild
         bg="bg.neutral"
-        className={clsx(className, styles.base)}
+        {...styles.skeleton({}, className)}
         color="surface"
         display="block"
         h={h}

--- a/packages/react/src/text/Text.css.ts
+++ b/packages/react/src/text/Text.css.ts
@@ -1,30 +1,38 @@
-import { style, styleVariants } from "../vanilla-extract";
+import { mapValues } from "../utils";
+import { type RecipeVariants, recipe, style } from "../vanilla-extract";
 
-const truncateBase = style({
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-});
-const lineClampBase = style([
-  truncateBase,
-  {
+const truncateBase = [
+  { overflow: "hidden" } as const,
+  style({ textOverflow: "ellipsis" }),
+];
+const lineClampBase = [
+  ...truncateBase,
+  style({
     WebkitBoxOrient: "vertical",
     display: "-webkit-box",
-  },
-]);
+  }),
+];
 
-export const lineClamp = styleVariants(
-  {
-    "1": "1",
-    "2": "2",
-    "3": "3",
-    "4": "4",
-  } as const,
-  (WebkitLineClamp) => [lineClampBase, { WebkitLineClamp }],
-);
-
-export const truncate = style([
-  truncateBase,
-  {
-    whiteSpace: "nowrap",
+export const text = recipe({
+  variants: {
+    lineClamp: mapValues(
+      {
+        "1": "1",
+        "2": "2",
+        "3": "3",
+        "4": "4",
+      } as const,
+      (WebkitLineClamp) => [...lineClampBase, style({ WebkitLineClamp })],
+    ),
+    truncate: {
+      true: [
+        ...truncateBase,
+        {
+          whiteSpace: "nowrap",
+        },
+      ],
+    },
   },
-]);
+});
+
+export type TextVariants = RecipeVariants<typeof text>;

--- a/packages/react/src/text/Text.tsx
+++ b/packages/react/src/text/Text.tsx
@@ -1,5 +1,4 @@
 import { Slot } from "@radix-ui/react-slot";
-import clsx from "clsx";
 import { type ComponentPropsWithRef, forwardRef } from "react";
 
 import { Box } from "../box";
@@ -11,9 +10,7 @@ type TextProps = ExtendProps<
   ComponentPropsWithRef<typeof Box>,
   {
     as?: "p" | "span";
-    lineClamp?: keyof typeof styles.lineClamp;
-    truncate?: boolean;
-  }
+  } & styles.TextVariants
 >;
 
 export const Text = forwardRef<HTMLParagraphElement, TextProps>(
@@ -26,13 +23,9 @@ export const Text = forwardRef<HTMLParagraphElement, TextProps>(
     return (
       <Box
         asChild
-        className={clsx(
-          lineClamp && styles.lineClamp[lineClamp],
-          truncate && styles.truncate,
-          className,
-        )}
         fontSize="md"
         ref={ref}
+        {...styles.text({ lineClamp, truncate }, className)}
         {...props}
       >
         <Comp>{children}</Comp>

--- a/packages/react/src/transition/Transition.css.ts
+++ b/packages/react/src/transition/Transition.css.ts
@@ -1,10 +1,4 @@
-import { style } from "../vanilla-extract";
-
-export const base = style({
-  transformOrigin: "var(--radix-popper-transform-origin)",
-  transitionProperty: "opacity, transform",
-  transitionTimingFunction: "ease",
-});
+import { type RecipeVariants, recipe, style } from "../vanilla-extract";
 
 const translate = (dir: "down" | "left" | "right" | "up", value: number) => {
   if (dir === "down" || dir === "up") {
@@ -52,16 +46,28 @@ const generate = ({
     }),
   });
 
-export const transitions = {
-  fade: generate(presets.fade()),
-  "fade-down": generate(presets.fade("down")),
-  "fade-left": generate(presets.fade("left")),
-  "fade-right": generate(presets.fade("right")),
-  "fade-up": generate(presets.fade("up")),
+export const transition = recipe({
+  base: style({
+    transformOrigin: "var(--radix-popper-transform-origin)",
+    transitionProperty: "opacity, transform",
+    transitionTimingFunction: "ease",
+  }),
 
-  pop: generate(presets.pop()),
-  "pop-down": generate(presets.pop("down")),
-  "pop-left": generate(presets.pop("left")),
-  "pop-right": generate(presets.pop("right")),
-  "pop-up": generate(presets.pop("up")),
-};
+  variants: {
+    type: {
+      fade: generate(presets.fade()),
+      "fade-down": generate(presets.fade("down")),
+      "fade-left": generate(presets.fade("left")),
+      "fade-right": generate(presets.fade("right")),
+      "fade-up": generate(presets.fade("up")),
+
+      pop: generate(presets.pop()),
+      "pop-down": generate(presets.pop("down")),
+      "pop-left": generate(presets.pop("left")),
+      "pop-right": generate(presets.pop("right")),
+      "pop-up": generate(presets.pop("up")),
+    },
+  },
+});
+
+export type TransitionVariants = RecipeVariants<typeof transition>;

--- a/packages/react/src/transition/Transition.tsx
+++ b/packages/react/src/transition/Transition.tsx
@@ -1,5 +1,4 @@
 import { Slot } from "@radix-ui/react-slot";
-import clsx from "clsx";
 import {
   type ComponentPropsWithRef,
   forwardRef,
@@ -22,8 +21,7 @@ type TransitionProps = ExtendProps<
   ComponentPropsWithRef<"div">,
   {
     duration?: keyof typeof transitionDuration;
-    type?: keyof typeof styles.transitions;
-  }
+  } & styles.TransitionVariants
 >;
 
 export const Transition = forwardRef<HTMLDivElement, TransitionProps>(
@@ -45,16 +43,15 @@ export const Transition = forwardRef<HTMLDivElement, TransitionProps>(
 
     return (
       <Slot
-        className={clsx(
-          className,
-          styles.base,
-          enter !== isPresent && styles.transitions[type],
-        )}
         ref={ref}
         style={{
           ...style,
           transitionDuration: `${transitionDuration[duration]}ms`,
         }}
+        {...styles.transition(
+          { type: enter !== isPresent ? type : undefined },
+          className,
+        )}
         {...props}
       >
         {children}

--- a/packages/react/src/vanilla-extract/index.ts
+++ b/packages/react/src/vanilla-extract/index.ts
@@ -1,6 +1,5 @@
-export { recipe } from "./recipe";
+export * from "./recipe";
 export { style } from "./style";
 export { styleVariants } from "./styleVariants";
 
 export * from "@vanilla-extract/css";
-export { type RecipeVariants } from "@vanilla-extract/recipes";

--- a/packages/react/src/vanilla-extract/recipe.ts
+++ b/packages/react/src/vanilla-extract/recipe.ts
@@ -1,56 +1,22 @@
 import { addFunctionSerializer } from "@vanilla-extract/css/functionSerializer";
-import { recipe as veRecipe } from "@vanilla-extract/recipes";
-import { createRuntimeFn } from "@vanilla-extract/recipes/createRuntimeFn";
 
-import { mapValues } from "../utils";
-import { style } from "./style";
-import { styleVariants } from "./styleVariants";
+/**
+ * Forked from https://vanilla-extract.style/documentation/packages/recipes/
+ */
 
-export const recipe: typeof veRecipe = (options, debugId) => {
-  const {
-    base,
-    compoundVariants = [],
-    defaultVariants = {},
-    variants = {},
-  } = options;
-  let defaultClassName;
-  if (!base || typeof base === "string") {
-    const baseClassName = style({});
-    defaultClassName = base ? `${baseClassName} ${base}` : baseClassName;
-  } else {
-    defaultClassName = style(base, debugId);
-  }
+import { recipeRuntime } from "./recipeRuntime";
 
-  const variantClassNames = mapValues(
-    variants,
-    (variantGroup, variantGroupName) =>
-      styleVariants(
-        variantGroup,
-        (styleRule) =>
-          typeof styleRule === "string" ? [styleRule] : styleRule,
-        debugId ? `${debugId}_${variantGroupName}` : variantGroupName,
-      ),
-  );
-  const compounds = [];
-  for (const { style: theStyle, variants: _variants } of compoundVariants) {
-    compounds.push([
-      _variants,
-      typeof theStyle === "string"
-        ? theStyle
-        : style(theStyle, `${debugId}_compound_${compounds.length}`),
-    ]);
-  }
-  const config = {
-    compoundVariants: compounds,
-    defaultClassName,
-    defaultVariants,
-    variantClassNames,
-  };
-  // @ts-expect-error -- too complex
-  return addFunctionSerializer(createRuntimeFn(config), {
+export const recipe: typeof recipeRuntime = (options) => {
+  const recipe = recipeRuntime(options);
+  addFunctionSerializer(recipe, {
     // @ts-expect-error -- too complex
-    args: [config],
-    importName: "createRuntimeFn",
-    importPath: "@vanilla-extract/recipes/createRuntimeFn",
+    args: [options],
+    importName: "recipeRuntime",
+    importPath: "../vanilla-extract/recipeRuntime",
   });
+  return recipe;
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type RecipeVariants<RecipeFn extends (...args: any) => any> =
+  Parameters<RecipeFn>[0];

--- a/packages/react/src/vanilla-extract/recipeRuntime.ts
+++ b/packages/react/src/vanilla-extract/recipeRuntime.ts
@@ -1,6 +1,14 @@
+import type { CSSProperties } from "react";
+
+import type { ExtendProps } from "../utils";
+
 import { type Sprinkles } from "../sprinkles";
 
-type RecipeStyleRule = Array<Sprinkles | string> | Sprinkles | string;
+type SprinklesRule = ExtendProps<
+  Partial<Record<"selectors" | "vars" | keyof CSSProperties, never>>,
+  Sprinkles
+>;
+type RecipeStyleRule = Array<SprinklesRule | string> | SprinklesRule | string;
 
 type VariantGroups = Record<string, Record<string, unknown>>;
 

--- a/packages/react/src/vanilla-extract/recipeRuntime.ts
+++ b/packages/react/src/vanilla-extract/recipeRuntime.ts
@@ -1,0 +1,94 @@
+import { type Sprinkles } from "../sprinkles";
+
+type RecipeStyleRule = Array<Sprinkles | string> | Sprinkles | string;
+
+type VariantGroups = Record<string, Record<string, unknown>>;
+
+type StringToBoolean<T> = T extends "false" | "true" ? boolean : T;
+type VariantSelection<Variants extends VariantGroups> = {
+  [VariantGroup in keyof Variants]?: StringToBoolean<
+    keyof Variants[VariantGroup]
+  >;
+};
+
+type CompoundVariant<Variants extends VariantGroups> = {
+  style: RecipeStyleRule;
+  variants: VariantSelection<Variants>;
+};
+type VariantDefinition<Variants extends VariantGroups> = {
+  [K in keyof Variants]: { [T in keyof Variants[K]]: RecipeStyleRule };
+};
+
+type Resolve<T> = { [Key in keyof T]: T[Key] } & NonNullable<unknown>;
+
+export const recipeRuntime = <Variants extends VariantGroups>({
+  base = {},
+  variants,
+  variantsCompounded = [],
+}: {
+  base?: RecipeStyleRule;
+  variants: VariantDefinition<Variants>;
+  variantsCompounded?: Array<CompoundVariant<NoInfer<Variants>>>;
+}) => {
+  return (
+    options?: Resolve<VariantSelection<Variants>>,
+    className?: string,
+  ) => {
+    const selections: VariantSelection<Variants> = options ?? {};
+
+    const classNames: string[] = className ? [className] : [];
+    const sprinkleProps: Record<string, unknown> = {};
+
+    function process(rule: RecipeStyleRule) {
+      for (const item of Array.isArray(rule) ? rule : [rule]) {
+        if (typeof item === "string") {
+          classNames.push(item);
+        } else {
+          for (const [name, value] of Object.entries(item)) {
+            sprinkleProps[name] = value;
+          }
+        }
+      }
+    }
+
+    process(base);
+    for (const variantName in variants) {
+      if (!selections[variantName]) {
+        continue;
+      }
+
+      const variant = variants[variantName];
+      const selection =
+        typeof selections[variantName] === "boolean"
+          ? selections[variantName]
+            ? "true"
+            : "false"
+          : selections[variantName];
+      process(variant[selection as keyof typeof variant]);
+    }
+    for (const { style, variants } of variantsCompounded) {
+      if (!shouldApplyCompound(variants, selections)) {
+        continue;
+      }
+      process(style);
+    }
+
+    return {
+      ...sprinkleProps,
+      className: classNames.join(" "),
+    };
+  };
+};
+
+const shouldApplyCompound = <Variants extends VariantGroups>(
+  compoundCheck: VariantSelection<Variants>,
+  selections: VariantSelection<Variants>,
+) => {
+  for (const key of Object.keys(compoundCheck)) {
+    if (compoundCheck[key] !== selections[key]) {
+      return false;
+    }
+  }
+
+  return true;
+};

--- a/packages/react/src/vanilla-extract/recipeRuntime.ts
+++ b/packages/react/src/vanilla-extract/recipeRuntime.ts
@@ -21,13 +21,15 @@ type VariantDefinition<Variants extends VariantGroups> = {
 
 type Resolve<T> = { [Key in keyof T]: T[Key] } & NonNullable<unknown>;
 
-export const recipeRuntime = <Variants extends VariantGroups>({
+export const recipeRuntime = <
+  Variants extends VariantGroups = Record<string, never>,
+>({
   base = {},
   variants,
   variantsCompounded = [],
 }: {
   base?: RecipeStyleRule;
-  variants: VariantDefinition<Variants>;
+  variants?: VariantDefinition<Variants>;
   variantsCompounded?: Array<CompoundVariant<NoInfer<Variants>>>;
 }) => {
   return (

--- a/packages/shared/.eslintplugin/css-conventions.js
+++ b/packages/shared/.eslintplugin/css-conventions.js
@@ -20,6 +20,17 @@ export default ESLintUtils.RuleCreator.withoutDocs({
             node,
           });
         },
+
+      /**
+       * @type {import('@typescript-eslint/utils').TSESLint.RuleListener['Property']}
+       */
+      'CallExpression[callee.name="recipe"] Property[key.name="defaultVariants"]':
+        (node) => {
+          context.report({
+            messageId: "defaultVariants",
+            node,
+          });
+        },
     };
   },
 
@@ -29,6 +40,9 @@ export default ESLintUtils.RuleCreator.withoutDocs({
     fixable: "code",
     messages: {
       aria: "Please use data-* attributes instead of aria-* attributes when writing CSS selectors.",
+      defaultVariants: `Please specify defaults within the component prop types instead.
+
+Otherwise there is a mismatch between the component logic and the styling logic.`,
     },
     schema: [],
     type: "suggestion",

--- a/packages/shared/.eslintplugin/sprinkles-conventions.js
+++ b/packages/shared/.eslintplugin/sprinkles-conventions.js
@@ -40,17 +40,6 @@ export default ESLintUtils.RuleCreator.withoutDocs({
             node,
           });
         },
-
-      /**
-       * @type {import('@typescript-eslint/utils').TSESLint.RuleListener['Property']}
-       */
-      'CallExpression[callee.name="recipe"] Property[key.name="defaultVariants"]':
-        (node) => {
-          context.report({
-            messageId: "defaultVariants",
-            node,
-          });
-        },
     };
   },
 
@@ -60,9 +49,6 @@ export default ESLintUtils.RuleCreator.withoutDocs({
     fixable: "code",
     messages: {
       const: "Please cast arrays using `as const`.",
-      defaultVariants: `Please specify defaults within the component prop types instead.
-
-Otherwise there is a mismatch between the component logic and the styling logic.`,
       string: "Please use string type for sprinkle values.",
     },
     schema: [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,9 +202,6 @@ importers:
       '@reach/auto-id':
         specifier: ^0.18.0
         version: 0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@vanilla-extract/recipes':
-        specifier: ^0.5.3
-        version: 0.5.3(@vanilla-extract/css@1.15.2)
       '@vanilla-extract/sprinkles':
         specifier: ^1.6.2
         version: 1.6.2(@vanilla-extract/css@1.15.2)
@@ -2653,11 +2650,6 @@ packages:
 
   '@vanilla-extract/private@1.0.5':
     resolution: {integrity: sha512-6YXeOEKYTA3UV+RC8DeAjFk+/okoNz/h88R+McnzA2zpaVqTR/Ep+vszkWYlGBcMNO7vEkqbq5nT/JMMvhi+tw==}
-
-  '@vanilla-extract/recipes@0.5.3':
-    resolution: {integrity: sha512-SPREq1NmaoKuvJeOV0pppOkwy3pWZUoDufsyQ6iHrbkHhAU7XQqG9o0iZSmg5JoVgDLIiOr9djQb0x9wuxig7A==}
-    peerDependencies:
-      '@vanilla-extract/css': ^1.0.0
 
   '@vanilla-extract/rollup-plugin@1.3.5':
     resolution: {integrity: sha512-eABKWhCzQrc+tuuQmMVFjEACX+Srb4nRvvt683fSyBXwZCncx+KcvWdxVLqk/qXBg65fmtQvwLYyGPQluqUAtA==}
@@ -10279,10 +10271,6 @@ snapshots:
       - terser
 
   '@vanilla-extract/private@1.0.5': {}
-
-  '@vanilla-extract/recipes@0.5.3(@vanilla-extract/css@1.15.2)':
-    dependencies:
-      '@vanilla-extract/css': 1.15.2
 
   '@vanilla-extract/rollup-plugin@1.3.5(@types/node@20.14.2)(rollup@4.18.0)(terser@5.31.1)':
     dependencies:


### PR DESCRIPTION
as best practice we should always use sprinkle props whenever possible and only fallback to custom styles when sprinkles doesn't cover something or if we need selector support

### Before
```tsx
export const button = recipe({
  base: {
    alignItems: "center",
    borderRadius: theme.borderRadius.sm,
    cursor: "pointer",

    /* ... */

    selectors: {
      '&:active:not([data-disabled="true"])': {
        boxShadow: theme.boxShadow.inner,
      },

      /* ... */
    },
  },
});

return (
  <Box
    className={clsx(
      styles.button({ colorScheme, size, variant }),
      className,
    )}
    {...props}
  >
);
```

### After
```tsx
export const button = recipe({
  base: [
    {
      alignItems: "center",
      rounded: "sm",

      /* ... */
    },
    style({
      cursor: "pointer",

      /* ... */

      selectors: {
        '&:active:not([data-disabled="true"])': {
          boxShadow: theme.boxShadow.inner,
        },

        /* ... */
      },
    }),
  ],
});

return (
  <Box
    {...styles.button({ colorScheme, size, variant }, className)}
    {...props}
  >
);
```

Also notice when consuming the recipe we're no longer setting it to the `className` prop and instead passing className as a second argument and spreading the results onto the element.

This allows us to just forward the sprinkle props to the underlying Box component which can optionally be overridden with user passed sprinkle props.


## Why
we want to ensure we don't create conflicting styles between components styles and sprinkle styles. and we also want to benefit from style re-use whenever possible - by re-using sprinkles rather than defining custom styles.

this forked `recipe()` method will help towards that goal by nudging devs to use sprinkle props by default and explicitly opting for `style()` when needed.

## Summary of changes

1. `recipe` now accepts either a `string` or `Sprinkles` type
2. `recipe` result must now be spread onto the element
3. `compoundVariants` has been renamed to `variantsCompounded`