### PR TITLE
use context to conditionally enable modal layer

### DIFF
--- a/.changeset/hot-apes-battle.md
+++ b/.changeset/hot-apes-battle.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/web-components": patch
+"@optiaxiom/react": patch
+---
+
+use context to conditionally enable modal layer

--- a/packages/react/src/alert-dialog-content/AlertDialogContent.tsx
+++ b/packages/react/src/alert-dialog-content/AlertDialogContent.tsx
@@ -8,6 +8,7 @@ import { useAlertDialogContext } from "../alert-dialog-context";
 import { Backdrop } from "../backdrop";
 import { Box, type BoxProps } from "../box";
 import { Flex } from "../flex";
+import { ModalContextProvider } from "../modal-context";
 import { Paper } from "../paper";
 import { Transition } from "../transition";
 import { TransitionGroup } from "../transition-group";
@@ -57,7 +58,7 @@ export const AlertDialogContent = forwardRef<
               {...styles.content({ size })}
             >
               <RadixAlertDialog.Content ref={ref} {...props}>
-                {children}
+                <ModalContextProvider enabled>{children}</ModalContextProvider>
               </RadixAlertDialog.Content>
             </Paper>
           </Transition>

--- a/packages/react/src/dialog-content/DialogContent.tsx
+++ b/packages/react/src/dialog-content/DialogContent.tsx
@@ -5,6 +5,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { Backdrop } from "../backdrop";
 import { type BoxProps } from "../box";
 import { useDialogContext } from "../dialog-context";
+import { ModalContextProvider } from "../modal-context";
 import { Paper } from "../paper";
 import { Transition } from "../transition";
 import { TransitionGroup } from "../transition-group";
@@ -61,7 +62,9 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
               {...styles.content({ size }, className)}
               {...props}
             >
-              <RadixDialog.Content ref={ref}>{children}</RadixDialog.Content>
+              <RadixDialog.Content ref={ref}>
+                <ModalContextProvider enabled>{children}</ModalContextProvider>
+              </RadixDialog.Content>
             </Paper>
           </Transition>
         </RadixDialog.Portal>

--- a/packages/react/src/drawer-content/DrawerContent.tsx
+++ b/packages/react/src/drawer-content/DrawerContent.tsx
@@ -4,6 +4,7 @@ import { forwardRef } from "react";
 import { Backdrop } from "../backdrop";
 import { type BoxProps } from "../box";
 import { useDrawerContext } from "../drawer-context";
+import { ModalContextProvider } from "../modal-context";
 import { Paper } from "../paper";
 import { Transition } from "../transition";
 import { TransitionGroup } from "../transition-group";
@@ -45,7 +46,7 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
               {...styles.content({ position })}
             >
               <RadixDialog.Content ref={ref} {...props}>
-                {children}
+                <ModalContextProvider enabled>{children}</ModalContextProvider>
               </RadixDialog.Content>
             </Paper>
           </Transition>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -73,6 +73,7 @@ export * from "./listbox-radio-item";
 export * from "./listbox-scroll-area";
 export * from "./listbox-separator";
 export * from "./listbox-switch-item";
+export * from "./modal-context";
 export * from "./modal-layer";
 export * from "./nav";
 export * from "./nav-account-item";

--- a/packages/react/src/modal-context/ModalContext.ts
+++ b/packages/react/src/modal-context/ModalContext.ts
@@ -1,0 +1,7 @@
+"use client";
+
+import { createContext } from "@radix-ui/react-context";
+
+export const [ModalContextProvider, useModalContext] = createContext<{
+  enabled: boolean;
+}>("Modal", { enabled: false });

--- a/packages/react/src/modal-context/index.ts
+++ b/packages/react/src/modal-context/index.ts
@@ -1,0 +1,1 @@
+export * from "./ModalContext";

--- a/packages/react/src/modal-layer/ModalLayer.tsx
+++ b/packages/react/src/modal-layer/ModalLayer.tsx
@@ -11,19 +11,36 @@ import { RemoveScroll as ReactRemoveScroll } from "react-remove-scroll";
 
 import type { Box } from "../box";
 
+import { useModalContext } from "../modal-context";
+
 type ModalLayerProps = Pick<ComponentPropsWithoutRef<typeof Box>, "asChild"> & {
   children?: ReactNode;
 };
 
 export const ModalLayer = forwardRef<HTMLDivElement, ModalLayerProps>(
   ({ asChild, children, ...props }, ref) => {
+    const { enabled } = useModalContext("ModalLayer");
+    const [locked] = useState(() => document.body.dataset.scrollLocked);
+    const [guards] = useState(() =>
+      document.querySelector("[data-radix-focus-guard]"),
+    );
+
+    if (!enabled) {
+      return asChild ? (
+        <Slot ref={ref} {...props}>
+          {children}
+        </Slot>
+      ) : (
+        <>{children}</>
+      );
+    }
+
     let result = (
       <DismissableLayer asChild={asChild} ref={ref} {...props}>
         {children}
       </DismissableLayer>
     );
 
-    const [locked] = useState(() => document.body.dataset.scrollLocked);
     if (locked) {
       result = (
         <ReactRemoveScroll allowPinchZoom as={Slot}>
@@ -32,9 +49,6 @@ export const ModalLayer = forwardRef<HTMLDivElement, ModalLayerProps>(
       );
     }
 
-    const [guards] = useState(() =>
-      document.querySelector("[data-radix-focus-guard]"),
-    );
     if (guards) {
       result = <FocusGuards>{result}</FocusGuards>;
     }

--- a/packages/react/src/popover-content/PopoverContent.tsx
+++ b/packages/react/src/popover-content/PopoverContent.tsx
@@ -5,6 +5,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import type { BoxProps } from "../box";
 
 import { MenuListbox } from "../menu-listbox";
+import { ModalContextProvider } from "../modal-context";
 import { usePopoverContext } from "../popover-context";
 import { TransitionGroup } from "../transition-group";
 import { type ExcludeProps, onReactSelectInputBlur } from "../utils";
@@ -53,7 +54,7 @@ export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>(
               ref={ref}
               sideOffset={sideOffset}
             >
-              {children}
+              <ModalContextProvider enabled>{children}</ModalContextProvider>
 
               {withArrow && (
                 <RadixPopover.Arrow asChild>

--- a/packages/web-components/src/mapping.ts
+++ b/packages/web-components/src/mapping.ts
@@ -15,6 +15,7 @@ type ComponentNames = Exclude<
       : never]: never;
   },
   | "FieldContext"
+  | "ModalContextProvider"
   | "ToastProvider"
   | "TooltipProvider"
   | "TransitionGlobalConfig"


### PR DESCRIPTION
ModalLayer should only add the dismiss layer, focus guards, and scroll lock if it's being used inside a dialog (or modal component that implements those things)

so consumers can easily place the ModalLayer in their portal components without having to consider these things

```ts
import { ModalLayer } from '@optiaxiom/react';
import type { ReactNode } from 'react';
import { createPortal } from 'react-dom';

export function Portal({ children }: { children: ReactNode }) {
  return createPortal(<ModalLayer>{children}</ModalLayer>, document.body);
}
```