### PR TITLE
fix menu-button prop overrides

### DIFF
--- a/packages/react/src/dropdown-menu-trigger/DropdownMenuTrigger.tsx
+++ b/packages/react/src/dropdown-menu-trigger/DropdownMenuTrigger.tsx
@@ -9,27 +9,12 @@ type MenuTriggerProps = ComponentPropsWithoutRef<typeof Button>;
 export const DropdownMenuTrigger = forwardRef<
   HTMLButtonElement,
   MenuTriggerProps
->(
-  (
-    { asChild, children, icon, iconPosition, justifyContent, ...props },
-    ref,
-  ) => {
-    return (
-      <RadixMenu.Trigger asChild ref={ref} {...props}>
-        {asChild ? (
-          children
-        ) : (
-          <MenuButton
-            icon={icon}
-            iconPosition={iconPosition}
-            justifyContent={justifyContent}
-          >
-            {children}
-          </MenuButton>
-        )}
-      </RadixMenu.Trigger>
-    );
-  },
-);
+>(({ asChild, children, ...props }, ref) => {
+  return (
+    <RadixMenu.Trigger asChild ref={ref} {...props}>
+      {asChild ? children : <MenuButton>{children}</MenuButton>}
+    </RadixMenu.Trigger>
+  );
+});
 
 DropdownMenuTrigger.displayName = "@optiaxiom/react/DropdownMenuTrigger";

--- a/packages/react/src/popover-trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover-trigger/PopoverTrigger.tsx
@@ -9,27 +9,12 @@ type PopoverTriggerProps = ComponentPropsWithoutRef<typeof Button>;
 export const PopoverTrigger = forwardRef<
   HTMLButtonElement,
   PopoverTriggerProps
->(
-  (
-    { asChild, children, icon, iconPosition, justifyContent, ...props },
-    ref,
-  ) => {
-    return (
-      <RadixPopover.Trigger asChild ref={ref} {...props}>
-        {asChild ? (
-          children
-        ) : (
-          <MenuButton
-            icon={icon}
-            iconPosition={iconPosition}
-            justifyContent={justifyContent}
-          >
-            {children}
-          </MenuButton>
-        )}
-      </RadixPopover.Trigger>
-    );
-  },
-);
+>(({ asChild, children, ...props }, ref) => {
+  return (
+    <RadixPopover.Trigger asChild ref={ref} {...props}>
+      {asChild ? children : <MenuButton>{children}</MenuButton>}
+    </RadixPopover.Trigger>
+  );
+});
 
 PopoverTrigger.displayName = "@optiaxiom/react/PopoverTrigger";


### PR DESCRIPTION
follow up to #504

just relying on asChild to override the props is good enough - no need to pull them out explicitly