### PR TITLE
ignore nullish sprinkle values

### DIFF
--- a/packages/react/src/box/Box.spec.tsx
+++ b/packages/react/src/box/Box.spec.tsx
@@ -28,6 +28,20 @@ describe("Box component", () => {
     expect(screen.getByText(/This is a box/i)).toContainHTML("marginLeft_0");
   });
 
+  it("should merge sprinkle props properly for direct undefined props", () => {
+    render(
+      <Box asChild mx="4">
+        <Box asChild mx="2">
+          <Box mx={undefined}>This is a box</Box>
+        </Box>
+      </Box>,
+    );
+    expect(screen.getByText(/This is a box/i)).not.toContainHTML(
+      "marginLeft_4",
+    );
+    expect(screen.getByText(/This is a box/i)).toContainHTML("marginLeft_2");
+  });
+
   it("should merge sprinkle props properly for indirect props", () => {
     render(
       <Text asChild fontSize="sm">

--- a/packages/react/src/sprinkles/extractSprinkles.ts
+++ b/packages/react/src/sprinkles/extractSprinkles.ts
@@ -6,8 +6,10 @@ export function extractSprinkles<S extends Record<string, unknown>>(props: S) {
 
   for (const [name, value] of Object.entries(props)) {
     if (styles.sprinkles.properties.has(name as never)) {
-      // @ts-expect-error -- too complex
-      sprinkleProps[name] = value;
+      if (value !== null && value !== undefined) {
+        // @ts-expect-error -- too complex
+        sprinkleProps[name] = value;
+      }
     } else {
       // @ts-expect-error -- too complex
       restProps[name] = value;


### PR DESCRIPTION
we need to ignore undefined sprinkle values when de-duping outer sprinkles

otherwise we were inadvertently removing class names for outer sprinkle values when an undefined value for the sprinkle (which has no effect) was being passed