### PR TITLE
inline auto-id package

### DIFF
--- a/.changeset/fuzzy-cows-sip.md
+++ b/.changeset/fuzzy-cows-sip.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+inline packages with peer dependency mismatch

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,6 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@mantine/hooks": "^7.14.3",
     "@optiaxiom/globals": "workspace:^",
     "@radix-ui/react-alert-dialog": "^1.1.2",
     "@radix-ui/react-arrow": "^1.1.0",
@@ -63,7 +62,6 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@radix-ui/react-use-controllable-state": "^1.1.0",
     "@radix-ui/react-visually-hidden": "^1.1.0",
-    "@reach/auto-id": "^0.18.0",
     "@vanilla-extract/dynamic": "^2.1.2",
     "clsx": "^2.1.1",
     "downshift": "^9.0.8",
@@ -72,7 +70,9 @@
   },
   "devDependencies": {
     "@emotion/hash": "^0.9.2",
+    "@mantine/hooks": "^7.14.3",
     "@optiaxiom/shared": "workspace:^",
+    "@reach/auto-id": "^0.18.0",
     "@types/node": "^20.17.9",
     "@types/use-sync-external-store": "^0.0.6",
     "@vanilla-extract/css": "^1.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,9 +248,6 @@ importers:
 
   packages/react:
     dependencies:
-      '@mantine/hooks':
-        specifier: ^7.14.3
-        version: 7.14.3(react@18.3.1)
       '@optiaxiom/globals':
         specifier: workspace:^
         version: link:../globals
@@ -335,9 +332,6 @@ importers:
       '@radix-ui/react-visually-hidden':
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@18.3.2)(@types/react@18.3.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reach/auto-id':
-        specifier: ^0.18.0
-        version: 0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-table':
         specifier: ^8.0.0
         version: 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -369,9 +363,15 @@ importers:
       '@emotion/hash':
         specifier: ^0.9.2
         version: 0.9.2
+      '@mantine/hooks':
+        specifier: ^7.14.3
+        version: 7.14.3(react@18.3.1)
       '@optiaxiom/shared':
         specifier: workspace:^
         version: link:../shared
+      '@reach/auto-id':
+        specifier: ^0.18.0
+        version: 0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: ^20.17.9
         version: 20.17.9


### PR DESCRIPTION
to prevent react version mismatch warnings:
- @mantine/hooks has peer dependency on react v18 and above only
- @reach/auto-id has peer dependency on react v17 and lower only
    
but our package supports react versions from 16 thru 19 (except for `react-remove-scroll` which has peer deps for v18 and lower only)