### PR TITLE
massively improve localdev performance

### DIFF
--- a/apps/storybook/.storybook/react-docgen-plugin.ts
+++ b/apps/storybook/.storybook/react-docgen-plugin.ts
@@ -3,6 +3,7 @@ import { getDocs } from "@optiaxiom/shared";
 import { createFilter } from "@rollup/pluginutils";
 import { basename, relative } from "node:path";
 import { ERROR_CODES, parse } from "react-docgen";
+import { displayNameHandler } from "react-docgen/dist/handlers";
 
 export function reactDocgenPlugin() {
   const docs = getDocs();
@@ -20,7 +21,9 @@ export function reactDocgenPlugin() {
       }
 
       try {
-        const docgenResults = parse(code);
+        const docgenResults = parse(code, {
+          handlers: [displayNameHandler],
+        });
         if (!docgenResults.length) {
           return;
         }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "pnpm": {
     "patchedDependencies": {
       "@vanilla-extract/sprinkles": "patches/@vanilla-extract__sprinkles.patch",
+      "react-docgen": "patches/react-docgen.patch",
       "react-docgen-typescript": "patches/react-docgen-typescript.patch"
     }
   }

--- a/packages/globals/rollup.config.mjs
+++ b/packages/globals/rollup.config.mjs
@@ -29,7 +29,7 @@ export default defineConfig([
           : "[name].js";
       },
       format: "es",
-      preserveModules: true,
+      preserveModules: env === "production",
     },
     plugins: [
       esbuild({

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -47,7 +47,7 @@ export default defineConfig([
           : "[name].js";
       },
       format: "es",
-      preserveModules: true,
+      preserveModules: env === "production",
     },
     plugins: [
       {

--- a/patches/react-docgen.patch
+++ b/patches/react-docgen.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/config.js b/dist/config.js
+index 030cba7351b1c2d0ac6d2d6d7f53309464b1afe0..a6fea93421aa566d40aa9ccf26f498c8a8fb7fba 100644
+--- a/dist/config.js
++++ b/dist/config.js
+@@ -2,9 +2,7 @@ import { childContextTypeHandler, codeTypeHandler, componentDocblockHandler, com
+ import { fsImporter } from './importer/index.js';
+ import { ChainResolver, FindAnnotatedDefinitionsResolver, FindExportedDefinitionsResolver, } from './resolver/index.js';
+ const defaultResolvers = [
+-    new FindExportedDefinitionsResolver({
+-        limit: 1,
+-    }),
++    new FindExportedDefinitionsResolver(),
+     new FindAnnotatedDefinitionsResolver(),
+ ];
+ const defaultResolver = new ChainResolver(defaultResolvers, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   '@vanilla-extract/sprinkles':
     hash: eh2tyazhmaumpwivglvpekok3e
     path: patches/@vanilla-extract__sprinkles.patch
+  react-docgen:
+    hash: jrenouyb6tsithaog3fiiutev4
+    path: patches/react-docgen.patch
   react-docgen-typescript:
     hash: 2ld3tc3apzxpaqkeup6dsrfezi
     path: patches/react-docgen-typescript.patch
@@ -225,7 +228,7 @@ importers:
         version: 4.0.2(webpack@5.93.0(esbuild@0.24.2))
       react-docgen:
         specifier: ^7.1.0
-        version: 7.1.0
+        version: 7.1.0(patch_hash=jrenouyb6tsithaog3fiiutev4)
       storybook:
         specifier: ^8.4.7
         version: 8.4.7(prettier@3.4.2)
@@ -9365,7 +9368,7 @@ snapshots:
       find-up: 5.0.0
       magic-string: 0.30.17
       react: 18.3.1
-      react-docgen: 7.1.0
+      react-docgen: 7.1.0(patch_hash=jrenouyb6tsithaog3fiiutev4)
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.10
       storybook: 8.4.7(prettier@3.4.2)
@@ -14044,7 +14047,7 @@ snapshots:
     dependencies:
       typescript: 5.7.2
 
-  react-docgen@7.1.0:
+  react-docgen@7.1.0(patch_hash=jrenouyb6tsithaog3fiiutev4):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/traverse': 7.26.4


### PR DESCRIPTION
right now rollup outputs separate modules/files for each file so we can support tree shaking for end users

but for localdev we can just generate single bundles and that way storybook and nextjs can get massive performance improvements since they have to watch fewer modules/files for changes and re-builds