### PR TITLE
do not reset highlight when mouse leaves menu

### DIFF
--- a/.changeset/rotten-clouds-punch.md
+++ b/.changeset/rotten-clouds-punch.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+do not reset highlight when mouse leaves menu

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -131,9 +131,12 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
       itemToKey: (item) => (item !== null ? item.value : item),
       itemToString: (item) => (item !== null ? item.label : ""),
       onHighlightedIndexChange(changes) {
+        if (changes.type === useSelect.stateChangeTypes.MenuMouseLeave) {
+          return;
+        }
+
         if (
-          ((changes.type === useSelect.stateChangeTypes.ItemMouseMove ||
-            changes.type === useSelect.stateChangeTypes.MenuMouseLeave) &&
+          (changes.type === useSelect.stateChangeTypes.ItemMouseMove &&
             isOpen) ||
           changes.isOpen
         ) {


### PR DESCRIPTION
otherwise it is very bad UX as lists with long scroll will keep resetting to the top and just disorient users