### PR TITLE
fix setting href when using asChild

### DIFF
--- a/.changeset/lemon-books-exist.md
+++ b/.changeset/lemon-books-exist.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+fix setting href when using asChild

--- a/.changeset/smart-news-rush.md
+++ b/.changeset/smart-news-rush.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+remove aria-label as required prop from NavItem

--- a/apps/docs/demos/sidebar/group/separator-usage/App.tsx
+++ b/apps/docs/demos/sidebar/group/separator-usage/App.tsx
@@ -22,25 +22,15 @@ export function App() {
         <Nav>
           <NavBody>
             <NavList>
-              <NavItem aria-label="All" icon={<IconCopy />}>
-                All
-              </NavItem>
-              <NavItem aria-label="Recent" icon={<IconRectangle />}>
-                Recent
-              </NavItem>
+              <NavItem icon={<IconCopy />}>All</NavItem>
+              <NavItem icon={<IconRectangle />}>Recent</NavItem>
               <NavGroup defaultOpen>
                 <NavSeparator />
                 <NavGroupTrigger>Location</NavGroupTrigger>
                 <NavGroupContent>
-                  <NavItem aria-label="CMP" icon={<IconDashboard />}>
-                    CMP
-                  </NavItem>
-                  <NavItem aria-label="CMS" icon={<IconDeviceDesktop />}>
-                    CMS
-                  </NavItem>
-                  <NavItem aria-label="Experimentation" icon={<IconTestPipe />}>
-                    Experimentation
-                  </NavItem>
+                  <NavItem icon={<IconDashboard />}>CMP</NavItem>
+                  <NavItem icon={<IconDeviceDesktop />}>CMS</NavItem>
+                  <NavItem icon={<IconTestPipe />}>Experimentation</NavItem>
                 </NavGroupContent>
               </NavGroup>
             </NavList>

--- a/apps/docs/demos/sidebar/group/usage/App.tsx
+++ b/apps/docs/demos/sidebar/group/usage/App.tsx
@@ -22,15 +22,9 @@ export function App() {
               <NavGroup defaultOpen>
                 <NavGroupTrigger>Location</NavGroupTrigger>
                 <NavGroupContent>
-                  <NavItem aria-label="CMP" icon={<IconDashboard />}>
-                    CMP
-                  </NavItem>
-                  <NavItem aria-label="CMS" icon={<IconDeviceDesktop />}>
-                    CMS
-                  </NavItem>
-                  <NavItem aria-label="Experimentation" icon={<IconTestPipe />}>
-                    Experimentation
-                  </NavItem>
+                  <NavItem icon={<IconDashboard />}>CMP</NavItem>
+                  <NavItem icon={<IconDeviceDesktop />}>CMS</NavItem>
+                  <NavItem icon={<IconTestPipe />}>Experimentation</NavItem>
                 </NavGroupContent>
               </NavGroup>
             </NavList>

--- a/apps/docs/demos/sidebar/item/active-usage/App.tsx
+++ b/apps/docs/demos/sidebar/item/active-usage/App.tsx
@@ -21,7 +21,6 @@ export function App() {
             <NavList>
               <NavItem
                 active={selected === "CMP"}
-                aria-label="CMP"
                 icon={<IconDashboard />}
                 onClick={() => setSelected("CMP")}
               >
@@ -29,7 +28,6 @@ export function App() {
               </NavItem>
               <NavItem
                 active={selected === "CMS"}
-                aria-label="CMS"
                 icon={<IconDeviceDesktop />}
                 onClick={() => setSelected("CMS")}
               >
@@ -37,7 +35,6 @@ export function App() {
               </NavItem>
               <NavItem
                 active={selected === "Experimentation"}
-                aria-label="Experimentation"
                 icon={<IconTestPipe />}
                 onClick={() => setSelected("Experimentation")}
               >

--- a/apps/docs/demos/sidebar/item/link-usage/App.tsx
+++ b/apps/docs/demos/sidebar/item/link-usage/App.tsx
@@ -12,7 +12,6 @@ export function App() {
             <NavList>
               <NavItem
                 addonAfter={<IconExternalLink size="16" />}
-                aria-label="Tutorial"
                 asChild
                 icon={<IconVocabulary />}
               >

--- a/apps/docs/demos/sidebar/item/usage/App.tsx
+++ b/apps/docs/demos/sidebar/item/usage/App.tsx
@@ -14,15 +14,9 @@ export function App() {
         <Nav>
           <NavBody>
             <NavList>
-              <NavItem aria-label="CMP" icon={<IconDashboard />}>
-                CMP
-              </NavItem>
-              <NavItem aria-label="CMS" icon={<IconDeviceDesktop />}>
-                CMS
-              </NavItem>
-              <NavItem aria-label="Experimentation" icon={<IconTestPipe />}>
-                Experimentation
-              </NavItem>
+              <NavItem icon={<IconDashboard />}>CMP</NavItem>
+              <NavItem icon={<IconDeviceDesktop />}>CMS</NavItem>
+              <NavItem icon={<IconTestPipe />}>Experimentation</NavItem>
             </NavList>
           </NavBody>
         </Nav>

--- a/apps/docs/demos/sidebar/sub-nav-usage/App.tsx
+++ b/apps/docs/demos/sidebar/sub-nav-usage/App.tsx
@@ -36,7 +36,6 @@ export function App() {
             <NavList>
               <NavItem
                 active={selected === "All"}
-                aria-label="All"
                 icon={<IconCopy />}
                 onClick={() => setSelected("All")}
               >
@@ -44,7 +43,6 @@ export function App() {
               </NavItem>
               <NavItem
                 active={selected === "Recent"}
-                aria-label="Recent"
                 icon={<IconRectangle />}
                 onClick={() => setSelected("Recent")}
               >
@@ -52,7 +50,6 @@ export function App() {
               </NavItem>
               <NavItem
                 active={selected === "Favorites"}
-                aria-label="Favorites"
                 icon={<IconStar />}
                 onClick={() => setSelected("Favorites")}
               >
@@ -60,7 +57,6 @@ export function App() {
               </NavItem>
               <NavItem
                 active={selected === "Trash"}
-                aria-label="Trash"
                 icon={<IconTrash />}
                 onClick={() => setSelected("Trash")}
               >
@@ -73,7 +69,6 @@ export function App() {
                 <NavGroupContent>
                   <NavItem
                     active={selected === "CMP"}
-                    aria-label="CMP"
                     icon={<IconDashboard />}
                     onClick={() => setSelected("CMP")}
                   >
@@ -81,7 +76,6 @@ export function App() {
                   </NavItem>
                   <NavItem
                     active={selected === "CMS"}
-                    aria-label="CMS"
                     icon={<IconDeviceDesktop />}
                     onClick={() => setSelected("CMS")}
                   >
@@ -89,7 +83,6 @@ export function App() {
                   </NavItem>
                   <NavItem
                     active={selected === "Experimentation"}
-                    aria-label="Experimentation"
                     icon={<IconTestPipe />}
                     onClick={() => setSelected("Experimentation")}
                   >
@@ -104,7 +97,6 @@ export function App() {
                 <NavGroupContent>
                   <NavItem
                     active={selected === "Dashboard"}
-                    aria-label="Dashboard"
                     icon={<IconDashboard />}
                     onClick={() => setSelected("Dashboard")}
                   >
@@ -112,7 +104,6 @@ export function App() {
                   </NavItem>
                   <NavItem
                     active={selected === "Reports"}
-                    aria-label="Reports"
                     icon={<IconReport />}
                     onClick={() => setSelected("Reports")}
                   >

--- a/apps/docs/demos/sidebar/sub-nav-usage/PrimaryNav.tsx
+++ b/apps/docs/demos/sidebar/sub-nav-usage/PrimaryNav.tsx
@@ -26,21 +26,14 @@ export function PrimaryNav() {
     <Nav>
       <NavBody>
         <NavList>
-          <NavItem aria-label="Projects" icon={<IconBinaryTree />}>
-            Projects
-          </NavItem>
-          <NavItem active aria-label="Flags" icon={<IconFlag2 />}>
+          <NavItem icon={<IconBinaryTree />}>Projects</NavItem>
+          <NavItem active icon={<IconFlag2 />}>
             Flags
           </NavItem>
-          <NavItem aria-label="Events" icon={<IconChartLine />}>
-            Events
-          </NavItem>
-          <NavItem aria-label="Settings" icon={<IconSettings />}>
-            Settings
-          </NavItem>
+          <NavItem icon={<IconChartLine />}>Events</NavItem>
+          <NavItem icon={<IconSettings />}>Settings</NavItem>
           <NavItem
             addonAfter={<IconExternalLink size="16" />}
-            aria-label="Tutorial"
             asChild
             icon={<IconVocabulary />}
           >

--- a/apps/docs/demos/sidebar/usage/App.tsx
+++ b/apps/docs/demos/sidebar/usage/App.tsx
@@ -31,21 +31,14 @@ export function App() {
         <Nav>
           <NavBody>
             <NavList>
-              <NavItem aria-label="Projects" icon={<IconBinaryTree />}>
-                Projects
-              </NavItem>
-              <NavItem active aria-label="Flags" icon={<IconFlag2 />}>
+              <NavItem icon={<IconBinaryTree />}>Projects</NavItem>
+              <NavItem active icon={<IconFlag2 />}>
                 Flags
               </NavItem>
-              <NavItem aria-label="Events" icon={<IconChartLine />}>
-                Events
-              </NavItem>
-              <NavItem aria-label="Settings" icon={<IconSettings />}>
-                Settings
-              </NavItem>
+              <NavItem icon={<IconChartLine />}>Events</NavItem>
+              <NavItem icon={<IconSettings />}>Settings</NavItem>
               <NavItem
                 addonAfter={<IconExternalLink size="16" />}
-                aria-label="Tutorial"
                 asChild
                 icon={<IconVocabulary />}
               >

--- a/apps/storybook/src/components/Layout.stories.tsx
+++ b/apps/storybook/src/components/Layout.stories.tsx
@@ -47,30 +47,17 @@ const SideNavTemplate = () => (
     <Nav>
       <NavBody>
         <NavList>
-          <NavItem aria-label="Projects" icon={<IconBinaryTree />}>
-            Projects
-          </NavItem>
-          <NavItem active aria-label="Flags" icon={<IconFlag2 />}>
+          <NavItem icon={<IconBinaryTree />}>Projects</NavItem>
+          <NavItem active icon={<IconFlag2 />}>
             Flags
           </NavItem>
-          <NavItem aria-label="Idea Lab" icon={<IconChartInfographic />}>
-            Idea Lab
-          </NavItem>
-          <NavItem aria-label="Audiences" icon={<IconUsers />}>
-            Audiences
-          </NavItem>
-          <NavItem aria-label="History" icon={<IconHistory />}>
-            History
-          </NavItem>
-          <NavItem aria-label="Events" icon={<IconChartLine />}>
-            Events
-          </NavItem>
-          <NavItem aria-label="Settings" icon={<IconSettings />}>
-            Settings
-          </NavItem>
+          <NavItem icon={<IconChartInfographic />}>Idea Lab</NavItem>
+          <NavItem icon={<IconUsers />}>Audiences</NavItem>
+          <NavItem icon={<IconHistory />}>History</NavItem>
+          <NavItem icon={<IconChartLine />}>Events</NavItem>
+          <NavItem icon={<IconSettings />}>Settings</NavItem>
           <NavItem
             addonAfter={<IconExternalLink size="16" />}
-            aria-label="Tutorial"
             asChild
             icon={<IconVocabulary />}
           >

--- a/apps/storybook/src/components/Sidebar.stories.tsx
+++ b/apps/storybook/src/components/Sidebar.stories.tsx
@@ -46,30 +46,17 @@ import {
 const body = (
   <NavBody>
     <NavList>
-      <NavItem aria-label="Projects" icon={<IconBinaryTree />}>
-        Projects
-      </NavItem>
-      <NavItem active aria-label="Flags" icon={<IconFlag2 />}>
+      <NavItem icon={<IconBinaryTree />}>Projects</NavItem>
+      <NavItem active icon={<IconFlag2 />}>
         Flags
       </NavItem>
-      <NavItem aria-label="Idea Lab" icon={<IconChartInfographic />}>
-        Idea Lab
-      </NavItem>
-      <NavItem aria-label="Audiences" icon={<IconUsers />}>
-        Audiences
-      </NavItem>
-      <NavItem aria-label="History" icon={<IconHistory />}>
-        History
-      </NavItem>
-      <NavItem aria-label="Events" icon={<IconChartLine />}>
-        Events
-      </NavItem>
-      <NavItem aria-label="Settings" icon={<IconSettings />}>
-        Settings
-      </NavItem>
+      <NavItem icon={<IconChartInfographic />}>Idea Lab</NavItem>
+      <NavItem icon={<IconUsers />}>Audiences</NavItem>
+      <NavItem icon={<IconHistory />}>History</NavItem>
+      <NavItem icon={<IconChartLine />}>Events</NavItem>
+      <NavItem icon={<IconSettings />}>Settings</NavItem>
       <NavItem
         addonAfter={<IconExternalLink size="16" />}
-        aria-label="Tutorial"
         asChild
         icon={<IconVocabulary />}
       >
@@ -197,18 +184,10 @@ export const WithSubNav: Story = {
         <SubNav>
           <NavBody>
             <NavList>
-              <NavItem aria-label="All" icon={<IconCopy />}>
-                All
-              </NavItem>
-              <NavItem aria-label="Recent" icon={<IconRectangle />}>
-                Recent
-              </NavItem>
-              <NavItem aria-label="Favorites" icon={<IconStar />}>
-                Favorites
-              </NavItem>
-              <NavItem aria-label="Trash" icon={<IconTrash />}>
-                Trash
-              </NavItem>
+              <NavItem icon={<IconCopy />}>All</NavItem>
+              <NavItem icon={<IconRectangle />}>Recent</NavItem>
+              <NavItem icon={<IconStar />}>Favorites</NavItem>
+              <NavItem icon={<IconTrash />}>Trash</NavItem>
 
               <NavGroup defaultOpen>
                 <NavSeparator />
@@ -216,15 +195,11 @@ export const WithSubNav: Story = {
                 <NavGroupTrigger>Location</NavGroupTrigger>
 
                 <NavGroupContent>
-                  <NavItem active aria-label="CMP" icon={<IconDashboard />}>
+                  <NavItem active icon={<IconDashboard />}>
                     CMP
                   </NavItem>
-                  <NavItem aria-label="CMS" icon={<IconDeviceDesktop />}>
-                    CMS
-                  </NavItem>
-                  <NavItem aria-label="Experimentation" icon={<IconTestPipe />}>
-                    Experimentation
-                  </NavItem>
+                  <NavItem icon={<IconDeviceDesktop />}>CMS</NavItem>
+                  <NavItem icon={<IconTestPipe />}>Experimentation</NavItem>
                 </NavGroupContent>
               </NavGroup>
 
@@ -234,12 +209,8 @@ export const WithSubNav: Story = {
                 <NavGroupTrigger>Analytics</NavGroupTrigger>
 
                 <NavGroupContent>
-                  <NavItem aria-label="Dashboard" icon={<IconDashboard />}>
-                    Dashboard
-                  </NavItem>
-                  <NavItem aria-label="Reports" icon={<IconReport />}>
-                    Reports
-                  </NavItem>
+                  <NavItem icon={<IconDashboard />}>Dashboard</NavItem>
+                  <NavItem icon={<IconReport />}>Reports</NavItem>
                 </NavGroupContent>
               </NavGroup>
             </NavList>

--- a/packages/react/src/link/Link.spec.tsx
+++ b/packages/react/src/link/Link.spec.tsx
@@ -1,0 +1,25 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+import { describe, expect, it } from "vitest";
+
+import { render, screen } from "../../vitest.rtl";
+import { Link } from "./Link";
+
+function CustomLink(props: ComponentPropsWithoutRef<"a">) {
+  return (
+    <a href="/sample" {...props}>
+      Sample link
+    </a>
+  );
+}
+
+describe("Link component", () => {
+  it("should handle href when using asChild composition", async () => {
+    render(
+      <Link asChild>
+        <CustomLink />
+      </Link>,
+    );
+    expect(screen.getByText("Sample link")).toHaveAttribute("href", "/sample");
+  });
+});

--- a/packages/react/src/link/Link.tsx
+++ b/packages/react/src/link/Link.tsx
@@ -31,7 +31,6 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       className,
       disabled,
       external,
-      href,
       overlay,
       ...props
     },
@@ -47,7 +46,6 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
             aria-disabled={disabled}
             data-disabled={disabled ? "" : undefined}
             data-overlay={overlay ? "" : undefined}
-            href={href}
             ref={ref}
             {...(external && { rel: "noopener noreferrer", target: "_blank" })}
             {...restProps}

--- a/packages/react/src/nav-item/NavItem.tsx
+++ b/packages/react/src/nav-item/NavItem.tsx
@@ -18,7 +18,6 @@ export type NavItemProps = BoxProps<
      * Display content inside the button after `children`.
      */
     addonAfter?: ReactNode;
-    "aria-label": string;
     /**
      * Display an icon before button content.
      */


### PR DESCRIPTION
remove useless href extraction from props - since it can override inner components with `href={undefined}` when used with asChild

resolves #776