### PR TITLE
fix regular cell width compared to fill cell

### DIFF
--- a/.changeset/curvy-parks-wear.md
+++ b/.changeset/curvy-parks-wear.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+fix regular cell width compared to fill cell

--- a/packages/react/src/data-table-body/DataTableBody.css.ts
+++ b/packages/react/src/data-table-body/DataTableBody.css.ts
@@ -132,6 +132,7 @@ export const cell = recipe({
       display: "flex",
     },
     style({
+      flexGrow: "999",
       width: cellSizeVar,
     }),
   ],


### PR DESCRIPTION
so regular cell will always take the lion's share of available space rather than equally sharing space with the fill cell at the end of the row

this also has the added benefit of growing cells to fill up larger tables in proportion to the specified sizes for each cell