### PR TITLE
fix textarea autosize in controlled usage

### DIFF
--- a/.changeset/gold-squids-sin.md
+++ b/.changeset/gold-squids-sin.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+fix textarea autosize in controlled usage

--- a/packages/react/src/textarea-autosize/TextareaAutosize.tsx
+++ b/packages/react/src/textarea-autosize/TextareaAutosize.tsx
@@ -1,5 +1,6 @@
 import { Slot } from "@radix-ui/react-slot";
-import { forwardRef, useState } from "react";
+import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import { forwardRef } from "react";
 
 import { Box, type BoxProps } from "../box";
 import { extractSprinkles } from "../sprinkles";
@@ -29,9 +30,10 @@ export const TextareaAutosize = forwardRef<
     const Comp = asChild ? Slot : "textarea";
     const { restProps, sprinkleProps } = extractSprinkles(props);
 
-    const [value, setValue] = useState(
-      props.value === undefined ? props.defaultValue : props.value,
-    );
+    const [value, setValue] = useControllableState({
+      defaultProp: props.defaultValue,
+      prop: props.value,
+    });
 
     return (
       <Box {...styles.wrapper({ maxRows, resize })}>


### PR DESCRIPTION
by using useControllableState hook to correctly access controlled/un-controlled values