### PR TITLE
fix indicator prop/ref forwarding 

### DIFF
--- a/.changeset/rich-lamps-retire.md
+++ b/.changeset/rich-lamps-retire.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+fix indicator prop/ref forwarding

--- a/packages/react/src/indicator/Indicator.css.ts
+++ b/packages/react/src/indicator/Indicator.css.ts
@@ -74,12 +74,13 @@ export const badge = recipe({
       },
       true: [
         {
-          px: "6",
+          px: "4",
+          py: "0",
         },
         style({
           selectors: {
             "&:not(:empty)": {
-              minWidth: "20px",
+              minWidth: "16px",
             },
           },
         }),

--- a/packages/react/src/indicator/Indicator.tsx
+++ b/packages/react/src/indicator/Indicator.tsx
@@ -1,4 +1,3 @@
-import { Slot } from "@radix-ui/react-slot";
 import { forwardRef, type ReactNode } from "react";
 
 import { Badge } from "../badge";
@@ -22,6 +21,7 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
     {
       asChild,
       children,
+      className,
       content,
       disabled,
       intent,
@@ -34,10 +34,8 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
     ref,
   ) => {
     return (
-      <Flex {...styles.indicator()}>
-        <Slot ref={ref} {...props}>
-          {children}
-        </Slot>
+      <Flex ref={ref} {...styles.indicator({}, className)} {...props}>
+        {children}
 
         {!disabled && (
           <Box {...styles.floating({ offset, position })}>


### PR DESCRIPTION
props from outer components should be applied on the indicator wrapper and if that breaks sizing then the child element should be manually modified to handle that. mostly needed for button icons for example:

```jsx
<Button
  icon={
    <Indicator>
      <IconSample h="full" w="auto" />
    </Indicator>
  }
>
  Display
</Button>
```