### PR TITLE
remove primitive colors tokens from theme

### DIFF
--- a/.changeset/angry-suns-matter.md
+++ b/.changeset/angry-suns-matter.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/globals": minor
+"@optiaxiom/react": minor
+---
+
+remove primitive color tokens from theme

--- a/packages/globals/src/tokens/colors.ts
+++ b/packages/globals/src/tokens/colors.ts
@@ -93,8 +93,6 @@ export const colorPalette = {
 } as const;
 
 export const colors = {
-  ...colorPalette,
-
   current: "currentColor" as const,
   transparent: "transparent" as const,
 
@@ -196,8 +194,6 @@ export const colors = {
 } as const;
 
 export const colorsDark = {
-  ...colorPalette,
-
   current: "currentColor" as const,
   transparent: "transparent" as const,
 


### PR DESCRIPTION
devs should only use semantic color tokens so the intent is always clear