### PR TITLE
prevent rendering popover trigger on first render if using custom anchor

### DIFF
--- a/packages/react/src/date-input/DateInput.tsx
+++ b/packages/react/src/date-input/DateInput.tsx
@@ -46,6 +46,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
                 <PopoverTrigger
                   appearance="subtle"
                   aria-label="Show date picker"
+                  hasCustomAnchor
                   icon={<IconCalendar />}
                   size="sm"
                   {...styles.picker()}

--- a/packages/react/src/popover-trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover-trigger/PopoverTrigger.tsx
@@ -1,26 +1,40 @@
 import * as RadixPopover from "@radix-ui/react-popover";
-import { forwardRef } from "react";
+import { forwardRef, useEffect, useState } from "react";
 
 import { Button, type ButtonProps } from "../button";
 import { usePopoverContext } from "../popover-context";
 
-type PopoverTriggerProps = ButtonProps<typeof RadixPopover.Trigger>;
+type PopoverTriggerProps = ButtonProps<
+  typeof RadixPopover.Trigger,
+  {
+    hasCustomAnchor?: boolean;
+  }
+>;
 
 export const PopoverTrigger = forwardRef<
   HTMLButtonElement,
   PopoverTriggerProps
->(({ asChild, children, ...props }, ref) => {
+>(({ asChild, children, hasCustomAnchor, ...props }, ref) => {
   const { presence } = usePopoverContext("PopoverTrigger");
 
+  const [shouldRender, setShouldRender] = useState(!hasCustomAnchor);
+  useEffect(() => {
+    if (!shouldRender) {
+      setShouldRender(true);
+    }
+  }, [shouldRender]);
+
   return (
-    <RadixPopover.Trigger
-      asChild
-      data-expanded={presence ? "" : undefined}
-      ref={ref}
-      {...props}
-    >
-      {asChild ? children : <Button>{children}</Button>}
-    </RadixPopover.Trigger>
+    shouldRender && (
+      <RadixPopover.Trigger
+        asChild
+        data-expanded={presence ? "" : undefined}
+        ref={ref}
+        {...props}
+      >
+        {asChild ? children : <Button>{children}</Button>}
+      </RadixPopover.Trigger>
+    )
   );
 });
 


### PR DESCRIPTION
since radix internally uses context and mount lifecycle on PopoverAnchor to determine if a custom anchor is being used and initially assumes no custom anchor is being used.

as a result if a custom anchor is used the trigger will first render an anchor and a button and then on the next render will remove the anchor and just render the button. but this causes the first button ref to get swapped in DOM and leads to inconsistent behavior if something targets that ref very quickly.