### PR TITLE
fix downshift web-components exports

### DIFF
--- a/.changeset/tasty-cars-win.md
+++ b/.changeset/tasty-cars-win.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/web-components": patch
+"@optiaxiom/react": patch
+---
+
+fix downshift web-components exports

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -172,6 +172,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     /**
      * Dummy calls to suppress warning from downshift
      */
+    downshift.getToggleButtonProps({}, { suppressRefError: true });
     downshift.getMenuProps({}, { suppressRefError: true });
 
     return (

--- a/packages/web-components/rollup.config.mjs
+++ b/packages/web-components/rollup.config.mjs
@@ -92,8 +92,25 @@ export default defineConfig([
             ) +
             "\n" +
             code.slice(code.indexOf("var dropdownDefaultStateValues = {"))
-          ).replace("Downshift as default,", "");
+          )
+            .replace("Downshift as default,", "")
+            .replace("import { isForwardRef } from 'react-is';", "")
+            .replace(
+              /var (propTypes|commonPropTypes|commonDropdownPropTypes|propTypes\$\d)([^;]|\s)+;/g,
+              "var $1 = _extends({})",
+            )
+            .replace(/PropTypes.checkPropTypes[^;]+;/g, "");
         },
+      },
+      {
+        load(id) {
+          if (!id.includes("prop-types")) {
+            return null;
+          }
+
+          return "export default {}";
+        },
+        name: "prop-types",
       },
       {
         name: "radix-collection:document-querySelectorAll",


### PR DESCRIPTION
need to remove the prop-types package and usages

and also suppress warnings about not calling getToggleButtonProps