### PR TITLE
fix input size on safari

### DIFF
--- a/packages/react/src/input-base/InputBase.css.ts
+++ b/packages/react/src/input-base/InputBase.css.ts
@@ -60,6 +60,7 @@ export const input = recipe({
     {
       bg: "transparent",
       flex: "auto",
+      w: "full",
     },
     style({
       /*


### PR DESCRIPTION
safari gives preference to the input[size] attribute which gives inputs a large minimum width.

so we handle that by giving the input a width of 100% to make it stretch/grow to fill the wrapper instead

### Before
<img width="1510" alt="Screenshot 2024-09-09 at 3 48 48 PM" src="https://github.com/user-attachments/assets/f7c0c6a3-f102-444f-9224-f03e09e63e7d">

### After
<img width="1510" alt="Screenshot 2024-09-09 at 3 48 30 PM" src="https://github.com/user-attachments/assets/51383442-e33a-4746-b070-3866d58d710d">
