### PR TITLE
fix indicator z-index on focus

### DIFF
--- a/.changeset/kind-bikes-matter.md
+++ b/.changeset/kind-bikes-matter.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+fix indicator z-index on focus

--- a/packages/react/src/indicator/Indicator.tsx
+++ b/packages/react/src/indicator/Indicator.tsx
@@ -35,6 +35,8 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
   ) => {
     return (
       <Flex ref={ref} {...styles.indicator({}, className)} {...props}>
+        {children}
+
         {!disabled && (
           <Box {...styles.floating({ offset, position })}>
             {ping && (
@@ -59,8 +61,6 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
             </Badge>
           </Box>
         )}
-
-        {children}
       </Flex>
     );
   },


### PR DESCRIPTION
by moving indicator badge after children so it appears above in css stack order