### PR TITLE
use events to correctly bridge web-component islands

### DIFF
--- a/.changeset/rare-beers-retire.md
+++ b/.changeset/rare-beers-retire.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/web-components": patch
+---
+
+use events to correctly bridge web-component islands


### PR DESCRIPTION
we need to create bridges between shadow DOM and preact in a sub-tree to:
- consume the context from the parent island and propagate it to children
- un-mount/re-mount children when ancestor components mount/un-mount

so we rely on custom events on the shadow DOM hosts to achieve this