### PR TITLE
prevent both inline sprinkles and recipes 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,6 @@
   "editor.quickSuggestions": {
     "strings": "on"
   },
-  "eslint.experimental.useFlatConfig": true,
+  "eslint.useFlatConfig": true,
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/apps/storybook/src/data-display/Avatar.stories.tsx
+++ b/apps/storybook/src/data-display/Avatar.stories.tsx
@@ -3,11 +3,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Avatar, Flex, Tooltip } from "@optiaxiom/react";
 import { IconUser } from "@tabler/icons-react";
 
-const meta: Meta<typeof Avatar> = {
+export default {
   component: Avatar,
-};
-
-export default meta;
+} as Meta<typeof Avatar>;
 
 type Story = StoryObj<typeof Avatar>;
 

--- a/apps/storybook/src/data-display/Separator.stories.tsx
+++ b/apps/storybook/src/data-display/Separator.stories.tsx
@@ -2,11 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Flex, Separator, Text } from "@optiaxiom/react";
 
-const meta: Meta<typeof Separator> = {
+export default {
   component: Separator,
-};
-
-export default meta;
+} as Meta<typeof Separator>;
 
 type Story = StoryObj<typeof Separator>;
 

--- a/apps/storybook/src/feedback/Progress.stories.tsx
+++ b/apps/storybook/src/feedback/Progress.stories.tsx
@@ -4,11 +4,9 @@ import { Button, Flex, Progress } from "@optiaxiom/react";
 import { userEvent, within } from "@storybook/test";
 import { useState } from "react";
 
-const meta: Meta<typeof Progress> = {
+export default {
   component: Progress,
-};
-
-export default meta;
+} as Meta<typeof Progress>;
 
 type Story = StoryObj<typeof Progress>;
 

--- a/apps/storybook/src/feedback/Skeleton.stories.tsx
+++ b/apps/storybook/src/feedback/Skeleton.stories.tsx
@@ -3,11 +3,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Flex, Grid, Paper, Skeleton } from "@optiaxiom/react";
 import { IconUserFilled } from "@tabler/icons-react";
 
-const meta: Meta<typeof Skeleton> = {
+export default {
   component: Skeleton,
-};
-
-export default meta;
+} as Meta<typeof Skeleton>;
 
 type Story = StoryObj<typeof Skeleton>;
 

--- a/apps/storybook/src/forms/Button.stories.tsx
+++ b/apps/storybook/src/forms/Button.stories.tsx
@@ -3,12 +3,12 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Button, Flex } from "@optiaxiom/react";
 import { IconChevronDown } from "@tabler/icons-react";
 
-const meta: Meta<typeof Button> = {
-  argTypes: { onClick: { action: "click" } },
+export default {
+  argTypes: {
+    onClick: { action: "click" },
+  },
   component: Button,
-};
-
-export default meta;
+} as Meta<typeof Button>;
 
 type Story = StoryObj<typeof Button>;
 

--- a/apps/storybook/src/forms/ButtonGroup.stories.tsx
+++ b/apps/storybook/src/forms/ButtonGroup.stories.tsx
@@ -4,11 +4,9 @@ import type { ComponentPropsWithRef } from "react";
 import { Button, ButtonGroup, Flex } from "@optiaxiom/react";
 import { IconArrowRight, IconDownload, IconPhoto } from "@tabler/icons-react";
 
-const meta: Meta<typeof ButtonGroup> = {
+export default {
   component: ButtonGroup,
-};
-
-export default meta;
+} as Meta<typeof ButtonGroup>;
 
 type Story = StoryObj<typeof ButtonGroup>;
 

--- a/apps/storybook/src/forms/Field.stories.tsx
+++ b/apps/storybook/src/forms/Field.stories.tsx
@@ -3,11 +3,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Field, Input } from "@optiaxiom/react";
 import { IconCalendar } from "@tabler/icons-react";
 
-const meta: Meta<typeof Field> = {
+export default {
   component: Field,
-};
-
-export default meta;
+} as Meta<typeof Field>;
 
 type Story = StoryObj<typeof Field>;
 

--- a/apps/storybook/src/forms/Input.stories.tsx
+++ b/apps/storybook/src/forms/Input.stories.tsx
@@ -3,11 +3,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Flex, Input } from "@optiaxiom/react";
 import { IconCalendar } from "@tabler/icons-react";
 
-const meta: Meta<typeof Input> = {
+export default {
   component: Input,
-};
-
-export default meta;
+} as Meta<typeof Input>;
 
 type Story = StoryObj<typeof Input>;
 

--- a/apps/storybook/src/forms/Switch.stories.tsx
+++ b/apps/storybook/src/forms/Switch.stories.tsx
@@ -2,16 +2,15 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Switch } from "@optiaxiom/react";
 
-const meta: Meta<typeof Switch> = {
+export default {
   args: {
     label: "On label",
   },
   component: Switch,
-};
-
-export default meta;
+} as Meta<typeof Switch>;
 
 type Story = StoryObj<typeof Switch>;
+
 export const Default: Story = {};
 
 export const Large: Story = {

--- a/apps/storybook/src/overlays/Tooltip.stories.tsx
+++ b/apps/storybook/src/overlays/Tooltip.stories.tsx
@@ -9,11 +9,9 @@ import {
   within,
 } from "@storybook/test";
 
-const meta: Meta<typeof Tooltip> = {
+export default {
   component: Tooltip,
-};
-
-export default meta;
+} as Meta<typeof Tooltip>;
 
 type Story = StoryObj<typeof Tooltip>;
 

--- a/apps/storybook/src/primitives/Box.stories.tsx
+++ b/apps/storybook/src/primitives/Box.stories.tsx
@@ -2,11 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Box, Text } from "@optiaxiom/react";
 
-const meta: Meta<typeof Box> = {
+export default {
   component: Box,
-};
-
-export default meta;
+} as Meta<typeof Box>;
 
 type Story = StoryObj<typeof Box>;
 

--- a/apps/storybook/src/primitives/Flex.stories.tsx
+++ b/apps/storybook/src/primitives/Flex.stories.tsx
@@ -2,11 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Flex, Text } from "@optiaxiom/react";
 
-const meta: Meta<typeof Flex> = {
+export default {
   component: Flex,
-};
-
-export default meta;
+} as Meta<typeof Flex>;
 
 type Story = StoryObj<typeof Flex>;
 

--- a/apps/storybook/src/primitives/Grid.stories.tsx
+++ b/apps/storybook/src/primitives/Grid.stories.tsx
@@ -2,11 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Grid, Text } from "@optiaxiom/react";
 
-const meta: Meta<typeof Grid> = {
+export default {
   component: Grid,
-};
-
-export default meta;
+} as Meta<typeof Grid>;
 
 type Story = StoryObj<typeof Grid>;
 

--- a/apps/storybook/src/primitives/Paper.stories.tsx
+++ b/apps/storybook/src/primitives/Paper.stories.tsx
@@ -2,11 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Flex, Paper, Text } from "@optiaxiom/react";
 
-const meta: Meta<typeof Paper> = {
+export default {
   component: Paper,
-};
-
-export default meta;
+} as Meta<typeof Paper>;
 
 type Story = StoryObj<typeof Paper>;
 

--- a/apps/storybook/src/typography/Heading.stories.tsx
+++ b/apps/storybook/src/typography/Heading.stories.tsx
@@ -2,11 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Heading } from "@optiaxiom/react";
 
-const meta: Meta<typeof Heading> = {
+export default {
   component: Heading,
-};
-
-export default meta;
+} as Meta<typeof Heading>;
 
 type Story = StoryObj<typeof Heading>;
 

--- a/apps/storybook/src/typography/Text.stories.tsx
+++ b/apps/storybook/src/typography/Text.stories.tsx
@@ -2,11 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Text } from "@optiaxiom/react";
 
-const meta: Meta<typeof Text> = {
+export default {
   component: Text,
-};
-
-export default meta;
+} as Meta<typeof Text>;
 
 type Story = StoryObj<typeof Text>;
 

--- a/packages/react/src/code/Code.css.ts
+++ b/packages/react/src/code/Code.css.ts
@@ -1,8 +1,16 @@
 import { recipe, style } from "../vanilla-extract";
 
 export const code = recipe({
-  base: style({
-    WebkitFontSmoothing: "auto",
-    fontSize: "0.875em",
-  }),
+  base: [
+    {
+      bg: "bg.neutral",
+      display: "inline-block",
+      px: "4",
+      rounded: "sm",
+    },
+    style({
+      WebkitFontSmoothing: "auto",
+      fontSize: "0.875em",
+    }),
+  ],
 });

--- a/packages/react/src/code/Code.tsx
+++ b/packages/react/src/code/Code.tsx
@@ -15,15 +15,7 @@ export const Code = forwardRef<HTMLElement, CodeProps>(
   ({ asChild, children, className, ...props }, ref) => {
     const Comp = asChild ? Slot : "code";
     return (
-      <Box
-        asChild
-        bg="bg.neutral"
-        display="inline-block"
-        px="4"
-        rounded="sm"
-        {...styles.code({}, className)}
-        {...props}
-      >
+      <Box asChild {...styles.code({}, className)} {...props}>
         <Comp ref={ref}>{children}</Comp>
       </Box>
     );

--- a/packages/react/src/kbd/Kbd.css.ts
+++ b/packages/react/src/kbd/Kbd.css.ts
@@ -1,9 +1,20 @@
 import { recipe, style } from "../vanilla-extract";
 
 export const kbd = recipe({
-  base: style({
-    borderBottomWidth: "2px",
-  }),
+  base: [
+    {
+      alignItems: "center",
+      border: "1",
+      display: "inline-flex",
+      flexDirection: "row",
+      fontWeight: "600",
+      gap: "4",
+      whiteSpace: "nowrap",
+    },
+    style({
+      borderBottomWidth: "2px",
+    }),
+  ],
 });
 
 export const keys = recipe({

--- a/packages/react/src/kbd/Kbd.tsx
+++ b/packages/react/src/kbd/Kbd.tsx
@@ -26,18 +26,7 @@ const mapKeyToCode = {
 export const Kbd = forwardRef<HTMLElement, KbdProps>(
   ({ children, className, keys, ...props }, ref) => {
     return (
-      <Code
-        alignItems="center"
-        asChild
-        border="1"
-        display="inline-flex"
-        flexDirection="row"
-        fontWeight="600"
-        gap="4"
-        whiteSpace="nowrap"
-        {...styles.kbd({}, className)}
-        {...props}
-      >
+      <Code asChild {...styles.kbd({}, className)} {...props}>
         <kbd ref={ref}>
           {keys &&
             (Array.isArray(keys) ? keys : [keys]).map((key) => (

--- a/packages/react/src/skeleton/Skeleton.css.ts
+++ b/packages/react/src/skeleton/Skeleton.css.ts
@@ -1,9 +1,17 @@
 import { recipe, style } from "../vanilla-extract";
 
 export const skeleton = recipe({
-  base: style({
-    selectors: {
-      "&:empty:before": { content: '"\\00a0"' },
+  base: [
+    {
+      animation: "pulse",
+      bg: "bg.neutral",
+      color: "surface",
+      display: "block",
     },
-  }),
+    style({
+      selectors: {
+        "&:empty:before": { content: '"\\00a0"' },
+      },
+    }),
+  ],
 });

--- a/packages/react/src/skeleton/Skeleton.tsx
+++ b/packages/react/src/skeleton/Skeleton.tsx
@@ -24,16 +24,12 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
   ({ children, circle, className, h, rounded, w, ...props }, ref) => {
     return (
       <Box
-        animation="pulse"
         asChild
-        bg="bg.neutral"
-        {...styles.skeleton({}, className)}
-        color="surface"
-        display="block"
         h={h}
         ref={ref}
         rounded={circle || rounded === "full" ? "full" : rounded ?? "sm"}
         w={w ?? (circle || rounded === "full" ? h : undefined)}
+        {...styles.skeleton({}, className)}
         {...props}
       >
         {children ?? <span />}

--- a/packages/react/src/switch/Switch.css.ts
+++ b/packages/react/src/switch/Switch.css.ts
@@ -4,8 +4,10 @@ import { type RecipeVariants, recipe, style } from "../vanilla-extract";
 export const root = recipe({
   base: [
     {
+      borderColor: "transparent",
       px: "12",
       py: "2",
+      rounded: "full",
     },
     style({
       backgroundColor: theme.colors["fg.brand"],
@@ -40,7 +42,9 @@ export const root = recipe({
 export const thumb = recipe({
   base: [
     {
+      bg: "white",
       display: "block",
+      rounded: "full",
       transition: "transform",
     },
     style({

--- a/packages/react/src/switch/Switch.tsx
+++ b/packages/react/src/switch/Switch.tsx
@@ -34,19 +34,13 @@ export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
         gap="0"
         {...sprinkleProps}
       >
-        <Box
-          asChild
-          borderColor="transparent"
-          id={id}
-          rounded="full"
-          {...styles.root({ size })}
-        >
+        <Box asChild id={id} {...styles.root({ size })}>
           <RadixSwitch.Root
             disabled={disabled || readonly}
             ref={ref}
             {...restProps}
           >
-            <Box asChild bg="white" rounded="full" {...styles.thumb({ size })}>
+            <Box asChild {...styles.thumb({ size })}>
               <RadixSwitch.Thumb />
             </Box>
           </RadixSwitch.Root>

--- a/packages/react/src/text/Text.css.ts
+++ b/packages/react/src/text/Text.css.ts
@@ -14,6 +14,10 @@ const lineClampBase = [
 ];
 
 export const text = recipe({
+  base: {
+    fontSize: "md",
+  },
+
   variants: {
     lineClamp: mapValues(
       {

--- a/packages/react/src/text/Text.tsx
+++ b/packages/react/src/text/Text.tsx
@@ -23,7 +23,6 @@ export const Text = forwardRef<HTMLParagraphElement, TextProps>(
     return (
       <Box
         asChild
-        fontSize="md"
         ref={ref}
         {...styles.text({ lineClamp, truncate }, className)}
         {...props}

--- a/packages/shared/.eslintplugin/consistent-recipe-sprinkles.js
+++ b/packages/shared/.eslintplugin/consistent-recipe-sprinkles.js
@@ -1,0 +1,59 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+export default ESLintUtils.RuleCreator.withoutDocs({
+  create(context) {
+    return {
+      /**
+       * @type {import('@typescript-eslint/utils').TSESLint.RuleListener['JSXSpreadAttribute']}
+       */
+      'JSXSpreadAttribute:has(MemberExpression[object.name="styles"])': ({
+        parent,
+      }) => {
+        if (parent.type !== "JSXOpeningElement") {
+          return;
+        }
+
+        const parserServices = ESLintUtils.getParserServices(context);
+        const component = parserServices.getTypeAtLocation(parent.name);
+        const props = component
+          .getCallSignatures()[0]
+          ?.getTypeParameterAtPosition(0);
+        if (!props) {
+          return;
+        }
+
+        for (const attribute of parent.attributes) {
+          if (attribute.type === "JSXSpreadAttribute") {
+            continue;
+          }
+          if (attribute.value?.type !== "Literal") {
+            continue;
+          }
+
+          const source = props
+            .getProperty(attribute.name.name)
+            ?.getDeclarations()[0]
+            .getSourceFile().fileName;
+          if (source?.endsWith("sprinkles.css.ts")) {
+            context.report({
+              messageId: "expected",
+              node: attribute.name,
+            });
+          }
+        }
+      },
+    };
+  },
+
+  defaultOptions: [],
+
+  meta: {
+    fixable: "code",
+    messages: {
+      expected:
+        "Please avoid inlining sprinkle props when using recipes and move them inside the recipe base instead.",
+    },
+    schema: [],
+    type: "suggestion",
+  },
+});

--- a/packages/shared/configs/eslint.config.base.js
+++ b/packages/shared/configs/eslint.config.base.js
@@ -60,6 +60,7 @@ export default tsEslint.config(
     rules: {
       ...reactRecommended.rules,
       ...jsxA11y.configs.recommended.rules,
+      "local/consistent-recipe-sprinkles": "error",
       "react/jsx-boolean-value": "error",
       "react/jsx-curly-brace-presence": "error",
       "react/react-in-jsx-scope": "off",


### PR DESCRIPTION
adding a lint rule `local/consistent-recipe-sprinkles` to catch instances where we mix inline sprinkles and also use recipes on `Box` elements since:

- you have to look at two places to figure out the final styles
- can lead to bugs where inline sprinkles and recipe sprinkles conflict