### PR TITLE
Add 'auto-resize' to `Textarea` component

### DIFF
--- a/apps/storybook/src/forms/Textarea.stories.tsx
+++ b/apps/storybook/src/forms/Textarea.stories.tsx
@@ -23,6 +23,13 @@ export const NoResize: Story = {
   },
 };
 
+export const AutoResize: Story = {
+  args: {
+    placeholder: "Enter text....",
+    resize: "auto",
+  },
+};
+
 export const WithTopSection: Story = {
   args: {
     placeholder: "Enter text....",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,8 @@
     "@reach/auto-id": "^0.18.0",
     "@vanilla-extract/sprinkles": "^1.6.2",
     "clsx": "^2.1.1",
-    "inter-ui": "^4.0.2"
+    "inter-ui": "^4.0.2",
+    "react-textarea-autosize": "^8.5.3"
   },
   "devDependencies": {
     "@optiaxiom/shared": "workspace:^",

--- a/packages/react/src/textarea/Textarea.css.ts
+++ b/packages/react/src/textarea/Textarea.css.ts
@@ -41,7 +41,9 @@ export const wrapper = recipe({
   ],
   variants: {
     resize: {
-      auto: {},
+      auto: style({
+        resize: "vertical",
+      }),
       none: style({
         resize: "none",
       }),
@@ -56,10 +58,10 @@ export const textarea = recipe({
     {
       alignItems: "start",
       borderColor: "border.default",
-      flex: "1",
     },
     style({
       color: theme.colors["fg.default"],
+      flexGrow: "1",
       resize: "none",
       selectors: {
         "&:focus-visible": {

--- a/packages/react/src/textarea/Textarea.tsx
+++ b/packages/react/src/textarea/Textarea.tsx
@@ -9,7 +9,7 @@ import { extractSprinkles } from "../sprinkles";
 import * as styles from "./Textarea.css";
 
 type TextareaProps = ExtendProps<
-  ComponentPropsWithRef<"textarea">,
+  ComponentPropsWithRef<typeof TextareaAutosize>,
   ComponentPropsWithRef<typeof Box>,
   {
     disabled?: boolean;
@@ -26,6 +26,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       disabled,
       endDecorator,
       error,
+      maxRows = 5,
       placeholder,
       readOnly,
       resize = "vertical",
@@ -56,7 +57,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           {...styles.textarea({}, className)}
         >
           <Component
-            maxRows={5}
+            maxRows={maxRows}
             placeholder={placeholder}
             readOnly={disabled || readOnly}
             ref={ref}

--- a/packages/react/src/textarea/Textarea.tsx
+++ b/packages/react/src/textarea/Textarea.tsx
@@ -1,4 +1,5 @@
 import { type ComponentPropsWithRef, type ReactNode, forwardRef } from "react";
+import TextareaAutosize from "react-textarea-autosize";
 
 import type { ExtendProps } from "../utils";
 
@@ -35,6 +36,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     ref,
   ) => {
     const { restProps, sprinkleProps } = extractSprinkles(props);
+    const Component = resize === "auto" ? TextareaAutosize : "textarea";
 
     return (
       <Flex
@@ -53,13 +55,14 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           color={disabled ? "fg.disabled" : "fg.default"}
           {...styles.textarea({}, className)}
         >
-          <textarea
+          <Component
+            maxRows={5}
             placeholder={placeholder}
             readOnly={disabled || readOnly}
             ref={ref}
             rows={rows}
             {...restProps}
-          ></textarea>
+          />
         </Box>
         {endDecorator}
       </Flex>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       react-dom:
         specifier: ^16.14.0 || ^17.0.0 || ^18.0.0
         version: 18.3.1(react@18.3.1)
+      react-textarea-autosize:
+        specifier: ^8.5.3
+        version: 8.5.3(@types/react@18.3.3)(react@18.3.1)
     devDependencies:
       '@optiaxiom/shared':
         specifier: workspace:^
@@ -6728,6 +6731,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-textarea-autosize@8.5.3:
+    resolution: {integrity: sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -7634,6 +7643,29 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-composed-ref@1.3.0:
+    resolution: {integrity: sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  use-isomorphic-layout-effect@1.1.2:
+    resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-latest@1.2.1:
+    resolution: {integrity: sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==}
+    peerDependencies:
+      '@types/react': '*'
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
       '@types/react':
@@ -15594,6 +15626,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
+  react-textarea-autosize@8.5.3(@types/react@18.3.3)(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.24.7
+      react: 18.3.1
+      use-composed-ref: 1.3.0(react@18.3.1)
+      use-latest: 1.2.1(@types/react@18.3.3)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -16711,6 +16752,23 @@ snapshots:
     dependencies:
       react: 18.3.1
       tslib: 2.6.3
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  use-composed-ref@1.3.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
+  use-isomorphic-layout-effect@1.1.2(@types/react@18.3.3)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  use-latest@1.2.1(@types/react@18.3.3)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      use-isomorphic-layout-effect: 1.1.2(@types/react@18.3.3)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.3
 


### PR DESCRIPTION
This PR implements auto-resize functionality for the Textarea component, allowing it to automatically adjust its height based on content. The feature is controlled by the `resize` prop and can be fine-tuned with `maxRows` and `minRows` props.

Changes:
- Added `resize` prop to Textarea component
- Implemented auto-resize logic when `resize` is set to `auto`
- Added `maxRows` prop to limit maximum number of rows
- Added `minRows` prop to set minimum number of rows
