### PR TITLE
display fixed weeks and outside days for date range picker

### DIFF
--- a/.changeset/curly-yaks-look.md
+++ b/.changeset/curly-yaks-look.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+display fixed weeks and outside days for date range picker

--- a/packages/react/src/calendar/Calendar.tsx
+++ b/packages/react/src/calendar/Calendar.tsx
@@ -175,6 +175,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
             ...(min ? [{ before: min }] : []),
             ...(max ? [{ after: max }] : []),
           ]}
+          fixedWeeks={mode === "range"}
           mode={mode as "single"}
           modifiers={{ holiday, weekend }}
           numberOfMonths={mode === "range" ? numberOfMonths : 1}
@@ -187,6 +188,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
           }}
           required
           selected={value as Date | undefined}
+          showOutsideDays={mode === "range"}
           today={today}
         />
         {type === "datetime-local" && mode == "single" && (

--- a/packages/react/src/calendar/CalendarDayButton.css.ts
+++ b/packages/react/src/calendar/CalendarDayButton.css.ts
@@ -9,7 +9,6 @@ export const button = recipe({
     {
       color: "fg.default",
       fontSize: "md",
-      mt: "2",
       size: "md",
       transition: "colors",
     },
@@ -50,7 +49,7 @@ export const button = recipe({
           outlineOffset: "1px",
           zIndex: "10",
         },
-        "&[disabled]": {
+        "&:is([data-disabled], [disabled])": {
           opacity: 0.32,
         },
       },

--- a/packages/react/src/calendar/CalendarDayButton.tsx
+++ b/packages/react/src/calendar/CalendarDayButton.tsx
@@ -24,6 +24,7 @@ export function CalendarDayButton({
   return (
     <Box
       asChild
+      data-disabled={modifiers.outside || props.disabled}
       {...styles.button(
         {
           appearance: modifiers.range_middle
@@ -36,7 +37,7 @@ export function CalendarDayButton({
                   ? "weekend"
                   : "default",
           range:
-            modifiers.range_start && modifiers.range_end
+            modifiers.outside || (modifiers.range_start && modifiers.range_end)
               ? undefined
               : modifiers.range_start
                 ? "start"

--- a/packages/react/src/calendar/CalendarWeek.tsx
+++ b/packages/react/src/calendar/CalendarWeek.tsx
@@ -8,7 +8,7 @@ type CalendarWeekProps = ComponentPropsWithoutRef<typeof Week>;
 
 export function CalendarWeek({ children, ...props }: CalendarWeekProps) {
   return (
-    <Box asChild display="flex" gap="2">
+    <Box asChild display="flex" gap="2" mt="2">
       <Week {...props}>{children}</Week>
     </Box>
   );

--- a/packages/react/src/date-range-picker-content/DateRangePickerContent.css.ts
+++ b/packages/react/src/date-range-picker-content/DateRangePickerContent.css.ts
@@ -1,4 +1,4 @@
-import { recipe, style } from "../vanilla-extract";
+import { recipe } from "../vanilla-extract";
 
 export const panels = recipe({
   base: [
@@ -7,8 +7,5 @@ export const panels = recipe({
       flexDirection: "row",
       gap: "0",
     },
-    style({
-      maxHeight: 304,
-    }),
   ],
 });

--- a/packages/react/src/date-range-picker-content/DateRangePickerContent.tsx
+++ b/packages/react/src/date-range-picker-content/DateRangePickerContent.tsx
@@ -69,6 +69,7 @@ export const DateRangePickerContent = forwardRef<
         <Flex {...styles.panels()}>
           {addonBefore}
           <Calendar
+            alignSelf="start"
             holiday={holiday}
             max={max}
             min={min}


### PR DESCRIPTION
to prevent layout shift as users navigate between months

resolves #895