### PR TITLE
Fix sprinkles type and css layers

### DIFF
--- a/apps/docs/demos/styles/index.ts
+++ b/apps/docs/demos/styles/index.ts
@@ -2,4 +2,4 @@ export { App as CssUsage } from "./css-usage/App";
 export { App as JsUsage } from "./js-usage/App";
 export { App as PropUsage } from "./prop-usage/App";
 export { App as ResponsiveComplexUsage } from "./responsive-complex-usage/App";
-export { App as ResponseUsage } from "./responsive-usage/App";
+export { App as ResponsiveUsage } from "./responsive-usage/App";

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -12,7 +12,7 @@ const withNextra = createNextra({
     },
     remarkPlugins: [remarkPlugin],
   },
-  theme: "./theme.tsx",
+  theme: "nextra-theme-docs",
   themeConfig: "./theme.config.tsx",
 });
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,6 +20,7 @@
     "next": "^14.2.14",
     "nextra": "^3.0.3",
     "nextra-theme-docs": "^3.0.3",
+    "postcss-assign-layer": "^0.4.0",
     "postcss-import": "^16.1.0",
     "react-docgen-typescript": "^2.2.2",
     "sharp": "^0.33.5",

--- a/apps/docs/pages/_app.tsx
+++ b/apps/docs/pages/_app.tsx
@@ -1,12 +1,9 @@
 import type { AppProps } from "next/app";
 
-import { Suspense, lazy, useEffect } from "react";
+import { AxiomProvider } from "@optiaxiom/react";
+import { useEffect } from "react";
 
 import "./globals.css";
-
-const AxiomProvider = lazy(async () => ({
-  default: (await import("@optiaxiom/react")).AxiomProvider,
-}));
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   /**
@@ -41,10 +38,8 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   }, []);
 
   return (
-    <Suspense>
-      <AxiomProvider>
-        <Component {...pageProps} />
-      </AxiomProvider>
-    </Suspense>
+    <AxiomProvider>
+      <Component {...pageProps} />
+    </AxiomProvider>
   );
 }

--- a/apps/docs/pages/globals.css
+++ b/apps/docs/pages/globals.css
@@ -1,5 +1,3 @@
-@import "nextra-theme-docs/dist/style.css" layer(optiaxiom.base);
-
 html {
   font-family: InterVariable, sans-serif;
   font-feature-settings: "cv02", "cv03", "cv04";

--- a/apps/docs/postcss.config.json
+++ b/apps/docs/postcss.config.json
@@ -1,3 +1,14 @@
 {
-  "plugins": ["postcss-import"]
+  "plugins": [
+    "postcss-import",
+    [
+      "postcss-assign-layer",
+      [
+        {
+          "include": "**/nextra-theme-docs/**",
+          "layerName": "optiaxiom.base"
+        }
+      ]
+    ]
+  ]
 }

--- a/apps/docs/theme.tsx
+++ b/apps/docs/theme.tsx
@@ -1,3 +1,0 @@
-import Layout from "nextra-theme-docs";
-
-export default Layout;

--- a/packages/react/src/layers/layers.css.ts
+++ b/packages/react/src/layers/layers.css.ts
@@ -1,7 +1,9 @@
 // eslint-disable-next-line local/no-global-styles
-import { globalLayer, layer } from "@vanilla-extract/css";
+import { generateIdentifier, globalLayer } from "@vanilla-extract/css";
 
-export const axiom = globalLayer("optiaxiom");
-export const base = globalLayer({ parent: axiom }, "base");
-export const reset = layer({ parent: axiom }, "reset");
-export const components = layer({ parent: axiom }, "components");
+export const axiom = "optiaxiom";
+export const base = `${axiom}.base`;
+export const reset = `${axiom}.${generateIdentifier()}`;
+export const components = `${axiom}.${generateIdentifier()}`;
+
+globalLayer([axiom, base, reset, components].join(", "));

--- a/packages/react/src/sprinkles/sprinkles.ts
+++ b/packages/react/src/sprinkles/sprinkles.ts
@@ -3,12 +3,10 @@ import { createMapValueFn, createSprinkles } from "@vanilla-extract/sprinkles";
 import * as styles from "./properties.css";
 
 export const sprinkles = createSprinkles(
-  styles.unresponsiveProps ?? { conditions: {} },
-  styles.responsiveProps ?? { conditions: {} },
+  styles.unresponsiveProps,
+  styles.responsiveProps,
 );
-export const mapResponsiveValue = createMapValueFn(
-  styles.responsiveProps ?? { conditions: {} },
-);
+export const mapResponsiveValue = createMapValueFn(styles.responsiveProps);
 
 type LonghandProps = keyof Pick<
   Parameters<typeof sprinkles>[0],

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -2,7 +2,7 @@ import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  plugins: [vanillaExtractPlugin()],
+  plugins: [vanillaExtractPlugin({ unstable_mode: "transform" })],
   test: {
     environment: "happy-dom",
     restoreMocks: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       nextra-theme-docs:
         specifier: ^3.0.3
         version: 3.0.3(next@14.2.14(@babel/core@7.24.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.0.3(@types/react@18.3.11)(next@14.2.14(@babel/core@7.24.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      postcss-assign-layer:
+        specifier: ^0.4.0
+        version: 0.4.0(postcss@8.4.47)
       postcss-import:
         specifier: ^16.1.0
         version: 16.1.0(postcss@8.4.47)
@@ -2123,6 +2126,10 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
+
+  '@rollup/pluginutils@4.2.1':
+    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
+    engines: {node: '>= 8.0.0'}
 
   '@rollup/pluginutils@5.1.2':
     resolution: {integrity: sha512-/FIdS3PyZ39bjZlwqFnWqCOVnW7o963LtKMwQOD0NhQqw22gSr2YY1afu3FxRip4ZCZNsD5jq6Aaz6QV3D/Njw==}
@@ -6194,6 +6201,12 @@ packages:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
 
+  postcss-assign-layer@0.4.0:
+    resolution: {integrity: sha512-ART9ENWnvEyW3yyfJe83nz5j/IsbQHBgSMsUNFmC/+6zy0uC9YTriHKV6TEjOOHXRzXS2yNPj0ksvYkEwwkv5w==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      postcss: ^8.3.0
+
   postcss-calc@10.0.2:
     resolution: {integrity: sha512-DT/Wwm6fCKgpYVI7ZEWuPJ4az8hiEHtCUeYjZXqU7Ou4QqYh1Df2yCQ7Ca6N7xqKPFkxN3fhf+u9KSoOCJNAjg==}
     engines: {node: ^18.12 || ^20.9 || >=22.0}
@@ -9617,6 +9630,11 @@ snapshots:
       resolve: 1.22.8
     optionalDependencies:
       rollup: 4.24.0
+
+  '@rollup/pluginutils@4.2.1':
+    dependencies:
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
 
   '@rollup/pluginutils@5.1.2(rollup@4.24.0)':
     dependencies:
@@ -14814,6 +14832,11 @@ snapshots:
       '@babel/runtime': 7.25.7
 
   possible-typed-array-names@1.0.0: {}
+
+  postcss-assign-layer@0.4.0(postcss@8.4.47):
+    dependencies:
+      '@rollup/pluginutils': 4.2.1
+      postcss: 8.4.47
 
   postcss-calc@10.0.2(postcss@8.4.47):
     dependencies:


### PR DESCRIPTION
actually transform `css.ts` files in vitest - to prevent `undefined` output and having to handle that in tests. because handling them in code just to fix the tests also has a side effect of breaking the types which is used to generate the docs.

fix the css cascade layers by applying a global layer statement with the layers in correct order in comma format - otherwise they end up as individual statements in the final file which can get mangled by css minifiers.