### PR TITLE
fix DataTable height and alignment

### DIFF
--- a/.changeset/brown-peaches-speak.md
+++ b/.changeset/brown-peaches-speak.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+fix DataTable height and alignment

--- a/.changeset/chilled-pandas-guess.md
+++ b/.changeset/chilled-pandas-guess.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+stretch table to fill container

--- a/packages/react/src/data-table-body/DataTableBody.tsx
+++ b/packages/react/src/data-table-body/DataTableBody.tsx
@@ -19,6 +19,7 @@ import { Table } from "../table";
 import { TableBody } from "../table-body";
 import { TableCell } from "../table-cell";
 import { TableHeader } from "../table-header";
+import { TableHeaderCell } from "../table-header-cell";
 import { TableRow } from "../table-row";
 import * as styles from "./DataTableBody.css";
 
@@ -119,6 +120,8 @@ export const DataTableBody = forwardRef<HTMLDivElement, DataTableBodyProps>(
                       )}
                 </DataTableHeaderCell>
               ))}
+
+              <TableHeaderCell flex="1" p="0" w="0" />
             </TableRow>
           ))}
         </TableHeader>
@@ -231,6 +234,8 @@ export const DataTableBody = forwardRef<HTMLDivElement, DataTableBodyProps>(
                   )}
                 </TableCell>
               ))}
+
+              <TableCell flex="1" p="0" w="0" />
             </TableRow>
           ))}
         </TableBody>

--- a/packages/react/src/data-table-footer/DataTableFooter.tsx
+++ b/packages/react/src/data-table-footer/DataTableFooter.tsx
@@ -36,6 +36,7 @@ export const DataTableFooter = forwardRef<HTMLDivElement, DataTableFooterProps>(
         alignSelf="stretch"
         flexDirection="row"
         justifyContent="space-between"
+        mt="auto"
         ref={ref}
         {...props}
       >

--- a/packages/react/src/data-table/DataTable.tsx
+++ b/packages/react/src/data-table/DataTable.tsx
@@ -21,7 +21,6 @@ export const DataTable = forwardRef<HTMLDivElement, DataTableProps>(
   ({ children, table, ...props }, ref) => {
     return (
       <Flex
-        alignItems="start"
         gap="8"
         justifyContent="start"
         maxH="full"

--- a/packages/react/src/data-table/DataTable.tsx
+++ b/packages/react/src/data-table/DataTable.tsx
@@ -20,7 +20,15 @@ type DataTableProps = BoxProps<
 export const DataTable = forwardRef<HTMLDivElement, DataTableProps>(
   ({ children, table, ...props }, ref) => {
     return (
-      <Flex alignItems="start" gap="8" maxW="full" ref={ref} {...props}>
+      <Flex
+        alignItems="start"
+        gap="8"
+        justifyContent="start"
+        maxH="full"
+        maxW="full"
+        ref={ref}
+        {...props}
+      >
         <DataTableContextProvider table={table}>
           {children}
         </DataTableContextProvider>

--- a/packages/react/src/table-header-cell/TableHeaderCell.css.ts
+++ b/packages/react/src/table-header-cell/TableHeaderCell.css.ts
@@ -18,8 +18,6 @@ export const content = recipe({
       display: "flex",
       fontSize: "sm",
       fontWeight: "400",
-      px: "16",
-      py: "12",
       size: "full",
     },
     style({

--- a/packages/react/src/table-header-cell/TableHeaderCell.tsx
+++ b/packages/react/src/table-header-cell/TableHeaderCell.tsx
@@ -8,12 +8,19 @@ type TableHeaderCellProps = BoxProps<"th">;
 export const TableHeaderCell = forwardRef<
   HTMLTableCellElement,
   TableHeaderCellProps
->(({ children, className, colSpan, ...props }, ref) => (
-  <Box asChild {...styles.cell({}, className)} {...props}>
-    <th colSpan={colSpan} ref={ref}>
-      <Box {...styles.content()}>{children}</Box>
-    </th>
-  </Box>
-));
+>(
+  (
+    { children, className, colSpan, p, px = "16", py = "12", ...props },
+    ref,
+  ) => (
+    <Box asChild {...styles.cell({}, className)} {...props}>
+      <th colSpan={colSpan} ref={ref}>
+        <Box {...styles.content()} px={p ?? px} py={p ?? py}>
+          {children}
+        </Box>
+      </th>
+    </Box>
+  ),
+);
 
 TableHeaderCell.displayName = "@optiaxiom/react/TableHeaderCell";

--- a/packages/react/src/table/Table.css.ts
+++ b/packages/react/src/table/Table.css.ts
@@ -5,6 +5,7 @@ export const table = recipe({
     {
       color: "fg.default",
       fontSize: "md",
+      w: "full",
     },
     style({
       captionSide: "bottom",
@@ -14,9 +15,6 @@ export const table = recipe({
   variants: {
     layout: {
       auto: [
-        {
-          w: "full",
-        },
         style({
           /**
            * Setting the table height to 1px allows cell content to stretch and fill
@@ -28,7 +26,6 @@ export const table = recipe({
       fixed: [
         {
           display: "grid",
-          w: "fit",
         },
         style({
           isolation: "isolate",


### PR DESCRIPTION
restrict table max-height to 100% of container

and set alignment of items along axis at start - otherwise table that has smaller height will be centered within the container

finally, push footer down to bottom of container when table is shorter than container