### PR TITLE
use context to pass onOpenChange handler from provider

### DIFF
--- a/.changeset/wise-ties-mate.md
+++ b/.changeset/wise-ties-mate.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+use context to pass handlers to toasts

--- a/packages/react/src/toast-context/ToastContext.ts
+++ b/packages/react/src/toast-context/ToastContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from "@radix-ui/react-context";
+
+export const [ToastContextProvider, useToastContext] = createContext<{
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}>("ToastProvider");

--- a/packages/react/src/toast-context/index.ts
+++ b/packages/react/src/toast-context/index.ts
@@ -1,0 +1,1 @@
+export * from "./ToastContext";

--- a/packages/react/src/toast-provider/ToastProvider.tsx
+++ b/packages/react/src/toast-provider/ToastProvider.tsx
@@ -2,7 +2,6 @@ import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import { Portal } from "@radix-ui/react-portal";
 import * as RadixToast from "@radix-ui/react-toast";
 import {
-  cloneElement,
   type ComponentPropsWithoutRef,
   forwardRef,
   isValidElement,
@@ -15,6 +14,7 @@ import { Flex } from "../flex";
 import { extractSprinkles } from "../sprinkles";
 import { Toast } from "../toast/Toast";
 import { ToastAction } from "../toast-action";
+import { ToastContextProvider } from "../toast-context";
 import { ToastTitle } from "../toast-title";
 import { type createToaster, toaster } from "./toaster";
 import * as styles from "./ToastProvider.css";
@@ -77,39 +77,32 @@ export const ToastProvider = forwardRef<HTMLOListElement, ToastProps>(
         swipeDirection={swipeDirection ?? mapPositionToSwipeDirection[position]}
         swipeThreshold={swipeThreshold}
       >
-        {toasts.map(({ id, open, toast }) =>
-          cloneElement(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/microsoft/TypeScript/issues/53178
-            isValidElement<any>(toast) ? (
-              toast
-            ) : (
-              <Toast colorScheme={toast.type} key={id}>
-                <ToastTitle>{toast.title}</ToastTitle>
-                {toast.action && (
-                  <ToastAction
-                    altText={toast.action.altText}
-                    onClick={toast.action.onClick}
-                  >
-                    {toast.action.label}
-                  </ToastAction>
-                )}
-              </Toast>
-            ),
+        {toasts.map(({ id, open, toast }) => (
+          <ToastContextProvider
+            key={id}
+            onOpenChange={() => toasterProp.remove(id)}
+            open={open}
+          >
             {
-              forceMount: true,
-              key: id,
-              onOpenChange: (open: boolean) => {
-                if (
-                  isValidElement<ComponentPropsWithoutRef<typeof Toast>>(toast)
-                ) {
-                  toast.props.onOpenChange?.(open);
-                }
-                toasterProp.remove(id);
-              },
-              open,
-            },
-          ),
-        )}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/microsoft/TypeScript/issues/53178
+              isValidElement<any>(toast) ? (
+                toast
+              ) : (
+                <Toast colorScheme={toast.type} key={id}>
+                  <ToastTitle>{toast.title}</ToastTitle>
+                  {toast.action && (
+                    <ToastAction
+                      altText={toast.action.altText}
+                      onClick={toast.action.onClick}
+                    >
+                      {toast.action.label}
+                    </ToastAction>
+                  )}
+                </Toast>
+              )
+            }
+          </ToastContextProvider>
+        ))}
 
         <Portal container={container}>
           <Flex

--- a/packages/react/src/toast/Toast.tsx
+++ b/packages/react/src/toast/Toast.tsx
@@ -10,6 +10,7 @@ import { IconCircleInfoFilled } from "../icons/IconCircleInfoFilled";
 import { IconTriangleExclamationFilled } from "../icons/IconTriangleExclamationFilled";
 import { IconX } from "../icons/IconX";
 import { extractSprinkles } from "../sprinkles";
+import { useToastContext } from "../toast-context";
 import * as styles from "./Toast.css";
 
 type ToastProps = BoxProps<
@@ -31,12 +32,17 @@ export const Toast = forwardRef<HTMLLIElement, ToastProps>(
     ref,
   ) => {
     const { restProps, sprinkleProps } = extractSprinkles(props);
+    const context = useToastContext("Toast");
 
     return (
       <Box asChild {...styles.root({ colorScheme })} {...sprinkleProps}>
         <RadixToast.Root
-          onOpenChange={onOpenChange}
-          open={open}
+          forceMount={!!context}
+          onOpenChange={(open) => {
+            onOpenChange?.(open);
+            context.onOpenChange(open);
+          }}
+          open={context.open || open}
           ref={ref}
           {...restProps}
         >


### PR DESCRIPTION
we should not rely on `cloneElement` to pass props/handlers since the target element could be deeply nested in which case `cloneElement` will not work

so we instead use context to pass the handler and state