### PR TITLE
pass shard ref to scroll lock

### DIFF
--- a/.changeset/sixty-badgers-shop.md
+++ b/.changeset/sixty-badgers-shop.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+pass shard ref to scroll lock

--- a/packages/react/src/alert-dialog-content/AlertDialogContent.tsx
+++ b/packages/react/src/alert-dialog-content/AlertDialogContent.tsx
@@ -1,6 +1,7 @@
 import * as RadixAlertDialog from "@radix-ui/react-alert-dialog";
+import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import { assignInlineVars } from "@vanilla-extract/dynamic";
-import { forwardRef } from "react";
+import { forwardRef, useRef } from "react";
 
 import type { ExcludeProps } from "../utils";
 
@@ -22,9 +23,12 @@ type AlertDialogContentProps = ExcludeProps<
 export const AlertDialogContent = forwardRef<
   HTMLDivElement,
   AlertDialogContentProps
->(({ children, size = "sm", style, ...props }, ref) => {
+>(({ children, size = "sm", style, ...props }, outerRef) => {
   const { nestedDialogCount, open, presence, setPresence } =
     useAlertDialogContext("AlertDialogContent");
+
+  const innerRef = useRef<HTMLDivElement>(null);
+  const ref = useComposedRefs(innerRef, outerRef);
 
   return (
     <TransitionGroup
@@ -58,7 +62,9 @@ export const AlertDialogContent = forwardRef<
               {...styles.content({ size })}
             >
               <RadixAlertDialog.Content ref={ref} {...props}>
-                <ModalContextProvider enabled>{children}</ModalContextProvider>
+                <ModalContextProvider shardRef={innerRef}>
+                  {children}
+                </ModalContextProvider>
               </RadixAlertDialog.Content>
             </Paper>
           </Transition>

--- a/packages/react/src/dialog-content/DialogContent.tsx
+++ b/packages/react/src/dialog-content/DialogContent.tsx
@@ -1,6 +1,7 @@
+import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import * as RadixDialog from "@radix-ui/react-dialog";
 import { assignInlineVars } from "@vanilla-extract/dynamic";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import { type ComponentPropsWithoutRef, forwardRef, useRef } from "react";
 
 import { Backdrop } from "../backdrop";
 import { type BoxProps } from "../box";
@@ -32,9 +33,12 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
       transitionType = "fade",
       ...props
     },
-    ref,
+    outerRef,
   ) => {
     const { nestedDialogCount, open } = useDialogContext("DialogContent");
+
+    const innerRef = useRef<HTMLDivElement>(null);
+    const ref = useComposedRefs(innerRef, outerRef);
 
     return (
       <TransitionGroup open={open}>
@@ -63,7 +67,9 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
               {...props}
             >
               <RadixDialog.Content ref={ref}>
-                <ModalContextProvider enabled>{children}</ModalContextProvider>
+                <ModalContextProvider shardRef={innerRef}>
+                  {children}
+                </ModalContextProvider>
               </RadixDialog.Content>
             </Paper>
           </Transition>

--- a/packages/react/src/drawer-content/DrawerContent.tsx
+++ b/packages/react/src/drawer-content/DrawerContent.tsx
@@ -1,5 +1,6 @@
+import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import * as RadixDialog from "@radix-ui/react-dialog";
-import { forwardRef } from "react";
+import { forwardRef, useRef } from "react";
 
 import { Backdrop } from "../backdrop";
 import { type BoxProps } from "../box";
@@ -23,8 +24,11 @@ const mapPositionToTransitionSide = {
 } as const;
 
 export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
-  ({ children, position = "right", ...props }, ref) => {
+  ({ children, position = "right", ...props }, outerRef) => {
     const { open } = useDrawerContext("DrawerContent");
+
+    const innerRef = useRef<HTMLDivElement>(null);
+    const ref = useComposedRefs(innerRef, outerRef);
 
     return (
       <TransitionGroup open={open}>
@@ -46,7 +50,9 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
               {...styles.content({ position })}
             >
               <RadixDialog.Content ref={ref} {...props}>
-                <ModalContextProvider enabled>{children}</ModalContextProvider>
+                <ModalContextProvider shardRef={innerRef}>
+                  {children}
+                </ModalContextProvider>
               </RadixDialog.Content>
             </Paper>
           </Transition>

--- a/packages/react/src/modal-context/ModalContext.ts
+++ b/packages/react/src/modal-context/ModalContext.ts
@@ -1,7 +1,9 @@
 "use client";
 
+import type { RefObject } from "react";
+
 import { createContext } from "@radix-ui/react-context";
 
 export const [ModalContextProvider, useModalContext] = createContext<{
-  enabled: boolean;
-}>("Modal", { enabled: false });
+  shardRef: RefObject<HTMLElement>;
+}>("Modal", { shardRef: { current: null } });

--- a/packages/react/src/modal-layer/ModalLayer.tsx
+++ b/packages/react/src/modal-layer/ModalLayer.tsx
@@ -19,13 +19,13 @@ type ModalLayerProps = Pick<ComponentPropsWithoutRef<typeof Box>, "asChild"> & {
 
 export const ModalLayer = forwardRef<HTMLDivElement, ModalLayerProps>(
   ({ asChild, children, ...props }, ref) => {
-    const { enabled } = useModalContext("ModalLayer");
+    const { shardRef } = useModalContext("ModalLayer");
     const [locked] = useState(() => document.body.dataset.scrollLocked);
     const [guards] = useState(() =>
       document.querySelector("[data-radix-focus-guard]"),
     );
 
-    if (!enabled) {
+    if (!shardRef.current) {
       return asChild ? (
         <Slot ref={ref} {...props}>
           {children}
@@ -43,7 +43,7 @@ export const ModalLayer = forwardRef<HTMLDivElement, ModalLayerProps>(
 
     if (locked) {
       result = (
-        <ReactRemoveScroll allowPinchZoom as={Slot}>
+        <ReactRemoveScroll allowPinchZoom as={Slot} shards={[shardRef]}>
           {result}
         </ReactRemoveScroll>
       );

--- a/packages/react/src/popover-content/PopoverContent.tsx
+++ b/packages/react/src/popover-content/PopoverContent.tsx
@@ -1,6 +1,7 @@
 import { theme } from "@optiaxiom/globals";
+import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import * as RadixPopover from "@radix-ui/react-popover";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import { type ComponentPropsWithoutRef, forwardRef, useRef } from "react";
 
 import type { BoxProps } from "../box";
 
@@ -32,8 +33,14 @@ type PopoverContentProps = ExcludeProps<
 >;
 
 export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>(
-  ({ align = "start", children, sideOffset = 2, withArrow, ...props }, ref) => {
+  (
+    { align = "start", children, sideOffset = 2, withArrow, ...props },
+    outerRef,
+  ) => {
     const { open, presence, setPresence } = usePopoverContext("PopoverContent");
+
+    const innerRef = useRef<HTMLDivElement>(null);
+    const ref = useComposedRefs(innerRef, outerRef);
 
     return (
       <TransitionGroup
@@ -54,7 +61,9 @@ export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>(
               ref={ref}
               sideOffset={sideOffset}
             >
-              <ModalContextProvider enabled>{children}</ModalContextProvider>
+              <ModalContextProvider shardRef={innerRef}>
+                {children}
+              </ModalContextProvider>
 
               {withArrow && (
                 <RadixPopover.Arrow asChild>


### PR DESCRIPTION
we need to carry over the ref to the content and include it in the nested scroll lock's shard list so it excludes that from the scroll lock