### PR TITLE
set the open state of popovers based on open or presence

### DIFF
--- a/.changeset/witty-news-guess.md
+++ b/.changeset/witty-news-guess.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/web-components": patch
+"@optiaxiom/react": patch
+---
+
+refactor presence of popovers

--- a/packages/react/src/actions-content/ActionsContent.css.ts
+++ b/packages/react/src/actions-content/ActionsContent.css.ts
@@ -25,7 +25,7 @@ export const content = recipe({
       },
 
       selectors: {
-        [`${rootStyles.className}:not(:has(${rootStyles.className})):focus-within &, &:has(:checked, [data-expanded], [data-state=open])`]:
+        [`${rootStyles.className}:not(:has(${rootStyles.className})):focus-within &, &:has(:checked, [data-state=open])`]:
           {
             opacity: "1",
             transition: "none",

--- a/packages/react/src/alert-dialog-trigger/AlertDialogTrigger.tsx
+++ b/packages/react/src/alert-dialog-trigger/AlertDialogTrigger.tsx
@@ -1,7 +1,6 @@
 import * as RadixAlertDialog from "@radix-ui/react-alert-dialog";
 import { forwardRef } from "react";
 
-import { useAlertDialogContext } from "../alert-dialog-context";
 import { Button, type ButtonProps } from "../button";
 
 type AlertDialogTriggerProps = ButtonProps<typeof RadixAlertDialog.Trigger>;
@@ -10,15 +9,8 @@ export const AlertDialogTrigger = forwardRef<
   HTMLButtonElement,
   AlertDialogTriggerProps
 >(({ asChild, children, ...props }, ref) => {
-  const { presence } = useAlertDialogContext("AlertDialogTrigger");
-
   return (
-    <RadixAlertDialog.Trigger
-      asChild
-      data-expanded={presence ? "" : undefined}
-      ref={ref}
-      {...props}
-    >
+    <RadixAlertDialog.Trigger asChild ref={ref} {...props}>
       {asChild ? children : <Button>{children}</Button>}
     </RadixAlertDialog.Trigger>
   );

--- a/packages/react/src/alert-dialog/AlertDialog.tsx
+++ b/packages/react/src/alert-dialog/AlertDialog.tsx
@@ -45,7 +45,11 @@ export function AlertDialog({
 
   return (
     <NestedDialogContextProvider onCountChange={setNestedDialogCount}>
-      <RadixAlertDialog.Root onOpenChange={setOpen} open={open} {...props}>
+      <RadixAlertDialog.Root
+        onOpenChange={setOpen}
+        open={open || presence}
+        {...props}
+      >
         <AlertDialogContextProvider
           nestedDialogCount={nestedDialogCount}
           open={open}

--- a/packages/react/src/dropdown-menu-trigger/DropdownMenuTrigger.tsx
+++ b/packages/react/src/dropdown-menu-trigger/DropdownMenuTrigger.tsx
@@ -3,7 +3,6 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 import { AngleMenuButton } from "../angle-menu-button";
 import { Button } from "../button";
-import { useDropdownMenuContext } from "../dropdown-menu-context";
 
 type MenuTriggerProps = ComponentPropsWithoutRef<typeof Button>;
 
@@ -11,15 +10,8 @@ export const DropdownMenuTrigger = forwardRef<
   HTMLButtonElement,
   MenuTriggerProps
 >(({ asChild, children, ...props }, ref) => {
-  const { presence } = useDropdownMenuContext("DropdownMenuTrigger");
-
   return (
-    <RadixMenu.Trigger
-      asChild
-      data-expanded={presence ? "" : undefined}
-      ref={ref}
-      {...props}
-    >
+    <RadixMenu.Trigger asChild ref={ref} {...props}>
       {asChild ? children : <AngleMenuButton>{children}</AngleMenuButton>}
     </RadixMenu.Trigger>
   );

--- a/packages/react/src/dropdown-menu/DropdownMenu.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenu.tsx
@@ -39,7 +39,7 @@ export function DropdownMenu({
   const [presence, setPresence] = useState<boolean>();
 
   return (
-    <RadixMenu.Root onOpenChange={setOpen} open={open} {...props}>
+    <RadixMenu.Root onOpenChange={setOpen} open={open || presence} {...props}>
       <DropdownMenuContextProvider
         open={open}
         presence={presence}

--- a/packages/react/src/popover-trigger/PopoverTrigger.tsx
+++ b/packages/react/src/popover-trigger/PopoverTrigger.tsx
@@ -2,7 +2,6 @@ import * as RadixPopover from "@radix-ui/react-popover";
 import { forwardRef, useEffect, useState } from "react";
 
 import { Button, type ButtonProps } from "../button";
-import { usePopoverContext } from "../popover-context";
 
 type PopoverTriggerProps = ButtonProps<
   typeof RadixPopover.Trigger,
@@ -15,8 +14,6 @@ export const PopoverTrigger = forwardRef<
   HTMLButtonElement,
   PopoverTriggerProps
 >(({ asChild, children, hasCustomAnchor, ...props }, ref) => {
-  const { presence } = usePopoverContext("PopoverTrigger");
-
   const [shouldRender, setShouldRender] = useState(!hasCustomAnchor);
   useEffect(() => {
     if (!shouldRender) {
@@ -26,12 +23,7 @@ export const PopoverTrigger = forwardRef<
 
   return (
     shouldRender && (
-      <RadixPopover.Trigger
-        asChild
-        data-expanded={presence ? "" : undefined}
-        ref={ref}
-        {...props}
-      >
+      <RadixPopover.Trigger asChild ref={ref} {...props}>
         {asChild ? children : <Button>{children}</Button>}
       </RadixPopover.Trigger>
     )

--- a/packages/react/src/popover/Popover.tsx
+++ b/packages/react/src/popover/Popover.tsx
@@ -39,7 +39,11 @@ export function Popover({
   const [presence, setPresence] = useState<boolean>();
 
   return (
-    <RadixPopover.Root onOpenChange={setOpen} open={open} {...props}>
+    <RadixPopover.Root
+      onOpenChange={setOpen}
+      open={open || presence}
+      {...props}
+    >
       <PopoverContextProvider
         open={open}
         presence={presence}


### PR DESCRIPTION
instead of manually setting a data attribute - so data-state=open reflects the true status of the control in DOM