### PR TITLE
support declarative shadow dom

### DIFF
--- a/.changeset/nine-dolls-lie.md
+++ b/.changeset/nine-dolls-lie.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/web-components": patch
+---
+
+support declarative shadow dom

--- a/packages/web-components/rollup.config.mjs
+++ b/packages/web-components/rollup.config.mjs
@@ -54,6 +54,21 @@ export default defineConfig([
         ],
       }),
       {
+        name: "axiom:theme-provider",
+        transform(code, id) {
+          if (
+            !(
+              code.includes(":root") &&
+              id.includes("packages/react/src/theme-provider")
+            )
+          ) {
+            return null;
+          }
+
+          return code.replace(":root", ":host");
+        },
+      },
+      {
         name: "radix-collection:document-querySelectorAll",
         transform(code, id) {
           if (

--- a/packages/web-components/src/register.ts
+++ b/packages/web-components/src/register.ts
@@ -15,7 +15,7 @@ import {
 import { createRoot } from "react-dom/client";
 
 import { mapping } from "./mapping";
-import { registerShadowRoot, unregisterShadowRoot } from "./styles";
+import { styleSheet } from "./styles";
 
 const CustomContextEvent = "__ax_context";
 const CustomMountEvent = "__ax_mount";
@@ -53,7 +53,7 @@ export function register<P extends object>(
         : element.attachShadow({ mode: "open" }),
     );
     if (element.shadowRoot) {
-      registerShadowRoot(element.shadowRoot);
+      element.shadowRoot.adoptedStyleSheets = [styleSheet];
     }
 
     const observer = new MutationObserver((mutationRecords) => {
@@ -162,9 +162,6 @@ export function register<P extends object>(
       observer.disconnect();
       vdom = null;
       root.unmount();
-      if (element.shadowRoot) {
-        unregisterShadowRoot(element.shadowRoot);
-      }
     };
 
     return { connectedCallback, disconnectedCallback };

--- a/packages/web-components/src/register.ts
+++ b/packages/web-components/src/register.ts
@@ -4,7 +4,6 @@
 
 import type { ReactElement } from "react";
 
-import { ThemeProvider } from "@optiaxiom/react";
 import {
   cloneElement,
   type ComponentType,
@@ -242,11 +241,7 @@ const withContextProvider = <P extends { context?: unknown }>(
 
     const props = Object.assign({}, rawProps);
     delete props.context;
-    return createElement(
-      ThemeProvider,
-      { selector: ":host" },
-      createElement<P>(Component, props),
-    );
+    return createElement<P>(Component, props);
   };
 };
 

--- a/packages/web-components/src/register.ts
+++ b/packages/web-components/src/register.ts
@@ -47,7 +47,11 @@ export function register<P extends object>(
   const withPreactElement = (element: HTMLElement) => {
     let vdom: null | ReactElement<object> = null;
 
-    const root = createRoot(element.attachShadow({ mode: "open" }));
+    const root = createRoot(
+      element.shadowRoot
+        ? createEmptyDiv(element.shadowRoot)
+        : element.attachShadow({ mode: "open" }),
+    );
     if (element.shadowRoot) {
       registerShadowRoot(element.shadowRoot);
     }
@@ -320,6 +324,13 @@ function toVdom<P>(
       : children,
   );
 }
+
+const createEmptyDiv = (parent: DocumentFragment) => {
+  const div = document.createElement("div");
+  div.style.display = "contents";
+  parent.insertBefore(div, parent.firstChild);
+  return div;
+};
 
 const toCamelCase = (str: string) =>
   str.startsWith("aria-") || str.startsWith("data-")

--- a/packages/web-components/src/styles.ts
+++ b/packages/web-components/src/styles.ts
@@ -1,13 +1,12 @@
-const shadowRoots = new Set<ShadowRoot>();
-const sheets: CSSStyleSheet[] = [];
-
-const sheet = new CSSStyleSheet();
-sheet.insertRule(`slot[name]::slotted(*) {
+const styles: string[] = [
+  `slot[name]::slotted(*) {
   display: inline-flex;
   height: 100%;
   width: 100%;
-}`);
-sheets.push(sheet);
+}`,
+];
+
+export const styleSheet = new CSSStyleSheet();
 
 const uuid = "ax" + crypto.getRandomValues(new Uint32Array(1))[0].toString(36);
 
@@ -30,22 +29,8 @@ export function injectGlobalStyle(text: string) {
 }
 
 export function injectLocalStyle(text: string) {
-  const sheet = new CSSStyleSheet();
-  void sheet.replace(
+  styles.push(
     text.replaceAll(/Fira Code Variable|InterVariable/g, (m) => `${uuid} ${m}`),
   );
-  sheets.push(sheet);
-
-  for (const shadowRoot of shadowRoots) {
-    shadowRoot.adoptedStyleSheets = sheets;
-  }
-}
-
-export function registerShadowRoot(shadowRoot: ShadowRoot) {
-  shadowRoots.add(shadowRoot);
-  shadowRoot.adoptedStyleSheets = sheets;
-}
-
-export function unregisterShadowRoot(shadowRoot: ShadowRoot) {
-  shadowRoots.delete(shadowRoot);
+  void styleSheet.replace(styles.join("\n"));
 }


### PR DESCRIPTION
resolves #507

now we can easily do things like:

```html
<ax-axiom-provider>
  <template shadowrootmode="open">
    <style>
      :host {
        --ax-colors-bg-default: #333;
      }
    </style>
  </template>
</ax-axiom-provider>
```

in order to override design tokens for a whole tree