### PR TITLE
fix disclosure trigger size

### DIFF
--- a/.changeset/short-foxes-beam.md
+++ b/.changeset/short-foxes-beam.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+fix disclosure trigger size

--- a/packages/react/src/disclosure-trigger/DisclosureTrigger.css.ts
+++ b/packages/react/src/disclosure-trigger/DisclosureTrigger.css.ts
@@ -2,15 +2,14 @@ import { theme } from "@optiaxiom/globals";
 
 import { recipe, style } from "../vanilla-extract";
 
-export const trigger = recipe({
+export const root = recipe({
   base: [
     {
       flexDirection: "row",
       fontSize: "md",
       fontWeight: "500",
       gap: "8",
-      h: "lg",
-      px: "8",
+      p: "8",
       transition: "colors",
     },
     style({
@@ -26,6 +25,23 @@ export const trigger = recipe({
           },
         },
       },
+    }),
+  ],
+});
+
+export const trigger = recipe({
+  base: [
+    {
+      flexDirection: "row",
+      fontSize: "inherit",
+      fontWeight: "inherit",
+      gap: "4",
+      rounded: "md",
+      textAlign: "start",
+      w: "full",
+    },
+    style({
+      minHeight: theme.size.sm,
     }),
   ],
 });

--- a/packages/react/src/disclosure-trigger/DisclosureTrigger.tsx
+++ b/packages/react/src/disclosure-trigger/DisclosureTrigger.tsx
@@ -36,18 +36,10 @@ export const DisclosureTrigger = forwardRef<
     useDisclosureContext("DisclosureTrigger");
 
     return (
-      <Flex ref={ref} {...styles.trigger({}, className)} {...props}>
+      <Flex ref={ref} {...styles.root({}, className)} {...props}>
         {addonBefore}
 
-        <Flex
-          asChild
-          flexDirection="row"
-          fontWeight="inherit"
-          gap="4"
-          rounded="md"
-          textAlign="start"
-          w="full"
-        >
+        <Flex asChild {...styles.trigger()}>
           <Cover asChild>
             <RadixCollapsible.Trigger>
               {chevronPosition === "start" && (

--- a/packages/react/src/nav-group-trigger/NavGroupTrigger.tsx
+++ b/packages/react/src/nav-group-trigger/NavGroupTrigger.tsx
@@ -18,6 +18,7 @@ export const NavGroupTrigger = forwardRef<HTMLDivElement, NavGroupTriggerProps>(
         id={id}
         mb="4"
         mt="8"
+        p="0"
         px="12"
         ref={ref}
         w="auto"


### PR DESCRIPTION
fix line-height of trigger button by setting it to inherit and add a min-height of 24px instead of hard coding height to 40px (to allow multi line triggers)