### PR TITLE
fix button alignment

### DIFF
--- a/.changeset/friendly-zoos-occur.md
+++ b/.changeset/friendly-zoos-occur.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+sync disclosure spec with figma

--- a/.changeset/pink-bags-know.md
+++ b/.changeset/pink-bags-know.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+fix button alignment

--- a/.changeset/slimy-ghosts-poke.md
+++ b/.changeset/slimy-ghosts-poke.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+fix table pagination layout shifting

--- a/apps/storybook/src/components/Spotlight.stories.tsx
+++ b/apps/storybook/src/components/Spotlight.stories.tsx
@@ -163,7 +163,7 @@ export const Basic: Story<Item & { items?: Item[] }> = {
       >
         <SpotlightTrigger
           addonAfter={
-            <Kbd keys="command" variant="subtle">
+            <Kbd keys="command" ml="auto" variant="subtle">
               K
             </Kbd>
           }

--- a/packages/react/src/button-label/ButtonLabel.tsx
+++ b/packages/react/src/button-label/ButtonLabel.tsx
@@ -10,7 +10,7 @@ export const ButtonLabel = forwardRef<HTMLDivElement, ButtonLabelProps>(
   ({ children, ...props }, ref) => {
     return (
       <ButtonLoadable asChild>
-        <Flex flex="1" flexDirection="row" gap="4" mx="4" ref={ref} {...props}>
+        <Flex flexDirection="row" gap="4" mx="4" ref={ref} {...props}>
           {children}
         </Flex>
       </ButtonLoadable>

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -104,13 +104,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <ButtonBase
         asChild
+        justifyContent={
+          square ? "center" : iconPosition === "end" ? "space-between" : "start"
+        }
         ref={ref}
         size={size}
         square={square}
         {...props}
-        {...(square && {
-          justifyContent: "center",
-        })}
       >
         <Comp>{children}</Comp>
       </ButtonBase>

--- a/packages/react/src/data-table-footer/DataTableFooter.css.ts
+++ b/packages/react/src/data-table-footer/DataTableFooter.css.ts
@@ -1,0 +1,16 @@
+import { recipe, style } from "../vanilla-extract";
+
+export const addon = recipe({
+  base: style({
+    width: "180px",
+  }),
+
+  variants: {
+    position: {
+      end: {
+        textAlign: "end",
+      },
+      start: {},
+    },
+  },
+});

--- a/packages/react/src/data-table-footer/DataTableFooter.tsx
+++ b/packages/react/src/data-table-footer/DataTableFooter.tsx
@@ -1,7 +1,7 @@
 import { useId } from "@radix-ui/react-id";
 import { forwardRef } from "react";
 
-import { type BoxProps } from "../box";
+import { Box, type BoxProps } from "../box";
 import { useDataTableContext } from "../data-table-context";
 import { Flex } from "../flex";
 import { Pagination } from "../pagination";
@@ -10,6 +10,7 @@ import { SelectContent } from "../select-content";
 import { SelectRadioItem } from "../select-radio-item";
 import { SelectTrigger } from "../select-trigger";
 import { Text } from "../text";
+import * as styles from "./DataTableFooter.css";
 
 type DataTableFooterProps = BoxProps<
   "div",
@@ -40,9 +41,9 @@ export const DataTableFooter = forwardRef<HTMLDivElement, DataTableFooterProps>(
         ref={ref}
         {...props}
       >
-        <Flex flexDirection="row" gap="8">
+        <Box {...styles.addon({ position: "start" })}>
           {showPageSizeOptions && (
-            <>
+            <Flex flexDirection="row" gap="8">
               <Text color="fg.secondary" id={pageSizeId}>
                 Page Size
               </Text>
@@ -66,9 +67,9 @@ export const DataTableFooter = forwardRef<HTMLDivElement, DataTableFooterProps>(
                   ))}
                 </SelectContent>
               </Select>
-            </>
+            </Flex>
           )}
-        </Flex>
+        </Box>
 
         {table.getPageCount() > 1 && (
           <Pagination
@@ -78,7 +79,7 @@ export const DataTableFooter = forwardRef<HTMLDivElement, DataTableFooterProps>(
           />
         )}
 
-        <Text>
+        <Text {...styles.addon({ position: "end" })}>
           {table.getRowCount() > 0 && (
             <>
               {pagination.pageIndex * pagination.pageSize + 1} -{" "}

--- a/packages/react/src/disclosure-content/DisclosureContent.tsx
+++ b/packages/react/src/disclosure-content/DisclosureContent.tsx
@@ -47,7 +47,7 @@ export const DisclosureContent = forwardRef<
         <Box {...styles.outer()}>
           <Box asChild {...styles.inner()}>
             <RadixCollapsible.Content forceMount>
-              <Box p="8" ref={ref} {...props}>
+              <Box pb="8" pt="4" ref={ref} {...props}>
                 {children}
               </Box>
             </RadixCollapsible.Content>

--- a/packages/react/src/disclosure-trigger/DisclosureTrigger.css.ts
+++ b/packages/react/src/disclosure-trigger/DisclosureTrigger.css.ts
@@ -7,9 +7,8 @@ export const root = recipe({
     {
       flexDirection: "row",
       fontSize: "md",
-      fontWeight: "500",
       gap: "8",
-      p: "8",
+      py: "8",
       transition: "colors",
     },
     style({

--- a/packages/react/src/spotlight-trigger/SpotlightTrigger.tsx
+++ b/packages/react/src/spotlight-trigger/SpotlightTrigger.tsx
@@ -20,18 +20,13 @@ const DEFAULT_HOTKEY = "mod+K";
 export const SpotlightTrigger = forwardRef<
   HTMLButtonElement,
   SpotlightTriggerProps
->(({ addonAfter, children, hotkey = DEFAULT_HOTKEY, ...props }, ref) => {
+>(({ children, hotkey = DEFAULT_HOTKEY, ...props }, ref) => {
   const { open, setOpen } = useSpotlightContext("SpotlightTrigger");
 
   useHotkeys([[hotkey, () => setOpen(!open)]]);
 
   return (
-    <DialogTrigger
-      addonAfter={addonAfter}
-      icon={<IconMagnifyingGlass />}
-      ref={ref}
-      {...props}
-    >
+    <DialogTrigger icon={<IconMagnifyingGlass />} ref={ref} {...props}>
       <Box color="fg.tertiary">{children}</Box>
     </DialogTrigger>
   );


### PR DESCRIPTION
by only using `justifyContent` to align icon and label in button

so consumers can easily override it by passing their own `justifyContent` and allowing them more manual control/flexibility around alignment of addons