### PR TITLE
rely on popper to detect when content is "placed"

### DIFF
--- a/packages/react/src/select-content/SelectContent.tsx
+++ b/packages/react/src/select-content/SelectContent.tsx
@@ -53,7 +53,11 @@ export const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>(
 
     return (
       <TransitionGroup
-        onPresenceChange={setPlaced}
+        onPresenceChange={(presence) => {
+          if (!presence) {
+            setPlaced(presence);
+          }
+        }}
         open={isOpen}
         presence={placed}
       >
@@ -71,7 +75,12 @@ export const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>(
                 { suppressRefError: !placed },
               )}
             >
-              <PopperContent align={align} side={side} sideOffset={5}>
+              <PopperContent
+                align={align}
+                onPlaced={() => setPlaced(true)}
+                side={side}
+                sideOffset={5}
+              >
                 {loading ? (
                   <Box display="flex" justifyContent="center" p="16">
                     <Spinner />

--- a/packages/react/src/transition-group/TransitionGroup.tsx
+++ b/packages/react/src/transition-group/TransitionGroup.tsx
@@ -39,9 +39,7 @@ export function TransitionGroup({
   });
   useEffect(() => {
     if (open) {
-      if (transitions.length > 0) {
-        requestAnimationFrame(() => setPresence(true));
-      }
+      requestAnimationFrame(() => setPresence(true));
     } else {
       if (transitions.length) {
         void Promise.allSettled(


### PR DESCRIPTION
as TransitionGroup has no knowledge of how popper positions the content