### PR TITLE
rename colorScheme to intent or appearance consistently across components

### DIFF
--- a/.changeset/tender-feet-report.md
+++ b/.changeset/tender-feet-report.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": minor
+---
+
+rename colorScheme to intent across components

--- a/.changeset/wicked-forks-count.md
+++ b/.changeset/wicked-forks-count.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": minor
+---
+
+rename colorScheme to appearance in spinner

--- a/apps/docs/demos/alert/appearance-usage/App.tsx
+++ b/apps/docs/demos/alert/appearance-usage/App.tsx
@@ -3,10 +3,10 @@ import type { ComponentPropsWithoutRef } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@optiaxiom/react";
 
 export function App({
-  colorScheme,
-}: Pick<ComponentPropsWithoutRef<typeof Alert>, "colorScheme">) {
+  intent,
+}: Pick<ComponentPropsWithoutRef<typeof Alert>, "intent">) {
   return (
-    <Alert colorScheme={colorScheme}>
+    <Alert intent={intent}>
       <AlertTitle>Alert title</AlertTitle>
       <AlertDescription>Description of the alert message</AlertDescription>
     </Alert>

--- a/apps/docs/demos/badge/appearance-usage/App.tsx
+++ b/apps/docs/demos/badge/appearance-usage/App.tsx
@@ -3,11 +3,11 @@ import type { ComponentPropsWithRef } from "react";
 import { Badge } from "@optiaxiom/react";
 
 export function App({
-  colorScheme = "success",
+  intent = "success",
   variant = "light",
-}: Pick<ComponentPropsWithRef<typeof Badge>, "colorScheme" | "variant">) {
+}: Pick<ComponentPropsWithRef<typeof Badge>, "intent" | "variant">) {
   return (
-    <Badge colorScheme={colorScheme} variant={variant}>
+    <Badge intent={intent} variant={variant}>
       Pending
     </Badge>
   );

--- a/apps/docs/demos/badge/usage/App.tsx
+++ b/apps/docs/demos/badge/usage/App.tsx
@@ -5,7 +5,7 @@ export function App() {
     <Flex flexDirection="row">
       <Badge>Status</Badge>
 
-      <Badge colorScheme="danger">99+</Badge>
+      <Badge intent="danger">99+</Badge>
     </Flex>
   );
 }

--- a/apps/docs/demos/banner/appearance-usage/App.tsx
+++ b/apps/docs/demos/banner/appearance-usage/App.tsx
@@ -3,10 +3,10 @@ import type { ComponentPropsWithoutRef } from "react";
 import { Banner, BannerDescription, BannerTitle } from "@optiaxiom/react";
 
 export function App({
-  colorScheme,
-}: Pick<ComponentPropsWithoutRef<typeof Banner>, "colorScheme">) {
+  intent,
+}: Pick<ComponentPropsWithoutRef<typeof Banner>, "intent">) {
   return (
-    <Banner colorScheme={colorScheme}>
+    <Banner intent={intent}>
       <BannerTitle>Banner title</BannerTitle>
       <BannerDescription>Description of the banner message</BannerDescription>
     </Banner>

--- a/apps/docs/demos/dropdown-menu/appearance-usage/App.tsx
+++ b/apps/docs/demos/dropdown-menu/appearance-usage/App.tsx
@@ -13,7 +13,7 @@ export function App() {
 
       <DropdownMenuContent>
         <DropdownMenuItem icon={<IconPencil />}>Edit</DropdownMenuItem>
-        <DropdownMenuItem colorScheme="danger" icon={<IconTrash />}>
+        <DropdownMenuItem icon={<IconTrash />} intent="danger">
           Delete
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/apps/docs/demos/dropdown-menu/description-usage/App.tsx
+++ b/apps/docs/demos/dropdown-menu/description-usage/App.tsx
@@ -19,7 +19,7 @@ export function App() {
           Copy task
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        <DropdownMenuItem colorScheme="danger">Delete task</DropdownMenuItem>
+        <DropdownMenuItem intent="danger">Delete task</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/docs/demos/indicator/appearance-usage/App.tsx
+++ b/apps/docs/demos/indicator/appearance-usage/App.tsx
@@ -4,11 +4,11 @@ import { Button, Indicator } from "@optiaxiom/react";
 import { IconBell } from "@tabler/icons-react";
 
 export function App({
-  colorScheme = "success",
+  intent = "success",
   variant = "light",
-}: Pick<ComponentPropsWithRef<typeof Indicator>, "colorScheme" | "variant">) {
+}: Pick<ComponentPropsWithRef<typeof Indicator>, "intent" | "variant">) {
   return (
-    <Indicator colorScheme={colorScheme} content="4" variant={variant}>
+    <Indicator content="4" intent={intent} variant={variant}>
       <Button aria-label="Notifications" icon={<IconBell />} />
     </Indicator>
   );

--- a/apps/docs/demos/indicator/content-usage/App.tsx
+++ b/apps/docs/demos/indicator/content-usage/App.tsx
@@ -3,7 +3,7 @@ import { IconBell } from "@tabler/icons-react";
 
 export function App() {
   return (
-    <Indicator colorScheme="danger" content="4" variant="solid">
+    <Indicator content="4" intent="danger" variant="solid">
       <Button aria-label="Notifications" icon={<IconBell />} />
     </Indicator>
   );

--- a/apps/docs/demos/indicator/disabled-usage/App.tsx
+++ b/apps/docs/demos/indicator/disabled-usage/App.tsx
@@ -7,7 +7,7 @@ export function App({
   disabled = false,
 }: Pick<ComponentPropsWithRef<typeof Indicator>, "disabled">) {
   return (
-    <Indicator colorScheme="danger" content="4" disabled={disabled}>
+    <Indicator content="4" disabled={disabled} intent="danger">
       <Button aria-label="Notifications" icon={<IconBell />} />
     </Indicator>
   );

--- a/apps/docs/demos/indicator/usage/App.tsx
+++ b/apps/docs/demos/indicator/usage/App.tsx
@@ -3,7 +3,7 @@ import { IconBell } from "@tabler/icons-react";
 
 export function App() {
   return (
-    <Indicator colorScheme="danger" variant="solid">
+    <Indicator intent="danger" variant="solid">
       <Button aria-label="Notifications" icon={<IconBell />} />
     </Indicator>
   );

--- a/apps/docs/demos/spinner/color-usage/App.tsx
+++ b/apps/docs/demos/spinner/color-usage/App.tsx
@@ -3,12 +3,12 @@ import type { ComponentPropsWithRef } from "react";
 import { Spinner } from "@optiaxiom/react";
 
 export function App({
-  colorScheme = "inverse",
-}: Pick<ComponentPropsWithRef<typeof Spinner>, "colorScheme">) {
+  appearance = "inverse",
+}: Pick<ComponentPropsWithRef<typeof Spinner>, "appearance">) {
   return (
     <Spinner
-      bg={colorScheme === "default" ? "bg.default" : "bg.default.inverse"}
-      colorScheme={colorScheme}
+      appearance={appearance}
+      bg={appearance === "default" ? "bg.default" : "bg.default.inverse"}
       p="xs"
       rounded="sm"
       size="sm"

--- a/apps/docs/demos/toast/appearance-usage/App.tsx
+++ b/apps/docs/demos/toast/appearance-usage/App.tsx
@@ -3,13 +3,13 @@ import type { ComponentPropsWithRef } from "react";
 import { Button, Toast, toaster, ToastTitle } from "@optiaxiom/react";
 
 export function App({
-  colorScheme,
-}: Pick<ComponentPropsWithRef<typeof Toast>, "colorScheme">) {
+  intent,
+}: Pick<ComponentPropsWithRef<typeof Toast>, "intent">) {
   return (
     <Button
       onClick={() =>
         toaster.create(
-          <Toast colorScheme={colorScheme}>
+          <Toast intent={intent}>
             <ToastTitle>This is an example toast message.</ToastTitle>
           </Toast>,
         )

--- a/apps/docs/pages/components/_meta.tsx
+++ b/apps/docs/pages/components/_meta.tsx
@@ -4,7 +4,7 @@ import { Badge, Flex } from "@optiaxiom/react";
 
 const AlphaItem = ({ children }: { children?: ReactNode }) => (
   <Flex flex="1" flexDirection="row" justifyContent="space-between">
-    {children} <Badge colorScheme="primary">ALPHA</Badge>
+    {children} <Badge intent="primary">ALPHA</Badge>
   </Flex>
 );
 

--- a/apps/docs/pages/components/alert.mdx
+++ b/apps/docs/pages/components/alert.mdx
@@ -15,7 +15,7 @@ Keeps users informed of important and sometimes time-sensitive changes.
 
 ### Appearance
 
-Use the `colorScheme` prop to select between the different alert types.
+Use the `intent` prop to select between the different alert types.
 
 <Demo component={AppearanceUsage} />
 

--- a/apps/docs/pages/components/badge.mdx
+++ b/apps/docs/pages/components/badge.mdx
@@ -15,7 +15,7 @@ Use to emphasize a status, count, state or value.
 
 ### Appearance
 
-Use the `colorScheme` and `variant` props to fine tune the appearance of the badge.
+Use the `intent` and `variant` props to fine tune the appearance of the badge.
 
 <Demo component={AppearanceUsage} />
 

--- a/apps/docs/pages/components/banner.mdx
+++ b/apps/docs/pages/components/banner.mdx
@@ -15,7 +15,7 @@ Display a prominent message at the top of the screen.
 
 ### Appearance
 
-Use the `colorScheme` prop to select between the different banner types.
+Use the `intent` prop to select between the different banner types.
 
 <Demo component={AppearanceUsage} />
 

--- a/apps/docs/pages/components/dropdown-menu.mdx
+++ b/apps/docs/pages/components/dropdown-menu.mdx
@@ -65,9 +65,9 @@ Use the `align` and `side` props on `DropdownMenuContent` to change the default 
 
 ### Appearance
 
-Use the `colorScheme` prop to control the appearance of items.
+Use the `intent` prop to control the appearance of items.
 
-<Demo meta='/colorScheme="danger"/' component={AppearanceUsage} />
+<Demo meta='/intent="danger"/' component={AppearanceUsage} />
 
 ### Description
 

--- a/apps/docs/pages/components/indicator.mdx
+++ b/apps/docs/pages/components/indicator.mdx
@@ -26,7 +26,7 @@ Use the `content` prop to set the content of the badge.
 
 ### Appearance
 
-Use the `colorScheme` and `variant` props to fine tune the appearance of the badge.
+Use the `intent` and `variant` props to fine tune the appearance of the badge.
 
 <Demo component={AppearanceUsage} />
 

--- a/apps/docs/pages/components/spinner.mdx
+++ b/apps/docs/pages/components/spinner.mdx
@@ -25,9 +25,9 @@ Use `children` to show an optional label for the spinner.
 
 <Demo component={LabelUsage} />
 
-### Color scheme
+### Appearance
 
-Set the `colorScheme` prop to `inverse` when displaying spinner on dark background.
+Set the `appearance` prop to `inverse` when displaying spinner on dark background.
 
 <Demo component={ColorUsage} />
 

--- a/apps/docs/pages/components/toast.mdx
+++ b/apps/docs/pages/components/toast.mdx
@@ -22,7 +22,7 @@ Use `toaster.create()` along with the `Toast` component to add toasts.
 
 ### Appearance
 
-Use the `colorScheme` prop to select between the different toast types.
+Use the `intent` prop to select between the different toast types.
 
 <Demo component={AppearanceUsage} />
 

--- a/apps/storybook/src/data-display/Indicator.stories.tsx
+++ b/apps/storybook/src/data-display/Indicator.stories.tsx
@@ -13,7 +13,7 @@ export default {
 
 type Story = StoryObj<typeof Indicator>;
 
-const colorSchemes = [
+const intents = [
   "primary",
   "success",
   "warning",
@@ -27,13 +27,8 @@ const positions = ["top-right", "bottom-right"] as const;
 const Variants: Story = {
   render: (args) => (
     <Flex flexDirection="column" gap="sm">
-      {colorSchemes.map((colorScheme) => (
-        <Indicator
-          {...args}
-          colorScheme={colorScheme}
-          content="4"
-          key={colorScheme}
-        />
+      {intents.map((intent) => (
+        <Indicator {...args} content="4" intent={intent} key={intent} />
       ))}
     </Flex>
   ),
@@ -63,7 +58,7 @@ export const Disabled: Story = {
 
 export const Position: Story = {
   args: {
-    colorScheme: "danger",
+    intent: "danger",
     variant: "solid",
   },
   render: (args) => (
@@ -79,8 +74,8 @@ export const Position: Story = {
 
 export const Ping: Story = {
   args: {
-    colorScheme: "information",
     content: "",
+    intent: "information",
     ping: true,
     variant: "solid",
   },

--- a/apps/storybook/src/feedback/Alert.stories.tsx
+++ b/apps/storybook/src/feedback/Alert.stories.tsx
@@ -52,11 +52,11 @@ export const Appearance: Story = {
   },
   render: (args) => (
     <Flex>
-      <Alert colorScheme="neutral" {...args} />
-      <Alert colorScheme="information" {...args} />
-      <Alert colorScheme="warning" {...args} />
-      <Alert colorScheme="danger" {...args} />
-      <Alert colorScheme="success" {...args} />
+      <Alert intent="neutral" {...args} />
+      <Alert intent="information" {...args} />
+      <Alert intent="warning" {...args} />
+      <Alert intent="danger" {...args} />
+      <Alert intent="success" {...args} />
     </Flex>
   ),
 };

--- a/apps/storybook/src/feedback/Badge.stories.tsx
+++ b/apps/storybook/src/feedback/Badge.stories.tsx
@@ -11,12 +11,12 @@ type Story = StoryObj<typeof Badge>;
 const Variants: Story = {
   render: (args) => (
     <Flex>
-      <Badge colorScheme="primary" {...args} />
-      <Badge colorScheme="success" {...args} />
-      <Badge colorScheme="warning" {...args} />
-      <Badge colorScheme="danger" {...args} />
-      <Badge colorScheme="neutral" {...args} />
-      <Badge colorScheme="information" {...args} />
+      <Badge intent="primary" {...args} />
+      <Badge intent="success" {...args} />
+      <Badge intent="warning" {...args} />
+      <Badge intent="danger" {...args} />
+      <Badge intent="neutral" {...args} />
+      <Badge intent="information" {...args} />
     </Flex>
   ),
 };
@@ -49,14 +49,14 @@ export const Count: Story = {
       <Flex flexDirection="row">
         <Button>
           Notifications
-          <Badge colorScheme="information" variant="light">
+          <Badge intent="information" variant="light">
             8
           </Badge>
         </Button>
 
         <Button>
           Errors
-          <Badge colorScheme="danger">15</Badge>
+          <Badge intent="danger">15</Badge>
         </Button>
       </Flex>
     </>
@@ -69,7 +69,7 @@ export const Inline: Story = {
       <Flex asChild flexDirection="row">
         <Text>
           Status
-          <Badge colorScheme="success" variant="light">
+          <Badge intent="success" variant="light">
             Published
           </Badge>
         </Text>
@@ -78,7 +78,7 @@ export const Inline: Story = {
       <Flex asChild flexDirection="row">
         <Heading level="4">
           Sample Heading
-          <Badge colorScheme="success">New</Badge>
+          <Badge intent="success">New</Badge>
         </Heading>
       </Flex>
     </Flex>

--- a/apps/storybook/src/feedback/Banner.stories.tsx
+++ b/apps/storybook/src/feedback/Banner.stories.tsx
@@ -62,11 +62,11 @@ export const Appearance: Story = {
   },
   render: (args) => (
     <Flex>
-      <Banner colorScheme="neutral" {...args} />
-      <Banner colorScheme="information" {...args} />
-      <Banner colorScheme="warning" {...args} />
-      <Banner colorScheme="danger" {...args} />
-      <Banner colorScheme="success" {...args} />
+      <Banner intent="neutral" {...args} />
+      <Banner intent="information" {...args} />
+      <Banner intent="warning" {...args} />
+      <Banner intent="danger" {...args} />
+      <Banner intent="success" {...args} />
     </Flex>
   ),
 };

--- a/apps/storybook/src/feedback/Spinner.stories.tsx
+++ b/apps/storybook/src/feedback/Spinner.stories.tsx
@@ -15,8 +15,8 @@ export const Basic: Story = {};
 export const Colors: Story = {
   render: (args) => (
     <Flex flexDirection="row">
-      <Spinner {...args} colorScheme="default" />
-      <Spinner {...args} colorScheme="inverse" />
+      <Spinner {...args} appearance="default" />
+      <Spinner {...args} appearance="inverse" />
     </Flex>
   ),
 };

--- a/apps/storybook/src/feedback/Toast.stories.tsx
+++ b/apps/storybook/src/feedback/Toast.stories.tsx
@@ -94,37 +94,29 @@ export const Appearance: Story = {
     return (
       <Flex flexDirection="row">
         <Button
-          onClick={() =>
-            toaster.create(<Toast {...args} colorScheme="neutral" />)
-          }
+          onClick={() => toaster.create(<Toast {...args} intent="neutral" />)}
         >
           Neutral
         </Button>
         <Button
           onClick={() =>
-            toaster.create(<Toast {...args} colorScheme="information" />)
+            toaster.create(<Toast {...args} intent="information" />)
           }
         >
           Information
         </Button>
         <Button
-          onClick={() =>
-            toaster.create(<Toast {...args} colorScheme="warning" />)
-          }
+          onClick={() => toaster.create(<Toast {...args} intent="warning" />)}
         >
           Warning
         </Button>
         <Button
-          onClick={() =>
-            toaster.create(<Toast {...args} colorScheme="danger" />)
-          }
+          onClick={() => toaster.create(<Toast {...args} intent="danger" />)}
         >
           Danger
         </Button>
         <Button
-          onClick={() =>
-            toaster.create(<Toast {...args} colorScheme="success" />)
-          }
+          onClick={() => toaster.create(<Toast {...args} intent="success" />)}
         >
           Success
         </Button>

--- a/apps/storybook/src/navigation/Tabs.stories.tsx
+++ b/apps/storybook/src/navigation/Tabs.stories.tsx
@@ -25,7 +25,7 @@ export default {
           </TabsTrigger>
           <TabsTrigger
             addonAfter={
-              <Badge colorScheme="primary" variant="solid">
+              <Badge intent="primary" variant="solid">
                 8
               </Badge>
             }
@@ -83,7 +83,7 @@ export const Vertical: Story = {
           </TabsTrigger>
           <TabsTrigger
             addonAfter={
-              <Badge colorScheme="primary" variant="solid">
+              <Badge intent="primary" variant="solid">
                 8
               </Badge>
             }

--- a/apps/storybook/src/overlays/DropdownMenu.stories.tsx
+++ b/apps/storybook/src/overlays/DropdownMenu.stories.tsx
@@ -106,7 +106,7 @@ export const Description: Story = {
             Copy task
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem colorScheme="danger">Delete task</DropdownMenuItem>
+          <DropdownMenuItem intent="danger">Delete task</DropdownMenuItem>
         </DropdownMenuContent>
       </>
     ),

--- a/apps/storybook/src/overlays/Spotlight.stories.tsx
+++ b/apps/storybook/src/overlays/Spotlight.stories.tsx
@@ -102,7 +102,7 @@ export const Basic: Story<(typeof pages)[number]> = {
         onInputValueChange={setInputValue}
         onItemSelect={(value) => {
           toaster.create(
-            <Toast colorScheme="success">
+            <Toast intent="success">
               <ToastTitle>
                 Selected <strong>{value.title}</strong>
               </ToastTitle>

--- a/packages/react/src/alert/Alert.css.ts
+++ b/packages/react/src/alert/Alert.css.ts
@@ -16,7 +16,7 @@ export const alert = recipe({
     },
   ],
   variants: {
-    colorScheme: {
+    intent: {
       danger: {
         bg: "bg.error.subtle",
       },
@@ -44,7 +44,7 @@ export const icon = recipe({
   ],
 
   variants: {
-    colorScheme: {
+    intent: {
       danger: {
         color: "fg.error.strong",
       },

--- a/packages/react/src/alert/Alert.tsx
+++ b/packages/react/src/alert/Alert.tsx
@@ -20,7 +20,7 @@ type AlertProps = BoxProps<
   } & styles.AlertVariants
 >;
 
-const iconMap = {
+const mapIntentToIcon = {
   danger: IconCircleExclamationFilled,
   information: IconCircleInfoFilled,
   neutral: IconCircleInfoFilled,
@@ -29,10 +29,7 @@ const iconMap = {
 };
 
 export const Alert = forwardRef<HTMLDivElement, AlertProps>(
-  (
-    { children, className, colorScheme = "neutral", onClose, ...props },
-    ref,
-  ) => {
+  ({ children, className, intent = "neutral", onClose, ...props }, ref) => {
     const descriptionId = useId();
     const labelId = useId();
 
@@ -43,11 +40,11 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
           aria-labelledby={labelId}
           ref={ref}
           role="alert"
-          {...styles.alert({ colorScheme }, className)}
+          {...styles.alert({ intent }, className)}
           {...props}
         >
-          <Icon asChild {...styles.icon({ colorScheme })}>
-            {createElement(iconMap[colorScheme])}
+          <Icon asChild {...styles.icon({ intent })}>
+            {createElement(mapIntentToIcon[intent])}
           </Icon>
 
           <Flex flex="1" gap="xs" my="2">

--- a/packages/react/src/badge/Badge.css.ts
+++ b/packages/react/src/badge/Badge.css.ts
@@ -30,7 +30,7 @@ export const badge = recipe({
     }),
   ],
   variants: {
-    colorScheme: {
+    intent: {
       danger: style({
         vars: {
           [solidBackgroundColorVar]: theme.colors["bg.error"],

--- a/packages/react/src/badge/Badge.tsx
+++ b/packages/react/src/badge/Badge.tsx
@@ -12,7 +12,7 @@ export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
       asChild,
       children,
       className,
-      colorScheme = "neutral",
+      intent = "neutral",
       variant = "light",
       ...props
     },
@@ -23,7 +23,7 @@ export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
       <Text
         asChild
         role="presentation"
-        {...styles.badge({ colorScheme, variant }, className)}
+        {...styles.badge({ intent, variant }, className)}
         {...props}
       >
         <Comp ref={ref}>{children}</Comp>

--- a/packages/react/src/banner/Banner.css.ts
+++ b/packages/react/src/banner/Banner.css.ts
@@ -15,7 +15,7 @@ export const banner = recipe({
     },
   ],
   variants: {
-    colorScheme: {
+    intent: {
       danger: {
         bg: "bg.error.light",
       },
@@ -42,7 +42,7 @@ export const icon = recipe({
     },
   ],
   variants: {
-    colorScheme: {
+    intent: {
       danger: {
         color: "fg.error.strong",
       },

--- a/packages/react/src/banner/Banner.tsx
+++ b/packages/react/src/banner/Banner.tsx
@@ -20,7 +20,7 @@ type BannerProps = BoxProps<
   } & styles.BannerVariants
 >;
 
-const iconMap = {
+const mapIntentToIcon = {
   danger: IconCircleExclamationFilled,
   information: IconCircleInfoFilled,
   neutral: IconCircleInfoFilled,
@@ -29,10 +29,7 @@ const iconMap = {
 };
 
 export const Banner = forwardRef<HTMLDivElement, BannerProps>(
-  (
-    { children, className, colorScheme = "neutral", onClose, ...props },
-    ref,
-  ) => {
+  ({ children, className, intent = "neutral", onClose, ...props }, ref) => {
     const descriptionId = useId();
     const labelId = useId();
 
@@ -43,11 +40,11 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(
           aria-labelledby={labelId}
           ref={ref}
           role="alert"
-          {...styles.banner({ colorScheme }, className)}
+          {...styles.banner({ intent }, className)}
           {...props}
         >
-          <Icon asChild {...styles.icon({ colorScheme })}>
-            {createElement(iconMap[colorScheme])}
+          <Icon asChild {...styles.icon({ intent })}>
+            {createElement(mapIntentToIcon[intent])}
           </Icon>
 
           <Flex flex="1" gap="xs" my="2">

--- a/packages/react/src/button-base/ButtonBase.css.ts
+++ b/packages/react/src/button-base/ButtonBase.css.ts
@@ -46,7 +46,13 @@ export const buttonBase = recipe({
     }),
   ],
   variants: {
-    colorScheme: {
+    iconOnly: {
+      false: style({
+        minWidth: "fit-content",
+      }),
+      true: {},
+    },
+    intent: {
       danger: style({
         vars: {
           [accentColorVar]: theme.colors["bg.error"],
@@ -77,12 +83,6 @@ export const buttonBase = recipe({
           [subtlePressedAccentColorVar]: theme.colors["bg.accent.light"],
         },
       }),
-    },
-    iconOnly: {
-      false: style({
-        minWidth: "fit-content",
-      }),
-      true: {},
     },
     size: {
       sm: {

--- a/packages/react/src/button-base/ButtonBase.tsx
+++ b/packages/react/src/button-base/ButtonBase.tsx
@@ -76,8 +76,8 @@ export const ButtonBase = forwardRef<HTMLButtonElement, ButtonBaseProps>(
           <AnimatePresence>
             {loading && (
               <Spinner
+                appearance={variant === "solid" ? "inverse" : "default"}
                 aria-hidden="true"
-                colorScheme={variant === "solid" ? "inverse" : "default"}
                 size="2xs"
                 {...styles.spinner()}
               />

--- a/packages/react/src/button-base/ButtonBase.tsx
+++ b/packages/react/src/button-base/ButtonBase.tsx
@@ -9,12 +9,12 @@ import { type ExtendProps } from "../utils";
 import * as styles from "./ButtonBase.css";
 
 const appearances = {
-  danger: { colorScheme: "danger", variant: "solid" },
-  "danger-outline": { colorScheme: "danger", variant: "outline" },
-  default: { colorScheme: "neutral", variant: "outline" },
-  inverse: { colorScheme: "neutral", variant: "solid" },
-  primary: { colorScheme: "primary", variant: "solid" },
-  subtle: { colorScheme: "neutral", variant: "subtle" },
+  danger: { intent: "danger", variant: "solid" },
+  "danger-outline": { intent: "danger", variant: "outline" },
+  default: { intent: "neutral", variant: "outline" },
+  inverse: { intent: "neutral", variant: "solid" },
+  primary: { intent: "primary", variant: "solid" },
+  subtle: { intent: "neutral", variant: "subtle" },
 } satisfies Record<string, styles.ButtonVariants>;
 
 export type ButtonBaseProps<
@@ -28,7 +28,7 @@ export type ButtonBaseProps<
       children?: ReactNode;
       disabled?: boolean;
       loading?: boolean;
-    } & Omit<styles.ButtonVariants, "colorScheme" | "variant">,
+    } & Omit<styles.ButtonVariants, "intent" | "variant">,
     P
   >
 >;
@@ -51,9 +51,7 @@ export const ButtonBase = forwardRef<HTMLButtonElement, ButtonBaseProps>(
     const Comp = asChild ? Slot : "button";
     const { restProps, sprinkleProps } = extractSprinkles(props);
 
-    const presetProps = appearances[appearance];
-    const colorScheme = presetProps.colorScheme;
-    const variant = presetProps.variant;
+    const { intent, variant } = appearances[appearance];
 
     return (
       <Box
@@ -63,8 +61,8 @@ export const ButtonBase = forwardRef<HTMLButtonElement, ButtonBaseProps>(
         data-loading={loading ? "" : undefined}
         {...styles.buttonBase(
           {
-            colorScheme,
             iconOnly: Boolean(iconOnly),
+            intent,
             size,
             variant,
           },

--- a/packages/react/src/highlight/Highlight.tsx
+++ b/packages/react/src/highlight/Highlight.tsx
@@ -15,7 +15,6 @@ type HighlightProps = BoxProps<
 
 export function Highlight({
   children = (chunk) => chunk,
-  className,
   content,
   query,
   ...props
@@ -28,7 +27,7 @@ export function Highlight({
         <Fragment key={index}>
           {highlighted
             ? children(
-                <Box asChild {...styles.mark({}, className)} {...props}>
+                <Box asChild {...styles.mark()}>
                   <mark>{chunk}</mark>
                 </Box>,
               )

--- a/packages/react/src/indicator/Indicator.tsx
+++ b/packages/react/src/indicator/Indicator.tsx
@@ -22,9 +22,9 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
       asChild,
       children,
       className,
-      colorScheme,
       content,
       disabled,
+      intent,
       offset = true,
       ping,
       position = "top-right",
@@ -43,7 +43,7 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
               <Badge
                 aria-hidden="true"
                 asChild={asChild}
-                colorScheme={colorScheme}
+                intent={intent}
                 variant={variant}
                 {...styles.badge({ offset, ping: true })}
               >
@@ -53,7 +53,7 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
 
             <Badge
               asChild={asChild}
-              colorScheme={colorScheme}
+              intent={intent}
               variant={variant}
               {...styles.badge({ offset })}
             >

--- a/packages/react/src/listbox-item-base/ListboxItemBase.css.ts
+++ b/packages/react/src/listbox-item-base/ListboxItemBase.css.ts
@@ -46,7 +46,7 @@ export const item = recipe({
   ],
 
   variants: {
-    colorScheme: {
+    intent: {
       danger: style({
         vars: {
           [accentColorVar]: theme.colors["fg.error"],

--- a/packages/react/src/listbox-item-base/ListboxItemBase.tsx
+++ b/packages/react/src/listbox-item-base/ListboxItemBase.tsx
@@ -38,9 +38,9 @@ export const ListboxItemBase = forwardRef<HTMLDivElement, ListboxItemBaseProps>(
       addonBefore,
       children,
       className,
-      colorScheme = "neutral",
       description,
       icon,
+      intent = "neutral",
       ...props
     },
     ref,
@@ -73,7 +73,7 @@ export const ListboxItemBase = forwardRef<HTMLDivElement, ListboxItemBaseProps>(
         aria-labelledby={labelId}
         asChild
         ref={ref}
-        {...styles.item({ colorScheme }, className)}
+        {...styles.item({ intent }, className)}
         {...props}
       >
         <Slot>

--- a/packages/react/src/spinner/Spinner.tsx
+++ b/packages/react/src/spinner/Spinner.tsx
@@ -7,22 +7,22 @@ import { Transition } from "../transition";
 type SpinnerProps = BoxProps<
   "div",
   {
-    colorScheme?: "default" | "inverse";
+    appearance?: "default" | "inverse";
     size?: "2xs" | "5xl" | "lg" | "md" | "sm" | "xl" | "xs";
   }
 >;
 
-const mapColorSchemeToBg = {
+const mapAppearanceToBg = {
   default: "spinner.bg.default",
   inverse: "spinner.bg.inverse",
 } as const;
-const mapColorSchemeToFg = {
+const mapAppearanceToFg = {
   default: "spinner.fg.default",
   inverse: "spinner.fg.inverse",
 } as const;
 
 export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(
-  ({ children, colorScheme = "default", size = "md", ...props }, ref) => {
+  ({ appearance = "default", children, size = "md", ...props }, ref) => {
     return (
       <Transition duration="sm">
         <Flex
@@ -41,7 +41,7 @@ export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(
               width={16}
               xmlns="http://www.w3.org/2000/svg"
             >
-              <Box asChild color={mapColorSchemeToBg[colorScheme]}>
+              <Box asChild color={mapAppearanceToBg[appearance]}>
                 <circle
                   cx="8"
                   cy="8"
@@ -51,7 +51,7 @@ export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(
                   strokeWidth="1.5"
                 />
               </Box>
-              <Box asChild color={mapColorSchemeToFg[colorScheme]}>
+              <Box asChild color={mapAppearanceToFg[appearance]}>
                 <path
                   d="M4.5 1.93782C5.45668 1.38549 6.53049 1.06741 7.63365 1.00959C8.73681 0.951779 9.83799 1.15587 10.8472 1.60518C11.8563 2.05449 12.7448 2.73627 13.44 3.59476C14.1352 4.45325 14.6174 5.46408 14.847 6.54462"
                   stroke="currentColor"

--- a/packages/react/src/toast-provider/ToastProvider.tsx
+++ b/packages/react/src/toast-provider/ToastProvider.tsx
@@ -88,7 +88,7 @@ export const ToastProvider = forwardRef<HTMLOListElement, ToastProps>(
               isValidElement<any>(toast) ? (
                 toast
               ) : (
-                <Toast colorScheme={toast.type} key={id}>
+                <Toast intent={toast.type} key={id}>
                   <ToastTitle>{toast.title}</ToastTitle>
                   {toast.action && (
                     <ToastAction

--- a/packages/react/src/toast/Toast.css.ts
+++ b/packages/react/src/toast/Toast.css.ts
@@ -114,7 +114,7 @@ export const root = recipe({
     }),
   ],
   variants: {
-    colorScheme: {
+    intent: {
       danger: style({
         vars: {
           [accentColorVar]: theme.colors["fg.error.light"],

--- a/packages/react/src/toast/Toast.tsx
+++ b/packages/react/src/toast/Toast.tsx
@@ -18,7 +18,7 @@ type ToastProps = BoxProps<
   NonNullable<styles.RootVariants>
 >;
 
-const iconMap = {
+const mapIntentToIcon = {
   danger: IconCircleExclamationFilled,
   information: IconCircleInfoFilled,
   neutral: IconCircleInfoFilled,
@@ -27,15 +27,12 @@ const iconMap = {
 };
 
 export const Toast = forwardRef<HTMLLIElement, ToastProps>(
-  (
-    { children, colorScheme = "neutral", onOpenChange, open, ...props },
-    ref,
-  ) => {
+  ({ children, intent = "neutral", onOpenChange, open, ...props }, ref) => {
     const { restProps, sprinkleProps } = extractSprinkles(props);
     const context = useToastContext("Toast");
 
     return (
-      <Box asChild {...styles.root({ colorScheme })} {...sprinkleProps}>
+      <Box asChild {...styles.root({ intent })} {...sprinkleProps}>
         <RadixToast.Root
           forceMount={!!context}
           onOpenChange={(open) => {
@@ -47,7 +44,7 @@ export const Toast = forwardRef<HTMLLIElement, ToastProps>(
           {...restProps}
         >
           <Icon asChild {...styles.icon()}>
-            {createElement(iconMap[colorScheme])}
+            {createElement(mapIntentToIcon[intent])}
           </Icon>
 
           {children}

--- a/packages/react/src/toast/Toast.tsx
+++ b/packages/react/src/toast/Toast.tsx
@@ -42,7 +42,7 @@ export const Toast = forwardRef<HTMLLIElement, ToastProps>(
             onOpenChange?.(open);
             context.onOpenChange(open);
           }}
-          open={context.open || open}
+          open={context.open ?? open}
           ref={ref}
           {...restProps}
         >


### PR DESCRIPTION
- `colorScheme` should be strictly for non-semantic colors - with the only use case being avatars right now
- `intent` should carry semantic information and can control a few more things than color in the component (like icons) and should be consistent across components
- `variant` will continue to control the visual style of the component without changing colors or intent (like solid/subtle on buttons) and should be consistent across components
- `appearance` can be a combination of `intent` and `variant` (such as button) or completely custom appearances like for `Link` or `Spinner` and don't have to have consistent values across components since they are component specific