### PR TITLE
disallow `rows` prop when auto sizing textarea

### DIFF
--- a/packages/react/src/textarea/Textarea.tsx
+++ b/packages/react/src/textarea/Textarea.tsx
@@ -10,6 +10,7 @@ type TextareaProps =
       typeof TextareaAutosize,
       {
         children?: never;
+        rows?: never;
         size?: never;
       }
     >)


### PR DESCRIPTION
closes #248

when resize=auto only minRows and maxRows prop is used so we ban rows to prevent confusion for devs