### PR TITLE
Revert "Support truncation in `Breadcrumb` items"

### DIFF
--- a/apps/storybook/src/components/Breadcrumb.stories.tsx
+++ b/apps/storybook/src/components/Breadcrumb.stories.tsx
@@ -99,25 +99,3 @@ export const WithDropdown: Story = {
     ),
   },
 };
-
-export const Truncated: Story = {
-  args: {
-    children: (
-      <>
-        <BreadcrumbItem>
-          <BreadcrumbLink href="/">
-            This is a home page breadcrumb
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbItem>
-          <BreadcrumbLink href="/components">
-            This is a component page breadcrumb
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbItem>
-          <BreadcrumbPage>This is a page of breadcrumb</BreadcrumbPage>
-        </BreadcrumbItem>
-      </>
-    ),
-  },
-};

--- a/packages/react/src/breadcrumb/BreadcrumbItem.css.ts
+++ b/packages/react/src/breadcrumb/BreadcrumbItem.css.ts
@@ -9,8 +9,6 @@ export const item = recipe({
       display: "inline-flex",
     },
     style({
-      maxWidth: "160px",
-
       selectors: {
         "&:not(:first-child)::before": {
           color: theme.colors["fg.tertiary"],

--- a/packages/react/src/breadcrumb/BreadcrumbLink.css.ts
+++ b/packages/react/src/breadcrumb/BreadcrumbLink.css.ts
@@ -5,14 +5,14 @@ import { recipe, style } from "../vanilla-extract";
 export const link = recipe({
   base: [
     {
+      alignItems: "center",
+      display: "flex",
       fontSize: "md",
-      overflow: "hidden",
+      h: "md",
       rounded: "md",
     },
     style({
       color: theme.colors["fg.tertiary"],
-      textOverflow: "ellipsis",
-      whiteSpace: "nowrap",
 
       "@media": {
         "(hover: hover)": {

--- a/packages/react/src/breadcrumb/BreadcrumbLink.css.ts
+++ b/packages/react/src/breadcrumb/BreadcrumbLink.css.ts
@@ -5,11 +5,7 @@ import { recipe, style } from "../vanilla-extract";
 export const link = recipe({
   base: [
     {
-      alignItems: "center",
-      display: "flex",
       fontSize: "md",
-      h: "md",
-      rounded: "md",
     },
     style({
       color: theme.colors["fg.tertiary"],

--- a/packages/react/src/breadcrumb/BreadcrumbLink.tsx
+++ b/packages/react/src/breadcrumb/BreadcrumbLink.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 
-import { type BoxProps } from "../box";
+import type { BoxProps } from "../box";
+
 import { Link } from "../link";
-import { Tooltip } from "../tooltip";
 import * as styles from "./BreadcrumbLink.css";
 
 export type BreadcrumbLinkProps = BoxProps<typeof Link>;
@@ -11,10 +11,6 @@ export const BreadcrumbLink = forwardRef<
   HTMLAnchorElement,
   BreadcrumbLinkProps
 >(({ className, ...props }, ref) => {
-  return (
-    <Tooltip auto content={props.children}>
-      <Link {...styles.link({}, className)} ref={ref} {...props} />
-    </Tooltip>
-  );
+  return <Link {...styles.link({}, className)} ref={ref} {...props} />;
 });
 BreadcrumbLink.displayName = "@optiaxiom/react/BreadcrumbLink";

--- a/packages/react/src/breadcrumb/BreadcrumbPage.tsx
+++ b/packages/react/src/breadcrumb/BreadcrumbPage.tsx
@@ -1,24 +1,14 @@
 import { forwardRef } from "react";
 
-import { type BoxProps } from "../box";
-import { Text } from "../text";
-import { Tooltip } from "../tooltip";
+import { Box, type BoxProps } from "../box";
 
 export type BreadcrumbPageProps = BoxProps<"span">;
 export const BreadcrumbPage = forwardRef<HTMLSpanElement, BreadcrumbPageProps>(
   ({ ...props }, ref) => {
     return (
-      <Tooltip auto content={props.children}>
-        <Text
-          aria-current="page"
-          asChild
-          color="fg.default"
-          fontSize="md"
-          truncate
-        >
-          <span ref={ref} {...props} />
-        </Text>
-      </Tooltip>
+      <Box aria-current="page" asChild color="fg.default" fontSize="md">
+        <span ref={ref} {...props} />
+      </Box>
     );
   },
 );


### PR DESCRIPTION
We need to handle truncation in end consumers.