### PR TITLE
add support for portals and rendering web component tree in correct order

### DIFF
--- a/.changeset/sharp-boxes-wait.md
+++ b/.changeset/sharp-boxes-wait.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/web-components": patch
+---
+
+add support for rendering portals

--- a/.changeset/witty-cooks-chew.md
+++ b/.changeset/witty-cooks-chew.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/web-components": patch
+---
+
+render web component tree in order

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -1,38 +1,4 @@
-import * as Components from "@optiaxiom/react";
-
-import type { KebabCase } from "./components/ComponentAttributes";
-
-import { exports } from "../package.json";
-
-type ComponentNames = Exclude<
-  keyof {
-    [Key in keyof typeof Components as Key extends `${infer C}${string}`
-      ? C extends Uppercase<C>
-        ? Key
-        : never
-      : never]: never;
-  },
-  "FieldContext"
->;
-
-type AllComponents = {
-  [Key in ComponentNames as `ax${KebabCase<Key>}`]: Key;
-};
-
-const exported = (
-  Object.keys(exports).filter((n) => n !== ".") as Array<
-    Exclude<keyof typeof exports, ".">
-  >
-).map(
-  <S extends string>(path: S) =>
-    [
-      "ax" + path.slice(2).replace(/[A-Z]/g, (m) => "-" + m.toLowerCase()),
-      path.slice(2),
-    ] as S extends `./${infer N}` ? [`ax${KebabCase<N>}`, N] : never,
-);
-const mapping: AllComponents = Object.fromEntries(exported) as {
-  [T in (typeof exported)[number] as T[0]]: T[1];
-};
+import { mapping } from "./mapping";
 
 function processNode(node: Node) {
   const nodeName = node.nodeName.toLowerCase();

--- a/packages/web-components/src/mapping.ts
+++ b/packages/web-components/src/mapping.ts
@@ -1,0 +1,36 @@
+import * as Components from "@optiaxiom/react";
+
+import type { KebabCase } from "./components/ComponentAttributes";
+
+import { exports } from "../package.json";
+
+type ComponentNames = Exclude<
+  keyof {
+    [Key in keyof typeof Components as Key extends `${infer C}${string}`
+      ? C extends Uppercase<C>
+        ? Key
+        : never
+      : never]: never;
+  },
+  "FieldContext"
+>;
+
+type AllComponents = {
+  [Key in ComponentNames as `ax${KebabCase<Key>}`]: Key;
+};
+
+const exported = (
+  Object.keys(exports).filter((n) => n !== ".") as Array<
+    Exclude<keyof typeof exports, ".">
+  >
+).map(
+  <S extends string>(path: S) =>
+    [
+      "ax" + path.slice(2).replace(/[A-Z]/g, (m) => "-" + m.toLowerCase()),
+      path.slice(2),
+    ] as S extends `./${infer N}` ? [`ax${KebabCase<N>}`, N] : never,
+);
+
+export const mapping: AllComponents = Object.fromEntries(exported) as {
+  [T in (typeof exported)[number] as T[0]]: T[1];
+};

--- a/packages/web-components/tests/Box.spec.tsx
+++ b/packages/web-components/tests/Box.spec.tsx
@@ -43,11 +43,6 @@ describe("Box component", () => {
   it("should render properly", async () => {
     setup();
     expect(
-      withinShadowRoot(screen.getByText("This is a box")).getByText(
-        "This is a box",
-      ),
-    ).toBeInTheDocument();
-    expect(
       withinShadowRoot(screen.getByText("Click")).getByRole("button"),
     ).toBeInTheDocument();
   });

--- a/packages/web-components/tests/Button.spec.tsx
+++ b/packages/web-components/tests/Button.spec.tsx
@@ -17,7 +17,7 @@ describe("Button component", () => {
   it("should render properly", async () => {
     setup();
     expect(
-      withinShadowRoot(screen.getByText("Primary")).getByText("Primary"),
+      withinShadowRoot(screen.getByText("Primary")).getByRole("button"),
     ).toBeInTheDocument();
   });
 

--- a/packages/web-components/tests/Menu.spec.tsx
+++ b/packages/web-components/tests/Menu.spec.tsx
@@ -1,0 +1,55 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { Menu } from "@optiaxiom/web-components/Menu";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { MenuContent } from "@optiaxiom/web-components/MenuContent";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { MenuItem } from "@optiaxiom/web-components/MenuItem";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { MenuSeparator } from "@optiaxiom/web-components/MenuSeparator";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { MenuTrigger } from "@optiaxiom/web-components/MenuTrigger";
+import { describe, expect, it } from "vitest";
+
+import { render, screen } from "../vitest.rtl";
+
+describe("Menu component", () => {
+  function setup() {
+    return render(
+      <Menu>
+        <MenuTrigger>Profile</MenuTrigger>
+
+        <MenuContent>
+          <MenuItem>View Profile</MenuItem>
+          <MenuSeparator />
+          <MenuItem>Logout</MenuItem>
+        </MenuContent>
+      </Menu>,
+    );
+  }
+
+  it("should render properly", async () => {
+    setup();
+
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: "View Profile" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should open menu on click", async () => {
+    const { user } = setup();
+
+    await user.hover(screen.getByText("Profile"));
+    expect(await screen.findByText("View Profile")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Logout"));
+    expect(
+      screen.queryByRole("menuitem", { name: "View Profile" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/web-components/tests/SelfLoading.spec.tsx
+++ b/packages/web-components/tests/SelfLoading.spec.tsx
@@ -19,7 +19,7 @@ describe("Self-loading components", () => {
     setup();
     await customElements.whenDefined(Button);
     expect(
-      withinShadowRoot(screen.getByText("Primary")).getByText("Primary"),
+      withinShadowRoot(screen.getByText("Primary")).getByRole("button"),
     ).toBeInTheDocument();
   });
 });

--- a/packages/web-components/tests/Slot.spec.tsx
+++ b/packages/web-components/tests/Slot.spec.tsx
@@ -19,6 +19,6 @@ describe("Component slots", () => {
     setup();
     expect(
       withinShadowRoot(screen.getByText("Primary")).getByRole("button"),
-    ).toHaveTextContent("Primaryicon");
+    ).toHaveTextContent("icon");
   });
 });

--- a/packages/web-components/tests/Tooltip.spec.tsx
+++ b/packages/web-components/tests/Tooltip.spec.tsx
@@ -3,7 +3,12 @@
 import { Tooltip } from "@optiaxiom/web-components/Tooltip";
 import { describe, expect, it } from "vitest";
 
-import { render, screen, waitForElementToBeRemoved } from "../vitest.rtl";
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+  withinShadowRoot,
+} from "../vitest.rtl";
 
 describe("Tooltip component", () => {
   function setup(overrides = {}) {
@@ -44,10 +49,16 @@ describe("Tooltip component", () => {
   });
 
   it("should render tooltip styles", async () => {
-    const { user } = setup();
+    const { user } = setup({ "data-testid": "tooltip" });
 
     await user.hover(screen.getByText("Tooltip Target"));
-    expect((await screen.findAllByText("Tooltip Content"))[0]).toHaveStyle({
+    expect(
+      (
+        await withinShadowRoot(screen.getByTestId("tooltip")).findAllByText(
+          "Tooltip Content",
+        )
+      )[0],
+    ).toHaveStyle({
       color: "#fff",
     });
   });


### PR DESCRIPTION
- render a single `<slot />` inside the shadow root where we want `children` props to be injected and forward the outer element as the `ref`
- render a preact context consumer inside the `<slot />` that propagates context across multiple render roots via `getChildContext` https://github.com/preactjs/preact-custom-element/pull/43
- wrap all components with a `CustomElementContext` to pass the custom element reference and use a custom preact `vnode` hook to inject the custom element's shadow root as the portal container