### PR TITLE
Fix Button as per specs (clone #96)

### DIFF
--- a/apps/storybook/src/forms/Button.stories.tsx
+++ b/apps/storybook/src/forms/Button.stories.tsx
@@ -1,12 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { Button, Flex } from "@optiaxiom/react";
-import {
-  IconArrowRight,
-  IconDownload,
-  IconHelicopterLanding,
-  IconPhoto,
-} from "@tabler/icons-react";
+import { IconChevronDown, IconDownload, IconPhoto } from "@tabler/icons-react";
 
 const meta: Meta<typeof Button> = {
   argTypes: { onClick: { action: "click" } },
@@ -37,7 +32,7 @@ const Variants: Story = {
 };
 
 const sizes = ["sm", "md", "lg"] as const;
-const presets = [
+const appearances = [
   ["default", "Default"],
   ["primary", "Primary"],
   ["danger", "Danger"],
@@ -73,11 +68,11 @@ export const Secondary: Story = {
   args: { colorScheme: "secondary" },
 };
 
-export const Preset: Story = {
+export const appearance: Story = {
   render: (args) => (
     <Flex>
-      {presets.map(([preset, label]) => (
-        <Button {...args} key={preset} preset={preset}>
+      {appearances.map(([appearance, label]) => (
+        <Button {...args} appearance={appearance} key={appearance}>
           {label}
         </Button>
       ))}
@@ -94,30 +89,96 @@ export const Link: Story = {
 
 export const StandaloneIcon: Story = {
   args: {
-    children: <IconHelicopterLanding />,
-  },
-};
-
-export const Icons: Story = {
-  args: {
-    colorScheme: "secondary",
-    size: "lg",
+    colorScheme: "danger",
   },
   render: (args) => (
     <Flex flexDirection="row">
-      <Button {...args} leftSection={<IconPhoto />}>
-        Gallery
-      </Button>
-      <Button {...args} rightSection={<IconDownload />}>
-        Download
-      </Button>
-      <Button
-        {...args}
-        leftSection={<IconPhoto />}
-        rightSection={<IconArrowRight />}
-      >
-        Enter Gallery
-      </Button>
+      <Button {...args} icon={<IconChevronDown />} size="sm"></Button>
+      <Button {...args} icon={<IconChevronDown />} size="md"></Button>
+      <Button {...args} icon={<IconChevronDown />} size="lg"></Button>
+    </Flex>
+  ),
+};
+export const Icons: Story = {
+  args: {
+    children: "Button",
+  },
+  render: (args) => (
+    <Flex>
+      <Flex flexDirection="row">
+        <Button
+          {...args}
+          icon={<IconChevronDown />}
+          iconPosition="start"
+          size="sm"
+        />
+        <Button
+          {...args}
+          icon={<IconChevronDown />}
+          iconPosition="start"
+          size="md"
+        />
+        <Button
+          {...args}
+          icon={<IconChevronDown />}
+          iconPosition="start"
+          size="lg"
+        />
+      </Flex>
+      <Flex flexDirection="row">
+        <Button
+          {...args}
+          icon={<IconChevronDown />}
+          iconPosition="end"
+          size="sm"
+        />
+        <Button
+          {...args}
+          icon={<IconChevronDown />}
+          iconPosition="end"
+          size="md"
+        />
+        <Button
+          {...args}
+          icon={<IconChevronDown />}
+          iconPosition="end"
+          size="lg"
+        />
+      </Flex>
+    </Flex>
+  ),
+};
+
+export const Example: Story = {
+  args: {
+    colorScheme: "secondary",
+  },
+  render: (args) => (
+    <Flex flexDirection="column">
+      <Flex flexDirection="row">
+        <Button size="lg" {...args} icon={<IconPhoto />} iconPosition="start">
+          Gallery
+        </Button>
+        <Button {...args} icon={<IconDownload />} iconPosition="end" size="lg">
+          Download
+        </Button>
+      </Flex>
+      <Flex flexDirection="row">
+        <Button size="md" {...args} icon={<IconPhoto />} iconPosition="start">
+          Gallery
+        </Button>
+        <Button {...args} icon={<IconDownload />} iconPosition="end" size="md">
+          Download
+        </Button>
+      </Flex>
+      <Flex flexDirection="row">
+        <Button size="sm" {...args} icon={<IconPhoto />}>
+          Gallery
+        </Button>
+        <Button {...args} icon={<IconDownload />} iconPosition="end" size="sm">
+          Download
+        </Button>
+      </Flex>
     </Flex>
   ),
 };

--- a/apps/storybook/src/forms/Button.stories.tsx
+++ b/apps/storybook/src/forms/Button.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { Button, Flex } from "@optiaxiom/react";
-import { IconChevronDown, IconDownload, IconPhoto } from "@tabler/icons-react";
+import { IconChevronDown } from "@tabler/icons-react";
 
 const meta: Meta<typeof Button> = {
   argTypes: { onClick: { action: "click" } },
@@ -88,14 +88,11 @@ export const Link: Story = {
 };
 
 export const StandaloneIcon: Story = {
-  args: {
-    colorScheme: "danger",
-  },
   render: (args) => (
     <Flex flexDirection="row">
-      <Button {...args} icon={<IconChevronDown />} size="sm"></Button>
-      <Button {...args} icon={<IconChevronDown />} size="md"></Button>
-      <Button {...args} icon={<IconChevronDown />} size="lg"></Button>
+      <Button {...args} icon={<IconChevronDown />} size="sm" />
+      <Button {...args} icon={<IconChevronDown />} size="md" />
+      <Button {...args} icon={<IconChevronDown />} size="lg" />
     </Flex>
   ),
 };
@@ -144,40 +141,6 @@ export const Icons: Story = {
           iconPosition="end"
           size="lg"
         />
-      </Flex>
-    </Flex>
-  ),
-};
-
-export const Example: Story = {
-  args: {
-    colorScheme: "secondary",
-  },
-  render: (args) => (
-    <Flex flexDirection="column">
-      <Flex flexDirection="row">
-        <Button size="lg" {...args} icon={<IconPhoto />} iconPosition="start">
-          Gallery
-        </Button>
-        <Button {...args} icon={<IconDownload />} iconPosition="end" size="lg">
-          Download
-        </Button>
-      </Flex>
-      <Flex flexDirection="row">
-        <Button size="md" {...args} icon={<IconPhoto />} iconPosition="start">
-          Gallery
-        </Button>
-        <Button {...args} icon={<IconDownload />} iconPosition="end" size="md">
-          Download
-        </Button>
-      </Flex>
-      <Flex flexDirection="row">
-        <Button size="sm" {...args} icon={<IconPhoto />}>
-          Gallery
-        </Button>
-        <Button {...args} icon={<IconDownload />} iconPosition="end" size="sm">
-          Download
-        </Button>
       </Flex>
     </Flex>
   ),

--- a/apps/storybook/src/forms/ButtonGroup.stories.tsx
+++ b/apps/storybook/src/forms/ButtonGroup.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { Button, ButtonGroup } from "@optiaxiom/react";
-import { IconArrowRight, IconDownload, IconPhoto } from "@tabler/icons-react";
+import { IconDownload, IconPhoto } from "@tabler/icons-react";
 
 const meta: Meta<typeof ButtonGroup> = {
   component: ButtonGroup,
@@ -14,10 +14,11 @@ type Story = StoryObj<typeof ButtonGroup>;
 export const Horizontal: Story = {
   render: () => (
     <ButtonGroup>
-      <Button leftSection={<IconPhoto />}>Gallery</Button>
-      <Button rightSection={<IconDownload />}>Download</Button>
-      <Button leftSection={<IconPhoto />} rightSection={<IconArrowRight />}>
-        Enter Gallery
+      <Button icon={<IconPhoto />} iconPosition="start">
+        Gallery
+      </Button>
+      <Button icon={<IconDownload />} iconPosition="end">
+        Download
       </Button>
     </ButtonGroup>
   ),
@@ -25,10 +26,11 @@ export const Horizontal: Story = {
 export const Vertical: Story = {
   render: () => (
     <ButtonGroup orientation="vertical">
-      <Button leftSection={<IconPhoto />}>Gallery</Button>
-      <Button rightSection={<IconDownload />}>Download</Button>
-      <Button leftSection={<IconPhoto />} rightSection={<IconArrowRight />}>
-        Enter Gallery
+      <Button icon={<IconPhoto />} iconPosition="start">
+        Gallery
+      </Button>
+      <Button icon={<IconDownload />} iconPosition="end">
+        Download
       </Button>
     </ButtonGroup>
   ),

--- a/apps/storybook/src/forms/ButtonGroup.stories.tsx
+++ b/apps/storybook/src/forms/ButtonGroup.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { Button, ButtonGroup } from "@optiaxiom/react";
-import { IconDownload, IconPhoto } from "@tabler/icons-react";
+import { IconArrowRight, IconDownload, IconPhoto } from "@tabler/icons-react";
 
 const meta: Meta<typeof ButtonGroup> = {
   component: ButtonGroup,
@@ -20,6 +20,9 @@ export const Horizontal: Story = {
       <Button icon={<IconDownload />} iconPosition="end">
         Download
       </Button>
+      <Button icon={<IconArrowRight />} iconPosition="end">
+        Enter Gallery
+      </Button>
     </ButtonGroup>
   ),
 };
@@ -31,6 +34,9 @@ export const Vertical: Story = {
       </Button>
       <Button icon={<IconDownload />} iconPosition="end">
         Download
+      </Button>
+      <Button icon={<IconArrowRight />} iconPosition="end">
+        Enter Gallery
       </Button>
     </ButtonGroup>
   ),

--- a/packages/react/src/button-group/ButtonGroup.tsx
+++ b/packages/react/src/button-group/ButtonGroup.tsx
@@ -20,7 +20,7 @@ type ButtonGroupProps = ExtendProps<
     children: ReactNode;
   } & Pick<
     ComponentPropsWithRef<typeof Button>,
-    "colorScheme" | "disabled" | "preset" | "size" | "variant"
+    "appearance" | "colorScheme" | "disabled" | "size" | "variant"
   > &
     styles.ButtonGroupVariants
 >;
@@ -28,13 +28,13 @@ type ButtonGroupProps = ExtendProps<
 export const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
   (
     {
+      appearance,
       children,
       className,
       colorScheme,
       disabled,
       gap = "0",
       orientation = "horizontal",
-      preset,
       size,
       variant,
       ...props
@@ -49,9 +49,9 @@ export const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
             {...styles.button({ orientation, spacing: gap !== "0" })}
           >
             {cloneElement(child, {
+              appearance: child.props.appearance || appearance,
               colorScheme: child.props.colorScheme || colorScheme,
               disabled: child.props.disabled || disabled,
-              preset: child.props.preset || preset,
               size: child.props.size || size,
               variant: child.props.variant || variant,
             })}

--- a/packages/react/src/button/Button.css.ts
+++ b/packages/react/src/button/Button.css.ts
@@ -81,7 +81,9 @@ export const button = recipe({
     },
     icon: {
       false: {},
-      true: {},
+      true: {
+        flex: "none",
+      },
     },
     size: {
       sm: {
@@ -190,16 +192,6 @@ export const button = recipe({
   ],
 });
 
-export const icon = recipe({
-  base: [
-    {
-      display: "block",
-    },
-    style({
-      flexShrink: "0",
-    }),
-  ],
-});
 export const section = recipe({
   base: {
     alignItems: "center",

--- a/packages/react/src/button/Button.css.ts
+++ b/packages/react/src/button/Button.css.ts
@@ -84,23 +84,23 @@ export const button = recipe({
       true: {},
     },
     size: {
-      sm: {
+      sm: style({
         fontSize: "sm",
-        h: "sm",
-        px: "4",
-      },
-      md: {
+        height: "24px",
+        paddingInline: "4px",
+      }),
+      md: style({
         fontSize: "md",
         gap: "2",
-        h: "md",
-        px: "8",
-      },
-      lg: {
+        height: "32px",
+        paddingInline: "8px",
+      }),
+      lg: style({
         fontSize: "lg",
         gap: "4",
-        h: "lg",
-        px: "12",
-      },
+        height: "40px",
+        paddingInline: "12px",
+      }),
     },
     variant: {
       ghost: style({

--- a/packages/react/src/button/Button.css.ts
+++ b/packages/react/src/button/Button.css.ts
@@ -12,6 +12,7 @@ export const button = recipe({
       alignItems: "center",
       display: "inline-flex",
       flexDirection: "row",
+      gap: "4",
       justifyContent: "center",
       overflow: "hidden",
       transition: "colors",
@@ -79,29 +80,22 @@ export const button = recipe({
         },
       }),
     },
-    icon: {
+    iconOnly: {
       false: {},
-      true: {
-        flex: "none",
-      },
+      true: {},
     },
     size: {
       sm: {
         fontSize: "sm",
         h: "sm",
-        px: "4",
       },
       md: {
         fontSize: "md",
-        gap: "2",
         h: "md",
-        px: "xs",
       },
       lg: {
         fontSize: "lg",
-        gap: "4",
         h: "lg",
-        px: "sm",
       },
     },
     variant: {
@@ -163,29 +157,55 @@ export const button = recipe({
     },
     {
       style: {
-        p: "0",
-        w: "sm",
+        px: "2",
       },
       variants: {
-        icon: true,
+        iconOnly: true,
         size: "sm",
       },
     },
     {
       style: {
-        w: "md",
+        px: "4",
       },
       variants: {
-        icon: true,
+        iconOnly: false,
+        size: "sm",
+      },
+    },
+    {
+      style: {
+        px: "6",
+      },
+      variants: {
+        iconOnly: true,
         size: "md",
       },
     },
     {
       style: {
-        w: "lg",
+        px: "8",
       },
       variants: {
-        icon: true,
+        iconOnly: false,
+        size: "md",
+      },
+    },
+    {
+      style: {
+        px: "10",
+      },
+      variants: {
+        iconOnly: true,
+        size: "lg",
+      },
+    },
+    {
+      style: {
+        px: "12",
+      },
+      variants: {
+        iconOnly: false,
         size: "lg",
       },
     },
@@ -193,12 +213,62 @@ export const button = recipe({
 });
 
 export const section = recipe({
-  base: {
-    alignItems: "center",
-    display: "inline-flex",
-    fontSize: "inherit",
-    justifyContent: "center",
+  variants: {
+    position: {
+      end: {},
+      start: {},
+    },
+    size: {
+      sm: {
+        w: "20",
+      },
+      md: {
+        w: "20",
+      },
+      lg: {
+        w: "20",
+      },
+    },
   },
+
+  variantsCompounded: [
+    {
+      style: {
+        ml: "2",
+      },
+      variants: {
+        position: "end",
+        size: "md",
+      },
+    },
+    {
+      style: {
+        mr: "2",
+      },
+      variants: {
+        position: "start",
+        size: "md",
+      },
+    },
+    {
+      style: {
+        ml: "4",
+      },
+      variants: {
+        position: "end",
+        size: "lg",
+      },
+    },
+    {
+      style: {
+        mr: "4",
+      },
+      variants: {
+        position: "start",
+        size: "lg",
+      },
+    },
+  ],
 });
 
 export type ButtonVariants = NonNullable<RecipeVariants<typeof button>>;

--- a/packages/react/src/button/Button.css.ts
+++ b/packages/react/src/button/Button.css.ts
@@ -5,7 +5,6 @@ import { type RecipeVariants, recipe } from "../vanilla-extract";
 const accentColorVar = createVar();
 const solidAccentColorVar = createVar();
 const subtleAccentColorVar = createVar();
-const internalSpaceVar = createVar();
 
 export const button = recipe({
   base: [
@@ -13,7 +12,6 @@ export const button = recipe({
       alignItems: "center",
       display: "inline-flex",
       flexDirection: "row",
-      gap: "xs",
       justifyContent: "center",
       overflow: "hidden",
       transition: "colors",
@@ -88,18 +86,20 @@ export const button = recipe({
     size: {
       sm: {
         fontSize: "sm",
-        h: "24",
-        px: "10",
+        h: "sm",
+        px: "4",
       },
       md: {
         fontSize: "md",
-        h: "32",
-        px: "12",
+        gap: "2",
+        h: "md",
+        px: "8",
       },
       lg: {
         fontSize: "lg",
-        h: "40",
-        px: "16",
+        gap: "4",
+        h: "lg",
+        px: "12",
       },
     },
     variant: {
@@ -203,34 +203,6 @@ export const section = recipe({
     display: "inline-flex",
     fontSize: "inherit",
     justifyContent: "center",
-  },
-
-  variants: {
-    position: {
-      end: style({
-        paddingLeft: internalSpaceVar,
-      }),
-      start: style({
-        paddingRight: internalSpaceVar,
-      }),
-    },
-    size: {
-      sm: style({
-        vars: {
-          [internalSpaceVar]: "0",
-        },
-      }),
-      md: style({
-        vars: {
-          [internalSpaceVar]: theme.spacing[2],
-        },
-      }),
-      lg: style({
-        vars: {
-          [internalSpaceVar]: theme.spacing[4],
-        },
-      }),
-    },
   },
 });
 

--- a/packages/react/src/button/Button.css.ts
+++ b/packages/react/src/button/Button.css.ts
@@ -84,23 +84,23 @@ export const button = recipe({
       true: {},
     },
     size: {
-      sm: style({
+      sm: {
         fontSize: "sm",
-        height: "24px",
-        paddingInline: "4px",
-      }),
-      md: style({
+        h: "sm",
+        px: "4",
+      },
+      md: {
         fontSize: "md",
         gap: "2",
-        height: "32px",
-        paddingInline: "8px",
-      }),
-      lg: style({
+        h: "md",
+        px: "xs",
+      },
+      lg: {
         fontSize: "lg",
         gap: "4",
-        height: "40px",
-        paddingInline: "12px",
-      }),
+        h: "lg",
+        px: "sm",
+      },
     },
     variant: {
       ghost: style({
@@ -160,25 +160,28 @@ export const button = recipe({
       },
     },
     {
-      style: style({ padding: "0", width: "24px" }),
+      style: {
+        p: "0",
+        w: "sm",
+      },
       variants: {
         icon: true,
         size: "sm",
       },
     },
     {
-      style: style({
-        width: "32px",
-      }),
+      style: {
+        w: "md",
+      },
       variants: {
         icon: true,
         size: "md",
       },
     },
     {
-      style: style({
-        width: "40px",
-      }),
+      style: {
+        w: "lg",
+      },
       variants: {
         icon: true,
         size: "lg",

--- a/packages/react/src/button/Button.css.ts
+++ b/packages/react/src/button/Button.css.ts
@@ -1,10 +1,14 @@
 import { theme } from "../styles";
-import { createVar, style } from "../vanilla-extract";
+import { createVar, fallbackVar, style } from "../vanilla-extract";
 import { type RecipeVariants, recipe } from "../vanilla-extract";
 
 const accentColorVar = createVar();
 const solidAccentColorVar = createVar();
 const subtleAccentColorVar = createVar();
+
+const borderColorVar = createVar();
+const boxShadowBorder = `inset 0 0 0 1px ${fallbackVar(borderColorVar, "transparent")}`;
+const boxShadowVar = createVar();
 
 export const button = recipe({
   base: [
@@ -25,7 +29,11 @@ export const button = recipe({
 
       selectors: {
         '&:active:not([data-disabled="true"])': {
-          boxShadow: theme.boxShadow.inner,
+          vars: {
+            [boxShadowVar]: theme.boxShadow.inner,
+          },
+
+          boxShadow: `${boxShadowBorder}, ${boxShadowVar}`,
         },
         "&:focus-visible": {
           outlineOffset: "1px",
@@ -114,8 +122,12 @@ export const button = recipe({
         },
       }),
       outline: style({
+        vars: {
+          [borderColorVar]: accentColorVar,
+        },
+
         backgroundColor: "transparent",
-        border: `1px solid ${accentColorVar}`,
+        boxShadow: boxShadowBorder,
         color: accentColorVar,
 
         selectors: {
@@ -123,7 +135,10 @@ export const button = recipe({
             backgroundColor: subtleAccentColorVar,
           },
           '&[data-disabled="true"]': {
-            borderColor: theme.colors["border.disabled"],
+            vars: {
+              [borderColorVar]: theme.colors["border.disabled"],
+            },
+
             color: theme.colors["fg.disabled"],
           },
         },
@@ -137,8 +152,12 @@ export const button = recipe({
             backgroundColor: solidAccentColorVar,
           },
           '&[data-disabled="true"]': {
+            vars: {
+              [borderColorVar]: theme.colors["border.disabled"],
+            },
+
             backgroundColor: theme.colors["bg.disabled"],
-            border: `1px solid ${theme.colors["border.disabled"]}`,
+            boxShadow: boxShadowBorder,
             color: theme.colors["fg.disabled"],
           },
         },
@@ -148,7 +167,9 @@ export const button = recipe({
   variantsCompounded: [
     {
       style: style({
-        borderColor: theme.colors["border.default"],
+        vars: {
+          [borderColorVar]: theme.colors["border.default"],
+        },
       }),
       variants: {
         colorScheme: "secondary",

--- a/packages/react/src/button/Button.css.ts
+++ b/packages/react/src/button/Button.css.ts
@@ -81,6 +81,10 @@ export const button = recipe({
         },
       }),
     },
+    icon: {
+      false: {},
+      true: {},
+    },
     size: {
       sm: {
         fontSize: "sm",
@@ -155,9 +159,44 @@ export const button = recipe({
         variant: "outline",
       },
     },
+    {
+      style: style({ padding: "0", width: "24px" }),
+      variants: {
+        icon: true,
+        size: "sm",
+      },
+    },
+    {
+      style: style({
+        width: "32px",
+      }),
+      variants: {
+        icon: true,
+        size: "md",
+      },
+    },
+    {
+      style: style({
+        width: "40px",
+      }),
+      variants: {
+        icon: true,
+        size: "lg",
+      },
+    },
   ],
 });
 
+export const icon = recipe({
+  base: [
+    {
+      display: "block",
+    },
+    style({
+      flexShrink: "0",
+    }),
+  ],
+});
 export const section = recipe({
   base: {
     alignItems: "center",
@@ -195,4 +234,4 @@ export const section = recipe({
   },
 });
 
-export type ButtonVariants = RecipeVariants<typeof button>;
+export type ButtonVariants = NonNullable<RecipeVariants<typeof button>>;

--- a/packages/react/src/button/Button.css.ts
+++ b/packages/react/src/button/Button.css.ts
@@ -5,6 +5,7 @@ import { type RecipeVariants, recipe } from "../vanilla-extract";
 const accentColorVar = createVar();
 const solidAccentColorVar = createVar();
 const subtleAccentColorVar = createVar();
+const internalSpaceVar = createVar();
 
 export const button = recipe({
   base: [
@@ -155,6 +156,43 @@ export const button = recipe({
       },
     },
   ],
+});
+
+export const section = recipe({
+  base: {
+    alignItems: "center",
+    display: "inline-flex",
+    fontSize: "inherit",
+    justifyContent: "center",
+  },
+
+  variants: {
+    position: {
+      end: style({
+        paddingLeft: internalSpaceVar,
+      }),
+      start: style({
+        paddingRight: internalSpaceVar,
+      }),
+    },
+    size: {
+      sm: style({
+        vars: {
+          [internalSpaceVar]: "0",
+        },
+      }),
+      md: style({
+        vars: {
+          [internalSpaceVar]: theme.spacing[2],
+        },
+      }),
+      lg: style({
+        vars: {
+          [internalSpaceVar]: theme.spacing[4],
+        },
+      }),
+    },
+  },
 });
 
 export type ButtonVariants = RecipeVariants<typeof button>;

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -46,7 +46,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       icon,
       iconPosition = "start",
       isLoading,
-      onClick,
       size = "md",
       variant,
       ...props

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -6,7 +6,7 @@ import type { ExtendProps } from "../utils";
 import { Box } from "../box";
 import * as styles from "./Button.css";
 
-const presets = {
+const appearances = {
   danger: { colorScheme: "danger", variant: "solid" },
   "danger-outline": { colorScheme: "danger", variant: "outline" },
   default: { colorScheme: "secondary", variant: "outline" },
@@ -18,11 +18,11 @@ type ButtonProps = ExtendProps<
   ComponentPropsWithRef<"button">,
   ComponentPropsWithRef<typeof Box>,
   {
+    appearance?: keyof typeof appearances;
     children?: ReactNode;
     disabled?: boolean;
     isLoading?: boolean;
     leftSection?: ReactNode;
-    preset?: keyof typeof presets;
     rightSection?: ReactNode;
   } & styles.ButtonVariants
 >;
@@ -30,6 +30,7 @@ type ButtonProps = ExtendProps<
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
+      appearance = "default",
       asChild,
       children,
       className,
@@ -37,7 +38,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       disabled,
       isLoading,
       leftSection,
-      preset = "default",
+      onClick,
       rightSection,
       size = "md",
       variant,
@@ -47,7 +48,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ) => {
     const Comp = asChild ? Slot : "button";
 
-    const presetProps = presets[preset];
+    const presetProps = appearances[appearance];
     const finalColorScheme = colorScheme ?? presetProps.colorScheme;
     const finalVariant = variant ?? presetProps.variant;
 

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -60,56 +60,39 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const finalVariant = variant ?? presetProps.variant;
 
     const isDisabled = Boolean(disabled || isLoading);
-    let isIcon = false;
 
-    let content;
     if (children) {
       children =
         asChild && isValidElement(children) ? (
           cloneElement(
             children,
             undefined,
-            <Text
-              as="span"
-              fontSize="inherit"
-              style={{
-                paddingInline: "4px",
-              }}
-            >
+            <Text as="span" fontSize="inherit" px="4">
               {children.props.children}
             </Text>,
           )
         ) : (
-          <Text
-            as="span"
-            fontSize="inherit"
-            style={{
-              paddingInline: "4px",
-            }}
-          >
+          <Text as="span" fontSize="inherit" px="4">
             {children}
           </Text>
         );
-
-      content = (
-        <>
-          {icon && iconPosition === "start" && (
-            <Box {...styles.section()}>{icon}</Box>
-          )}
-          <Slottable>{children}</Slottable>
-          {icon && iconPosition === "end" && (
-            <Box {...styles.section()}>{icon}</Box>
-          )}
-        </>
-      );
-    } else {
-      isIcon = true;
-      content = (
-        <Box asChild {...styles.icon()}>
-          {icon}
-        </Box>
-      );
     }
+    const isIcon = Boolean(!children && icon);
+    const content = isIcon ? (
+      <Box asChild {...styles.icon()}>
+        {icon}
+      </Box>
+    ) : (
+      <>
+        {icon && iconPosition === "start" && (
+          <Box {...styles.section()}>{icon}</Box>
+        )}
+        <Slottable>{children}</Slottable>
+        {icon && iconPosition === "end" && (
+          <Box {...styles.section()}>{icon}</Box>
+        )}
+      </>
+    );
 
     return (
       <Box

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -73,14 +73,20 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
               as="span"
               fontSize="inherit"
               style={{
-                padding: "0px 4px",
+                paddingInline: "4px",
               }}
             >
               {children.props.children}
             </Text>,
           )
         ) : (
-          <Text as="span" fontSize="inherit">
+          <Text
+            as="span"
+            fontSize="inherit"
+            style={{
+              paddingInline: "4px",
+            }}
+          >
             {children}
           </Text>
         );
@@ -88,15 +94,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       content = (
         <>
           {icon && iconPosition === "start" && (
-            <Box {...styles.section({ position: iconPosition, size: size })}>
-              {icon}
-            </Box>
+            <Box {...styles.section()}>{icon}</Box>
           )}
           <Slottable>{children}</Slottable>
           {icon && iconPosition === "end" && (
-            <Box {...styles.section({ position: iconPosition, size: size })}>
-              {icon}
-            </Box>
+            <Box {...styles.section()}>{icon}</Box>
           )}
         </>
       );

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -53,22 +53,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const isDisabled = Boolean(disabled || isLoading);
     const isIcon = Boolean(!children && icon);
 
-    const content = isIcon ? (
-      <Box asChild {...styles.icon()}>
-        {icon}
-      </Box>
-    ) : (
-      <>
-        {icon && iconPosition === "start" && (
-          <Box {...styles.section()}>{icon}</Box>
-        )}
-        <Slottable>{children}</Slottable>
-        {icon && iconPosition === "end" && (
-          <Box {...styles.section()}>{icon}</Box>
-        )}
-      </>
-    );
-
     return (
       <Box
         asChild
@@ -85,7 +69,19 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       >
         <Comp disabled={isDisabled} ref={ref}>
-          {content}
+          {isIcon ? (
+            icon
+          ) : (
+            <>
+              {icon && iconPosition === "start" && (
+                <Box {...styles.section()}>{icon}</Box>
+              )}
+              <Slottable>{children}</Slottable>
+              {icon && iconPosition === "end" && (
+                <Box {...styles.section()}>{icon}</Box>
+              )}
+            </>
+          )}
         </Comp>
       </Box>
     );

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -1,9 +1,16 @@
 import { Slot, Slottable } from "@radix-ui/react-slot";
-import { type ComponentPropsWithRef, type ReactNode, forwardRef } from "react";
+import {
+  type ComponentPropsWithRef,
+  type ReactNode,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+} from "react";
 
 import type { ExtendProps } from "../utils";
 
 import { Box } from "../box";
+import { Text } from "../text";
 import * as styles from "./Button.css";
 
 const appearances = {
@@ -21,9 +28,9 @@ type ButtonProps = ExtendProps<
     appearance?: keyof typeof appearances;
     children?: ReactNode;
     disabled?: boolean;
+    icon?: ReactNode;
+    iconPosition?: "end" | "start";
     isLoading?: boolean;
-    leftSection?: ReactNode;
-    rightSection?: ReactNode;
   } & styles.ButtonVariants
 >;
 
@@ -36,10 +43,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       className,
       colorScheme,
       disabled,
+      icon,
+      iconPosition = "start",
       isLoading,
-      leftSection,
       onClick,
-      rightSection,
       size = "md",
       variant,
       ...props
@@ -53,6 +60,46 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const finalVariant = variant ?? presetProps.variant;
 
     const isDisabled = Boolean(disabled || isLoading);
+
+    let content;
+    if (children) {
+      children =
+        asChild && isValidElement(children) ? (
+          cloneElement(
+            children,
+            undefined,
+            <Text
+              as="span"
+              fontSize="inherit"
+              style={{
+                padding: "0px 4px",
+              }}
+            >
+              {children.props.children}
+            </Text>,
+          )
+        ) : (
+          <Text as="span" fontSize="inherit">
+            {children}
+          </Text>
+        );
+
+      content = (
+        <>
+          {icon && iconPosition === "start" && (
+            <Box {...styles.section({ position: iconPosition, size: size })}>
+              {icon}
+            </Box>
+          )}
+          <Slottable>{children}</Slottable>
+          {icon && iconPosition === "end" && (
+            <Box {...styles.section({ position: iconPosition, size: size })}>
+              {icon}
+            </Box>
+          )}
+        </>
+      );
+    }
 
     return (
       <Box
@@ -69,9 +116,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       >
         <Comp disabled={isDisabled} ref={ref}>
-          {leftSection}
-          <Slottable>{children}</Slottable>
-          {rightSection}
+          {content}
         </Comp>
       </Box>
     );

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -24,7 +24,7 @@ type ButtonProps = ExtendProps<
     icon?: ReactNode;
     iconPosition?: "end" | "start";
     isLoading?: boolean;
-  } & Omit<styles.ButtonVariants, "icon">
+  } & Omit<styles.ButtonVariants, "iconOnly">
 >;
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -51,7 +51,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const finalColorScheme = colorScheme ?? presetProps.colorScheme;
     const finalVariant = variant ?? presetProps.variant;
     const isDisabled = Boolean(disabled || isLoading);
-    const isIcon = Boolean(!children && icon);
+    const isIconOnly = Boolean(!children && icon);
 
     return (
       <Box
@@ -60,7 +60,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...styles.button(
           {
             colorScheme: finalColorScheme,
-            icon: isIcon,
+            iconOnly: isIconOnly,
             size,
             variant: finalVariant,
           },
@@ -69,12 +69,36 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       >
         <Comp disabled={isDisabled} ref={ref}>
-          {!isIcon && icon && iconPosition === "start" && (
-            <Box {...styles.section()}>{icon}</Box>
+          {!isIconOnly && (
+            <Box
+              asChild
+              {...styles.section({
+                position: "start",
+                size: icon && iconPosition === "start" ? size : undefined,
+              })}
+            >
+              {icon && iconPosition === "start" ? icon : <div />}
+            </Box>
           )}
-          <Slottable>{isIcon ? icon : children}</Slottable>
-          {!isIcon && icon && iconPosition === "end" && (
-            <Box {...styles.section()}>{icon}</Box>
+          <Slottable>
+            {isIconOnly ? (
+              <Box asChild {...styles.section({ size })}>
+                {icon}
+              </Box>
+            ) : (
+              children
+            )}
+          </Slottable>
+          {!isIconOnly && (
+            <Box
+              asChild
+              {...styles.section({
+                position: "end",
+                size: icon && iconPosition === "end" ? size : undefined,
+              })}
+            >
+              {icon && iconPosition === "end" ? icon : <div />}
+            </Box>
           )}
         </Comp>
       </Box>

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -69,18 +69,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       >
         <Comp disabled={isDisabled} ref={ref}>
-          {isIcon ? (
-            icon
-          ) : (
-            <>
-              {icon && iconPosition === "start" && (
-                <Box {...styles.section()}>{icon}</Box>
-              )}
-              <Slottable>{children}</Slottable>
-              {icon && iconPosition === "end" && (
-                <Box {...styles.section()}>{icon}</Box>
-              )}
-            </>
+          {!isIcon && icon && iconPosition === "start" && (
+            <Box {...styles.section()}>{icon}</Box>
+          )}
+          <Slottable>{isIcon ? icon : children}</Slottable>
+          {!isIcon && icon && iconPosition === "end" && (
+            <Box {...styles.section()}>{icon}</Box>
           )}
         </Comp>
       </Box>

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -1,16 +1,9 @@
 import { Slot, Slottable } from "@radix-ui/react-slot";
-import {
-  type ComponentPropsWithRef,
-  type ReactNode,
-  cloneElement,
-  forwardRef,
-  isValidElement,
-} from "react";
+import { type ComponentPropsWithRef, type ReactNode, forwardRef } from "react";
 
 import type { ExtendProps } from "../utils";
 
 import { Box } from "../box";
-import { Text } from "../text";
 import * as styles from "./Button.css";
 
 const appearances = {
@@ -57,26 +50,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const presetProps = appearances[appearance];
     const finalColorScheme = colorScheme ?? presetProps.colorScheme;
     const finalVariant = variant ?? presetProps.variant;
-
     const isDisabled = Boolean(disabled || isLoading);
-
-    if (children) {
-      children =
-        asChild && isValidElement(children) ? (
-          cloneElement(
-            children,
-            undefined,
-            <Text as="span" fontSize="inherit" px="4">
-              {children.props.children}
-            </Text>,
-          )
-        ) : (
-          <Text as="span" fontSize="inherit" px="4">
-            {children}
-          </Text>
-        );
-    }
     const isIcon = Boolean(!children && icon);
+
     const content = isIcon ? (
       <Box asChild {...styles.icon()}>
         {icon}

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -31,7 +31,7 @@ type ButtonProps = ExtendProps<
     icon?: ReactNode;
     iconPosition?: "end" | "start";
     isLoading?: boolean;
-  } & styles.ButtonVariants
+  } & Omit<styles.ButtonVariants, "icon">
 >;
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -60,6 +60,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const finalVariant = variant ?? presetProps.variant;
 
     const isDisabled = Boolean(disabled || isLoading);
+    let isIcon = false;
 
     let content;
     if (children) {
@@ -99,6 +100,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           )}
         </>
       );
+    } else {
+      isIcon = true;
+      content = (
+        <Box asChild {...styles.icon()}>
+          {icon}
+        </Box>
+      );
     }
 
     return (
@@ -108,6 +116,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...styles.button(
           {
             colorScheme: finalColorScheme,
+            icon: isIcon,
             size,
             variant: finalVariant,
           },

--- a/packages/web-components/tests/Button.spec.tsx
+++ b/packages/web-components/tests/Button.spec.tsx
@@ -8,7 +8,7 @@ import { render, screen, withinShadowRoot } from "../vitest.rtl";
 describe("Button component", () => {
   function setup(overrides = {}) {
     return render(
-      <Button preset="primary" {...overrides}>
+      <Button appearance="primary" {...overrides}>
         Primary
       </Button>,
     );

--- a/packages/web-components/tests/Paper.spec.tsx
+++ b/packages/web-components/tests/Paper.spec.tsx
@@ -26,7 +26,7 @@ describe("Paper component", () => {
       <Paper p="md">
         This is a paper
         <Button
-          preset={preset}
+          appearance={preset}
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           ref={(node) => {

--- a/packages/web-components/tests/SelfLoading.spec.tsx
+++ b/packages/web-components/tests/SelfLoading.spec.tsx
@@ -8,7 +8,7 @@ const Button = "ax-button";
 describe("Self-loading components", () => {
   function setup(overrides = {}) {
     return render(
-      <Button preset="primary" {...overrides}>
+      <Button appearance="primary" {...overrides}>
         Primary
       </Button>,
     );

--- a/packages/web-components/tests/Slot.spec.tsx
+++ b/packages/web-components/tests/Slot.spec.tsx
@@ -8,8 +8,8 @@ import { render, screen, withinShadowRoot } from "../vitest.rtl";
 describe("Component slots", () => {
   function setup(overrides = {}) {
     return render(
-      <Button preset="primary" {...overrides}>
-        <i slot="rightSection">icon</i>
+      <Button appearance="primary" icon-position="end" {...overrides}>
+        <i slot="icon">icon</i>
         Primary
       </Button>,
     );


### PR DESCRIPTION
clones #96 

resolves: https://github.com/optimizely-axiom/optiaxiom/issues/34

Summary of Changes:

1. Rename `preset` to `appearance`: Updated the Button component to use the term `appearance` instead of `preset` for better clarity and consistency.
2. Icon Styling Added
3. Spacing and Gaps Fixed
4. Refactored leftSection & rightSection:
    i. The `leftSection` and `rightSection` properties have been refactored to `icon` and `iconPosition`.
    ii. The new structure does not support having icons on both sides simultaneously, simplifying the component design.