### PR TITLE
adjust dropdown menu stories

### DIFF
--- a/apps/storybook/src/overlays/DropdownMenu.stories.tsx
+++ b/apps/storybook/src/overlays/DropdownMenu.stories.tsx
@@ -112,6 +112,20 @@ export const Description: Story = {
     ),
     defaultOpen: true,
   },
+  play: async () => {
+    await waitFor(
+      async () =>
+        await expect(
+          screen.getByRole("menuitem", { name: "New task" }),
+        ).toBeVisible(),
+    );
+    await waitFor(
+      async () =>
+        await expect(
+          screen.getByRole("menuitem", { description: "Copy this task" }),
+        ).toBeVisible(),
+    );
+  },
 };
 
 export const LongContent: Story = {

--- a/apps/storybook/src/overlays/DropdownMenu.stories.tsx
+++ b/apps/storybook/src/overlays/DropdownMenu.stories.tsx
@@ -24,6 +24,9 @@ import {
 } from "@tabler/icons-react";
 
 export default {
+  args: {
+    defaultOpen: true,
+  },
   component: DropdownMenu,
 } as Meta<typeof DropdownMenu>;
 
@@ -70,6 +73,7 @@ export const Basic: Story = {
         </DropdownMenuContent>
       </>
     ),
+    defaultOpen: false,
   },
   play: async ({ canvas }) => {
     const button = canvas.getByRole("button", {
@@ -86,9 +90,6 @@ export const Basic: Story = {
 
     await expect(menuItems[0]).not.toBeDisabled();
     await expect(menuItems[1]).toHaveAttribute("aria-disabled", "true");
-
-    await userEvent.keyboard("{Escape}");
-    await expect(menu).not.toBeVisible();
   },
 };
 
@@ -110,7 +111,6 @@ export const Description: Story = {
         </DropdownMenuContent>
       </>
     ),
-    defaultOpen: true,
   },
   play: async () => {
     await waitFor(
@@ -144,7 +144,14 @@ export const LongContent: Story = {
         </DropdownMenuContent>
       </>
     ),
-    defaultOpen: true,
+  },
+  play: async () => {
+    await waitFor(
+      async () =>
+        await expect(
+          screen.getByRole("menuitem", { name: "Logout" }),
+        ).toBeVisible(),
+    );
   },
 };
 
@@ -169,7 +176,6 @@ export const Nested: Story = {
         </DropdownMenuContent>
       </>
     ),
-    defaultOpen: true,
   },
   play: async () => {
     await waitFor(
@@ -185,14 +191,6 @@ export const Nested: Story = {
         await expect(
           screen.getByRole("menuitem", { name: "Privacy" }),
         ).toBeVisible(),
-    );
-
-    await userEvent.keyboard("{Escape}");
-    await waitFor(
-      async () =>
-        await expect(
-          screen.queryByRole("menu", { name: "My Profile" }),
-        ).not.toBeInTheDocument(),
     );
   },
 };

--- a/packages/react/src/menu-item-base/MenuItemBase.tsx
+++ b/packages/react/src/menu-item-base/MenuItemBase.tsx
@@ -1,4 +1,5 @@
 import { Slot, Slottable } from "@radix-ui/react-slot";
+import { useId } from "@reach/auto-id";
 import {
   type ElementType,
   type ReactNode,
@@ -41,16 +42,21 @@ export const MenuItemBase = forwardRef<HTMLDivElement, MenuItemBaseProps>(
     },
     ref,
   ) => {
+    const labelId = useId();
+    const descriptionId = useId();
+
     const newElement = isValidElement(children) ? children : null;
     children = newElement
       ? cloneElement(
           newElement,
           undefined,
           <Box flex="1">
-            <Box asChild>{fallbackSpan(newElement.props.children)}</Box>
+            <Box asChild id={labelId}>
+              {fallbackSpan(newElement.props.children)}
+            </Box>
 
             {description && (
-              <Text color="fg.tertiary" fontSize="sm">
+              <Text color="fg.tertiary" fontSize="sm" id={descriptionId}>
                 {description}
               </Text>
             )}
@@ -60,6 +66,8 @@ export const MenuItemBase = forwardRef<HTMLDivElement, MenuItemBaseProps>(
 
     return (
       <Flex
+        aria-describedby={description ? descriptionId : undefined}
+        aria-labelledby={labelId}
         asChild
         ref={ref}
         {...styles.item({ colorScheme }, className)}


### PR DESCRIPTION
related: #324

so menus remain open for chromatic to take screenshots

and also correctly identify label and description elements using aria attributes