### PR TITLE
enable font smoothing using grayscale antialiasing

### DIFF
--- a/packages/react/src/box/Box.css.ts
+++ b/packages/react/src/box/Box.css.ts
@@ -8,6 +8,7 @@ export const box = recipe({
   base: style({
     "@layer": {
       [layers.reset]: {
+        WebkitFontSmoothing: "antialiased",
         border: `0 solid ${theme.colors["border.default"]}`,
         boxSizing: "border-box",
         fontFamily: theme.fontFamily.sans,


### PR DESCRIPTION
to ensure typography matches figma design

### Before
<img width="194" alt="Screenshot 2024-08-23 at 6 52 02 PM" src="https://github.com/user-attachments/assets/36aa9ea4-55ef-4b32-90d8-2b02172daec9">

### After
<img width="194" alt="Screenshot 2024-08-23 at 6 51 40 PM" src="https://github.com/user-attachments/assets/325d1161-db5a-436c-abc2-e19ec2038d82">
