### PR TITLE
fix excluding size prop from combobox content

### DIFF
--- a/.changeset/wild-phones-occur.md
+++ b/.changeset/wild-phones-occur.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+fix excluding size prop from combobox content

--- a/packages/react/src/combobox-content/ComboboxContent.tsx
+++ b/packages/react/src/combobox-content/ComboboxContent.tsx
@@ -3,7 +3,6 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 import type { ComboboxDialogContent } from "../combobox-dialog-content";
 import type { ComboboxPopoverContent } from "../combobox-popover-content";
-import type { ExcludeProps } from "../utils";
 
 import { useComboboxContext } from "../combobox-context";
 import { Command } from "../command";
@@ -11,12 +10,9 @@ import { CommandListbox } from "../command-listbox";
 import { useFieldContext } from "../field-context";
 import { useResponsiveMatches } from "../use-responsive-matches";
 
-type ComboboxContentProps = ExcludeProps<
-  ComponentPropsWithoutRef<
-    typeof ComboboxDialogContent | typeof ComboboxPopoverContent
-  >,
-  "size"
->;
+type ComboboxContentProps =
+  | ComponentPropsWithoutRef<typeof ComboboxDialogContent>
+  | ComponentPropsWithoutRef<typeof ComboboxPopoverContent>;
 
 export const ComboboxContent = forwardRef<HTMLDivElement, ComboboxContentProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/combobox-dialog-content/ComboboxDialogContent.tsx
+++ b/packages/react/src/combobox-dialog-content/ComboboxDialogContent.tsx
@@ -2,14 +2,16 @@ import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 import type { MenuListbox } from "../menu-listbox";
+import type { ExcludeProps } from "../utils";
 
 import { DialogContent } from "../dialog-content";
 import { DialogTitle } from "../dialog-title";
 
-type ComboboxDialogContentProps = ComponentPropsWithoutRef<
-  typeof DialogContent
-> &
-  Pick<ComponentPropsWithoutRef<typeof MenuListbox>, "maxH" | "minW">;
+type ComboboxDialogContentProps = ExcludeProps<
+  ComponentPropsWithoutRef<typeof DialogContent> &
+    Pick<ComponentPropsWithoutRef<typeof MenuListbox>, "maxH" | "minW">,
+  "size"
+>;
 
 export const ComboboxDialogContent = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/combobox-popover-content/ComboboxPopoverContent.tsx
+++ b/packages/react/src/combobox-popover-content/ComboboxPopoverContent.tsx
@@ -1,9 +1,12 @@
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
+import type { ExcludeProps } from "../utils";
+
 import { PopoverContent } from "../popover-content";
 
-type ComboboxPopoverContentProps = ComponentPropsWithoutRef<
-  typeof PopoverContent
+type ComboboxPopoverContentProps = ExcludeProps<
+  ComponentPropsWithoutRef<typeof PopoverContent>,
+  "size"
 >;
 
 export const ComboboxPopoverContent = forwardRef<


### PR DESCRIPTION
excluding from the union (which we're doing right now) causes issues for props that only belong on PopoverContent but do not on DialogContent (such as `align` and `side`). so we apply the exclude on the individual components before doing the union.