### PR TITLE
ensure hover rules always wrapped in media query

### DIFF
--- a/.changeset/new-islands-change.md
+++ b/.changeset/new-islands-change.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+bring back disclosure show/hide animation

--- a/apps/docs/demos/alert-dialog/confirmation-usage/App.tsx
+++ b/apps/docs/demos/alert-dialog/confirmation-usage/App.tsx
@@ -30,7 +30,7 @@ export function App() {
         <AlertDialogTrigger>Delete comment</AlertDialogTrigger>
 
         <AlertDialogContent>
-          <AlertDialogHeader>Delete comment and replies?</AlertDialogHeader>
+          <AlertDialogHeader>Delete comment?</AlertDialogHeader>
 
           <AlertDialogBody>
             The comment and all replies will be deleted.

--- a/apps/docs/demos/alert-dialog/controlled-usage/App.tsx
+++ b/apps/docs/demos/alert-dialog/controlled-usage/App.tsx
@@ -18,7 +18,7 @@ export function App() {
       <AlertDialogTrigger>Delete comment</AlertDialogTrigger>
 
       <AlertDialogContent>
-        <AlertDialogHeader>Delete comment and replies?</AlertDialogHeader>
+        <AlertDialogHeader>Delete comment?</AlertDialogHeader>
 
         <AlertDialogBody>
           The comment and all replies will be deleted.

--- a/apps/docs/demos/alert-dialog/usage/App.tsx
+++ b/apps/docs/demos/alert-dialog/usage/App.tsx
@@ -15,7 +15,7 @@ export function App() {
       <AlertDialogTrigger>Delete comment</AlertDialogTrigger>
 
       <AlertDialogContent>
-        <AlertDialogHeader>Delete comment and replies?</AlertDialogHeader>
+        <AlertDialogHeader>Delete comment?</AlertDialogHeader>
 
         <AlertDialogBody>
           The comment and all replies will be deleted.

--- a/apps/docs/pages/globals.css
+++ b/apps/docs/pages/globals.css
@@ -264,7 +264,7 @@ body:before {
     border-color: var(--ax-colors-border-tertiary);
     border-radius: var(--ax-borderRadius-md);
     border-width: 1px;
-    flex: 1;
+    flex-basis: 50%;
     flex-wrap: wrap;
     gap: 0 0.5rem;
     margin: 0;
@@ -278,7 +278,7 @@ body:before {
       width: 100%;
     }
 
-    &:first-child {
+    &:not(.ltr\:_text-right) {
       div {
         justify-content: start;
       }
@@ -289,8 +289,9 @@ body:before {
       }
     }
 
-    &:last-child {
+    &.ltr\:_text-right {
       justify-content: end;
+      margin-left: auto;
 
       & div {
         flex-direction: row-reverse;

--- a/apps/storybook/src/components/Disclosure.stories.tsx
+++ b/apps/storybook/src/components/Disclosure.stories.tsx
@@ -63,3 +63,9 @@ export const Controlled: Story = {
     );
   },
 };
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/packages/react/src/alert-dialog-action/AlertDialogAction.tsx
+++ b/packages/react/src/alert-dialog-action/AlertDialogAction.tsx
@@ -8,12 +8,23 @@ type AlertDialogActionProps = ButtonProps<typeof RadixAlertDialog.Action>;
 export const AlertDialogAction = forwardRef<
   HTMLButtonElement,
   AlertDialogActionProps
->(({ appearance = "danger", asChild, children, ...props }, ref) => {
-  return (
-    <RadixAlertDialog.Action asChild ref={ref} {...props}>
-      {asChild ? children : <Button appearance={appearance}>{children}</Button>}
-    </RadixAlertDialog.Action>
-  );
-});
+>(
+  (
+    { appearance = "danger", asChild, children, size = "lg", ...props },
+    ref,
+  ) => {
+    return (
+      <RadixAlertDialog.Action asChild ref={ref} {...props}>
+        {asChild ? (
+          children
+        ) : (
+          <Button appearance={appearance} size={size}>
+            {children}
+          </Button>
+        )}
+      </RadixAlertDialog.Action>
+    );
+  },
+);
 
 AlertDialogAction.displayName = "@optiaxiom/react/AlertDialogAction";

--- a/packages/react/src/alert-dialog-cancel/AlertDialogCancel.tsx
+++ b/packages/react/src/alert-dialog-cancel/AlertDialogCancel.tsx
@@ -8,12 +8,29 @@ type AlertDialogCancelProps = ButtonProps<typeof RadixAlertDialog.Cancel>;
 export const AlertDialogCancel = forwardRef<
   HTMLButtonElement,
   AlertDialogCancelProps
->(({ appearance = "subtle", asChild, children = "Cancel", ...props }, ref) => {
-  return (
-    <RadixAlertDialog.Cancel asChild ref={ref} {...props}>
-      {asChild ? children : <Button appearance={appearance}>{children}</Button>}
-    </RadixAlertDialog.Cancel>
-  );
-});
+>(
+  (
+    {
+      appearance = "subtle",
+      asChild,
+      children = "Cancel",
+      size = "lg",
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <RadixAlertDialog.Cancel asChild ref={ref} {...props}>
+        {asChild ? (
+          children
+        ) : (
+          <Button appearance={appearance} size={size}>
+            {children}
+          </Button>
+        )}
+      </RadixAlertDialog.Cancel>
+    );
+  },
+);
 
 AlertDialogCancel.displayName = "@optiaxiom/react/AlertDialogCancel";

--- a/packages/react/src/breadcrumb-link/BreadcrumbLink.css.ts
+++ b/packages/react/src/breadcrumb-link/BreadcrumbLink.css.ts
@@ -14,10 +14,17 @@ export const link = recipe({
     style({
       color: theme.colors["fg.tertiary"],
 
-      selectors: {
-        "&:hover:not([data-disabled])": {
-          color: theme.colors["fg.secondary"],
+      "@media": {
+        "(hover: hover)": {
+          selectors: {
+            "&:hover:not([data-disabled])": {
+              color: theme.colors["fg.secondary"],
+            },
+          },
         },
+      },
+
+      selectors: {
         "&:visited": {
           color: theme.colors["fg.tertiary"],
         },

--- a/packages/react/src/button-base/ButtonBase.css.ts
+++ b/packages/react/src/button-base/ButtonBase.css.ts
@@ -120,6 +120,21 @@ export const buttonBase = recipe({
         color: fallbackVar(textColorVar, accentColorVar),
         paddingInline: `calc(${paddingInlineVar} - 1px)`,
 
+        "@media": {
+          "(hover: hover)": {
+            selectors: {
+              '&:hover:not(:active, [data-disabled], [data-loading], [data-state="active"], [data-state="on"])':
+                {
+                  backgroundColor: subtleHoverAccentColorVar,
+                  borderColor: fallbackVar(
+                    subtleHoverOutlineColorVar,
+                    hoverAccentColorVar,
+                  ),
+                },
+            },
+          },
+        },
+
         selectors: {
           '&:active:not([data-disabled], [data-loading], [data-state="active"], [data-state="on"])':
             {
@@ -129,14 +144,7 @@ export const buttonBase = recipe({
                 hoverAccentColorVar,
               ),
             },
-          '&:hover:not(:active, [data-disabled], [data-loading], [data-state="active"], [data-state="on"])':
-            {
-              backgroundColor: subtleHoverAccentColorVar,
-              borderColor: fallbackVar(
-                subtleHoverOutlineColorVar,
-                hoverAccentColorVar,
-              ),
-            },
+
           '&:is([data-state="active"], [data-state="on"])': {
             backgroundColor: theme.colors["bg.accent.subtle"],
             borderColor: theme.colors["fg.accent"],
@@ -152,13 +160,21 @@ export const buttonBase = recipe({
         backgroundColor: accentColorVar,
         color: fallbackVar(solidTextColorVar, theme.colors["fg.white"]),
 
+        "@media": {
+          "(hover: hover)": {
+            selectors: {
+              "&:hover:not(:active, [data-disabled], [data-loading])": {
+                backgroundColor: hoverAccentColorVar,
+              },
+            },
+          },
+        },
+
         selectors: {
           "&:active:not([data-disabled], [data-loading])": {
             backgroundColor: pressedAccentColorVar,
           },
-          "&:hover:not(:active, [data-disabled], [data-loading])": {
-            backgroundColor: hoverAccentColorVar,
-          },
+
           "&[data-disabled]:not([data-loading])": {
             backgroundColor: theme.colors["bg.secondary"],
             border: `1px solid ${theme.colors["border.disabled"]}`,
@@ -172,6 +188,20 @@ export const buttonBase = recipe({
         borderColor: accentColorVar,
         color: fallbackVar(textColorVar, accentColorVar),
 
+        "@media": {
+          "(hover: hover)": {
+            selectors: {
+              '&:hover:not(:active, [data-disabled], [data-loading], [data-state="active"], [data-state="on"])':
+                {
+                  backgroundColor: fallbackVar(
+                    transparentHoverAccentColorVar,
+                    subtleHoverAccentColorVar,
+                  ),
+                },
+            },
+          },
+        },
+
         selectors: {
           '&:active:not([data-disabled], [data-loading], [data-state="active"], [data-state="on"])':
             {
@@ -180,13 +210,7 @@ export const buttonBase = recipe({
                 subtlePressedAccentColorVar,
               ),
             },
-          '&:hover:not(:active, [data-disabled], [data-loading], [data-state="active"], [data-state="on"])':
-            {
-              backgroundColor: fallbackVar(
-                transparentHoverAccentColorVar,
-                subtleHoverAccentColorVar,
-              ),
-            },
+
           '&:is([data-state="active"], [data-state="on"])': {
             backgroundColor: theme.colors["bg.accent.subtle"],
             color: theme.colors["fg.accent"],

--- a/packages/react/src/data-table-header-cell/DataTableHeaderCell.css.ts
+++ b/packages/react/src/data-table-header-cell/DataTableHeaderCell.css.ts
@@ -21,6 +21,16 @@ export const button = recipe({
       textDecoration: "none",
       userSelect: "none",
 
+      "@media": {
+        "(hover: hover)": {
+          selectors: {
+            "&:hover": {
+              color: theme.colors["fg.secondary"],
+            },
+          },
+        },
+      },
+
       selectors: {
         "&::after": {
           content: "",
@@ -35,9 +45,6 @@ export const button = recipe({
           borderRadius: theme.borderRadius.md,
           outline: `2px solid ${theme.colors["border.focus"]}`,
           outlineOffset: "-2px",
-        },
-        "&:hover": {
-          color: theme.colors["fg.secondary"],
         },
       },
     }),
@@ -70,9 +77,13 @@ export const icon = recipe({
       true: style({
         opacity: "0",
 
-        selectors: {
-          [`${marker}:is(:focus-visible, :hover) &`]: {
-            opacity: "1",
+        "@media": {
+          "(hover: hover)": {
+            selectors: {
+              [`${marker}:is(:focus-visible, :hover) &`]: {
+                opacity: "1",
+              },
+            },
           },
         },
       }),

--- a/packages/react/src/data-table/DataTable.css.ts
+++ b/packages/react/src/data-table/DataTable.css.ts
@@ -139,14 +139,18 @@ export const cell = recipe({
       body: style({
         backgroundColor: theme.colors["bg.default"],
 
-        selectors: {
-          [`${row}:hover &`]: {
-            backgroundImage: `
-              linear-gradient(
-                ${theme.colors["bg.default.hovered"]},
-                ${theme.colors["bg.default.hovered"]}
-              )
-            `,
+        "@media": {
+          "(hover: hover)": {
+            selectors: {
+              [`${row}:hover &`]: {
+                backgroundImage: `
+                  linear-gradient(
+                    ${theme.colors["bg.default.hovered"]},
+                    ${theme.colors["bg.default.hovered"]}
+                  )
+                `,
+              },
+            },
           },
         },
       }),

--- a/packages/react/src/dialog-close/DialogClose.tsx
+++ b/packages/react/src/dialog-close/DialogClose.tsx
@@ -6,10 +6,10 @@ import { Button, type ButtonProps } from "../button";
 type DialogCloseProps = ButtonProps<typeof RadixDialog.Close>;
 
 export const DialogClose = forwardRef<HTMLButtonElement, DialogCloseProps>(
-  ({ asChild, children, ...props }, ref) => {
+  ({ asChild, children, size = "lg", ...props }, ref) => {
     return (
       <RadixDialog.Close asChild ref={ref} {...props}>
-        {asChild ? children : <Button>{children}</Button>}
+        {asChild ? children : <Button size={size}>{children}</Button>}
       </RadixDialog.Close>
     );
   },

--- a/packages/react/src/disclosure-content/DisclosureContent.css.ts
+++ b/packages/react/src/disclosure-content/DisclosureContent.css.ts
@@ -1,0 +1,40 @@
+import { keyframes, recipe, style } from "../vanilla-extract";
+
+const slideDown = keyframes({
+  from: {
+    height: 0,
+    opacity: 0,
+    overflowY: "hidden",
+  },
+  to: {
+    height: "var(--radix-collapsible-content-height)",
+    overflowY: "hidden",
+  },
+});
+
+const slideUp = keyframes({
+  from: {
+    height: "var(--radix-collapsible-content-height)",
+    overflowY: "hidden",
+  },
+  to: {
+    height: 0,
+    opacity: 0,
+    overflowY: "hidden",
+  },
+});
+
+export const content = recipe({
+  base: [
+    style({
+      selectors: {
+        '&[data-state="closed"]': {
+          animation: `${slideUp} 300ms ease`,
+        },
+        '&[data-state="open"]': {
+          animation: `${slideDown} 300ms ease`,
+        },
+      },
+    }),
+  ],
+});

--- a/packages/react/src/disclosure-content/DisclosureContent.tsx
+++ b/packages/react/src/disclosure-content/DisclosureContent.tsx
@@ -3,17 +3,18 @@ import { forwardRef } from "react";
 
 import { Box, type BoxProps } from "../box";
 import { useDisclosureContext } from "../disclosure-context";
+import * as styles from "./DisclosureContent.css";
 
 type DisclosureContentProps = BoxProps<typeof RadixCollapsible.Content>;
 
 export const DisclosureContent = forwardRef<
   HTMLDivElement,
   DisclosureContentProps
->(({ children, ...props }, ref) => {
+>(({ children, className, ...props }, ref) => {
   useDisclosureContext("DisclosureContent");
 
   return (
-    <Box asChild ref={ref} {...props}>
+    <Box asChild ref={ref} {...styles.content({}, className)} {...props}>
       <RadixCollapsible.Content>
         <Box color="fg.default" fontSize="md" p="8" pt="0">
           {children}

--- a/packages/react/src/disclosure-trigger/DisclosureTrigger.css.ts
+++ b/packages/react/src/disclosure-trigger/DisclosureTrigger.css.ts
@@ -18,13 +18,20 @@ export const trigger = recipe({
     style({
       color: theme.colors["fg.default"],
 
+      "@media": {
+        "(hover: hover)": {
+          selectors: {
+            "&:is([data-disabled], :hover)": {
+              color: theme.colors["fg.secondary"],
+            },
+          },
+        },
+      },
+
       selectors: {
         "&:focus-visible": {
           outline: `2px solid ${theme.colors["border.focus"]}`,
           outlineOffset: "1px",
-        },
-        "&:is([data-disabled], :hover)": {
-          color: theme.colors["fg.secondary"],
         },
       },
     }),

--- a/packages/react/src/input-root/InputRoot.css.ts
+++ b/packages/react/src/input-root/InputRoot.css.ts
@@ -20,6 +20,16 @@ export const root = recipe({
       color: theme.colors["fg.default"],
       position: "relative",
 
+      "@media": {
+        "(hover: hover)": {
+          selectors: {
+            "&:hover": {
+              borderColor: theme.colors["border.active"],
+            },
+          },
+        },
+      },
+
       selectors: {
         [`&:has(${marker}:focus)`]: {
           zIndex: "10",
@@ -36,9 +46,6 @@ export const root = recipe({
           borderColor: theme.colors["border.accent"],
         },
 
-        "&:hover": {
-          borderColor: theme.colors["border.active"],
-        },
         [`&:has(${marker}:is([data-invalid]))`]: {
           borderColor: theme.colors["border.error"],
         },

--- a/packages/react/src/link/Link.css.ts
+++ b/packages/react/src/link/Link.css.ts
@@ -8,13 +8,20 @@ export const link = recipe({
     style({
       textDecoration: "none",
 
+      "@media": {
+        "(hover: hover)": {
+          selectors: {
+            "&:hover:not([data-disabled])": {
+              textDecoration: "underline",
+            },
+          },
+        },
+      },
+
       selectors: {
         "&:focus-visible": {
           outline: `2px auto ${theme.colors["border.focus"]}`,
           outlineOffset: "1px",
-        },
-        "&:hover:not([data-disabled])": {
-          textDecoration: "underline",
         },
         "&:visited": {
           color: theme.colors["fg.link.visited"],
@@ -33,9 +40,13 @@ export const link = recipe({
       default: style({
         color: theme.colors["fg.link.default"],
 
-        selectors: {
-          "&:hover:not([data-disabled])": {
-            color: theme.colors["fg.link.default.hovered"],
+        "@media": {
+          "(hover: hover)": {
+            selectors: {
+              "&:hover:not([data-disabled])": {
+                color: theme.colors["fg.link.default.hovered"],
+              },
+            },
           },
         },
       }),

--- a/packages/react/src/switch/Switch.css.ts
+++ b/packages/react/src/switch/Switch.css.ts
@@ -19,10 +19,14 @@ export const container = recipe({
         [styles.controlColorVar]: theme.colors["bg.tertiary"],
       },
 
-      selectors: {
-        [`&:has(${inputMarker}:not(:disabled):not(:checked)):hover`]: {
-          vars: {
-            [styles.controlColorVar]: theme.colors["bg.tertiary.hovered"],
+      "@media": {
+        "(hover: hover)": {
+          selectors: {
+            [`&:has(${inputMarker}:not(:disabled):not(:checked)):hover`]: {
+              vars: {
+                [styles.controlColorVar]: theme.colors["bg.tertiary.hovered"],
+              },
+            },
           },
         },
       },

--- a/packages/react/src/table-row/TableRow.css.ts
+++ b/packages/react/src/table-row/TableRow.css.ts
@@ -12,9 +12,13 @@ export const row = recipe({
       w: "full",
     },
     style({
-      selectors: {
-        "&:hover": {
-          backgroundColor: theme.colors["bg.default.hovered"],
+      "@media": {
+        "(hover: hover)": {
+          selectors: {
+            "&:hover": {
+              backgroundColor: theme.colors["bg.default.hovered"],
+            },
+          },
         },
       },
     }),

--- a/packages/react/src/tabs-trigger/TabsTrigger.css.ts
+++ b/packages/react/src/tabs-trigger/TabsTrigger.css.ts
@@ -12,6 +12,7 @@ export const trigger = recipe({
       fontSize: "md",
       fontWeight: "500",
       py: "4",
+      transition: "colors",
     },
     style({
       borderColor: `transparent`,

--- a/packages/react/src/tabs-trigger/TabsTrigger.css.ts
+++ b/packages/react/src/tabs-trigger/TabsTrigger.css.ts
@@ -18,14 +18,21 @@ export const trigger = recipe({
       color: theme.colors["fg.tertiary"],
       userSelect: "none",
 
+      "@media": {
+        "(hover: hover)": {
+          selectors: {
+            '&:hover:not([data-state="active"])': {
+              borderColor: theme.colors["border.default"],
+              color: theme.colors["fg.secondary"],
+            },
+          },
+        },
+      },
+
       selectors: {
         "&:focus-visible": {
           outline: `2px solid ${theme.colors["border.focus"]}`,
           outlineOffset: "1px",
-        },
-        '&:hover:not([data-state="active"])': {
-          borderColor: theme.colors["border.default"],
-          color: theme.colors["fg.secondary"],
         },
         "&[data-disabled]": {
           color: theme.colors["fg.disabled"],

--- a/packages/react/src/toggle-input/ToggleInput.css.ts
+++ b/packages/react/src/toggle-input/ToggleInput.css.ts
@@ -25,18 +25,24 @@ export const toggleInput = recipe({
       color: theme.colors["fg.default"],
       position: "relative",
 
-      selectors: {
-        [`&:has(${input}:not(:disabled):checked):hover`]: {
-          vars: {
-            [controlColorVar]: theme.colors["bg.accent.hovered"],
+      "@media": {
+        "(hover: hover)": {
+          selectors: {
+            [`&:has(${input}:not(:disabled):checked):hover`]: {
+              vars: {
+                [controlColorVar]: theme.colors["bg.accent.hovered"],
+              },
+            },
+            [`&:has(${input}:not(:disabled):not(:checked)):hover`]: {
+              vars: {
+                [controlColorVar]: theme.colors["border.active.hovered"],
+              },
+            },
           },
         },
-        [`&:has(${input}:not(:disabled):not(:checked)):hover`]: {
-          vars: {
-            [controlColorVar]: theme.colors["border.active.hovered"],
-          },
-        },
+      },
 
+      selectors: {
         [`&:has(${input}:checked)`]: {
           vars: {
             [controlColorVar]: theme.colors["bg.accent"],

--- a/packages/shared/.eslintplugin/prefer-hover-media.js
+++ b/packages/shared/.eslintplugin/prefer-hover-media.js
@@ -1,0 +1,132 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+export default ESLintUtils.RuleCreator.withoutDocs({
+  create(context) {
+    return {
+      /**
+       * @type {import('@typescript-eslint/utils').TSESLint.RuleListener['Property']}
+       */
+      'CallExpression:matches([callee.name="recipe"], [callee.name="style"]) ObjectExpression > Property':
+        (node) => {
+          const key = node.key;
+          const raw =
+            key.type === "Literal"
+              ? [key.raw]
+              : key.type === "TemplateLiteral"
+                ? key.quasis.map((quasi) => quasi.value.raw)
+                : [];
+          if (
+            raw.every(
+              (raw) =>
+                !(raw.includes(":hover") && !raw.includes(":not(:hover)")),
+            )
+          ) {
+            return;
+          }
+
+          let rule = node.parent.parent;
+          while (
+            !(
+              rule.type === "ObjectExpression" &&
+              rule.parent.type === "CallExpression"
+            )
+          ) {
+            if (rule.parent) {
+              rule = rule.parent;
+            } else {
+              return;
+            }
+          }
+
+          const selectors = key.parent.parent?.parent;
+          if (selectors?.parent?.type !== "ObjectExpression") {
+            return;
+          }
+
+          const parent = selectors?.parent?.parent;
+          if (
+            parent?.type === "Property" &&
+            parent.key.type === "Literal" &&
+            parent.key.value === "(hover: hover)"
+          ) {
+            return;
+          }
+
+          const media = rule.properties.find(
+            (prop) =>
+              prop.type === "Property" &&
+              prop.key.type === "Literal" &&
+              prop.key.value === "@media",
+          );
+          const mediaToken =
+            media?.type === "Property" &&
+            context.sourceCode.getFirstToken(media.value);
+          const hover =
+            (media?.type === "Property" &&
+              media.value.type === "ObjectExpression" &&
+              media.value.properties.find(
+                (prop) =>
+                  prop.type === "Property" &&
+                  prop.key.type === "Literal" &&
+                  prop.key.value === "(hover: hover)",
+              )) ||
+            undefined;
+          const hoverToken =
+            hover?.type === "Property" &&
+            context.sourceCode.getFirstToken(hover.value);
+          const hoverSelectors =
+            (hover?.type === "Property" &&
+              hover.value.type === "ObjectExpression" &&
+              hover.value.properties.find(
+                (prop) =>
+                  prop.type === "Property" &&
+                  prop.key.type === "Identifier" &&
+                  prop.key.name === "selectors",
+              )) ||
+            undefined;
+          const hoverSelectorsToken =
+            hoverSelectors?.type === "Property" &&
+            context.sourceCode.getFirstToken(hoverSelectors.value);
+
+          const block = context.sourceCode.getText(node, 0, 1);
+          context.report({
+            fix: (fixer) => [
+              hoverSelectorsToken
+                ? fixer.insertTextAfter(hoverSelectorsToken, block)
+                : hoverToken
+                  ? fixer.insertTextAfter(
+                      hoverToken,
+                      `selectors: { ${block} },`,
+                    )
+                  : mediaToken
+                    ? fixer.insertTextAfter(
+                        mediaToken,
+                        `"(hover: hover)": { selectors: { ${block} } },`,
+                      )
+                    : fixer.insertTextBefore(
+                        selectors,
+                        `"@media": {"(hover: hover)": { selectors: { ${block} } }},\n\n`,
+                      ),
+              ...context.sourceCode
+                .getTokens(node, 0, 1)
+                .map((token) => fixer.remove(token)),
+            ],
+            messageId: "media",
+            node: key,
+          });
+        },
+    };
+  },
+
+  defaultOptions: [],
+
+  meta: {
+    fixable: "code",
+    messages: {
+      media:
+        "Please place `:hover` selectors inside `@media (hover: hover)` blocks.",
+    },
+    schema: [],
+    type: "suggestion",
+  },
+});

--- a/packages/shared/configs/eslint.config.base.js
+++ b/packages/shared/configs/eslint.config.base.js
@@ -93,6 +93,7 @@ export default tsEslint.config(
       "local/no-aria-selectors": "error",
       "local/no-global-styles": "error",
       "local/no-sprinkles-style-conflict": "error",
+      "local/prefer-hover-media": "error",
       "local/prefer-recipe-export": "error",
       "local/sprinkle-const-array": "error",
       "local/sprinkle-string-type": "error",


### PR DESCRIPTION
using eslint rule we enforce wrapping selectors using `:hover` with a hover media query:

```css
@media (hover: hover) {
  /* rule goes here */
}
```