### PR TITLE
only suppress ref error

### DIFF
--- a/packages/react/src/select-content/SelectContent.tsx
+++ b/packages/react/src/select-content/SelectContent.tsx
@@ -60,7 +60,10 @@ export const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>(
               provider="popper"
               {...styles.content({}, className)}
               {...boxProps}
-              {...(placed && downshift.getMenuProps({ ref, ...restProps }))}
+              {...downshift.getMenuProps(
+                { ref, ...restProps },
+                { suppressRefError: !placed },
+              )}
             >
               <PopperContent
                 align={align}


### PR DESCRIPTION
rather than not applying the ref or other props at all - otherwise some event listeners do not work - for example cannot select items on touch devices