### PR TITLE
gracefully handle rendering inside shadow DOM

### DIFF
--- a/.changeset/deep-rabbits-exist.md
+++ b/.changeset/deep-rabbits-exist.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+gracefully handle rendering inside shadow DOM

--- a/packages/react/src/alert-dialog/AlertDialogContent.tsx
+++ b/packages/react/src/alert-dialog/AlertDialogContent.tsx
@@ -10,6 +10,7 @@ import { Box, type BoxProps } from "../box";
 import { Flex } from "../flex";
 import { ModalProvider } from "../modal";
 import { Paper } from "../paper";
+import { Portal } from "../portal";
 import { Transition, TransitionGroup } from "../transition";
 import * as styles from "./AlertDialogContent.css";
 import { useAlertDialogContext } from "./AlertDialogContext";
@@ -35,7 +36,7 @@ export const AlertDialogContent = forwardRef<
       open={open}
       presence={presence}
     >
-      <RadixAlertDialog.Portal forceMount>
+      <Portal>
         <Transition>
           <Backdrop
             asChild
@@ -69,7 +70,7 @@ export const AlertDialogContent = forwardRef<
           <Box flex="1" pointerEvents="none" />
           <Box flex="1" pointerEvents="none" />
         </Flex>
-      </RadixAlertDialog.Portal>
+      </Portal>
     </TransitionGroup>
   );
 });

--- a/packages/react/src/dialog/DialogContent.tsx
+++ b/packages/react/src/dialog/DialogContent.tsx
@@ -7,6 +7,7 @@ import { Backdrop } from "../backdrop";
 import { type BoxProps } from "../box";
 import { ModalProvider } from "../modal";
 import { Paper } from "../paper";
+import { Portal } from "../portal";
 import { Transition, TransitionGroup } from "../transition";
 import { type ExcludeProps, onReactSelectInputBlur } from "../utils";
 import * as styles from "./DialogContent.css";
@@ -43,7 +44,7 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
 
     return (
       <TransitionGroup open={open}>
-        <RadixDialog.Portal forceMount>
+        <Portal>
           <Transition>
             <Backdrop
               asChild
@@ -72,7 +73,7 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
               </RadixDialog.Content>
             </Paper>
           </Transition>
-        </RadixDialog.Portal>
+        </Portal>
       </TransitionGroup>
     );
   },

--- a/packages/react/src/dropdown-menu/DropdownMenuContent.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuContent.tsx
@@ -5,6 +5,7 @@ import type { ExcludeProps } from "../utils";
 
 import { Box, type BoxProps } from "../box";
 import { ModalListbox } from "../modal/internals";
+import { Portal } from "../portal";
 import { Spinner } from "../spinner";
 import { TransitionGroup } from "../transition";
 import { useDropdownMenuContext } from "./DropdownMenuContext";
@@ -46,7 +47,7 @@ export const DropdownMenuContent = forwardRef<
       open={open}
       presence={presence}
     >
-      <RadixMenu.Portal forceMount>
+      <Portal asChild>
         <ModalListbox
           asChild
           minW={loading ? "trigger" : undefined}
@@ -72,7 +73,7 @@ export const DropdownMenuContent = forwardRef<
             )}
           </RadixMenu.Content>
         </ModalListbox>
-      </RadixMenu.Portal>
+      </Portal>
     </TransitionGroup>
   );
 });

--- a/packages/react/src/dropdown-menu/DropdownMenuSubContent.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuSubContent.tsx
@@ -5,6 +5,7 @@ import type { BoxProps } from "../box";
 import type { ExcludeProps } from "../utils";
 
 import { ModalListbox } from "../modal/internals";
+import { Portal } from "../portal";
 import { TransitionGroup } from "../transition";
 import { useDropdownMenuSubContext } from "./DropdownMenuSubContext";
 
@@ -36,7 +37,7 @@ export const DropdownMenuSubContent = forwardRef<
 
   return (
     <TransitionGroup onPresenceChange={setPresence} open={open}>
-      <RadixMenu.Portal forceMount>
+      <Portal asChild>
         <ModalListbox
           asChild
           minW="trigger"
@@ -52,7 +53,7 @@ export const DropdownMenuSubContent = forwardRef<
             {children}
           </RadixMenu.SubContent>
         </ModalListbox>
-      </RadixMenu.Portal>
+      </Portal>
     </TransitionGroup>
   );
 });

--- a/packages/react/src/popover/PopoverContent.tsx
+++ b/packages/react/src/popover/PopoverContent.tsx
@@ -7,6 +7,7 @@ import type { BoxProps } from "../box";
 
 import { ModalProvider } from "../modal";
 import { ModalListbox } from "../modal/internals";
+import { Portal } from "../portal";
 import { TransitionGroup } from "../transition";
 import { type ExcludeProps, onReactSelectInputBlur } from "../utils";
 import { usePopoverContext } from "./PopoverContext";
@@ -49,7 +50,7 @@ export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>(
         open={open}
         presence={presence}
       >
-        <RadixPopover.Portal forceMount>
+        <Portal asChild>
           <ModalListbox
             asChild
             onBlur={onReactSelectInputBlur}
@@ -86,7 +87,7 @@ export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>(
               )}
             </RadixPopover.Content>
           </ModalListbox>
-        </RadixPopover.Portal>
+        </Portal>
       </TransitionGroup>
     );
   },

--- a/packages/react/src/portal/Portal.tsx
+++ b/packages/react/src/portal/Portal.tsx
@@ -1,0 +1,20 @@
+import * as RadixPortal from "@radix-ui/react-portal";
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
+
+import { usePortalContext } from "./PortalContext";
+
+type PortalProps = ComponentPropsWithoutRef<typeof RadixPortal.Root>;
+
+export const Portal = forwardRef<HTMLDivElement, PortalProps>(
+  ({ children, ...props }, ref) => {
+    const { container } = usePortalContext("@optiaxiom/react/Portal");
+
+    return (
+      <RadixPortal.Root container={container} ref={ref} {...props}>
+        {children}
+      </RadixPortal.Root>
+    );
+  },
+);
+
+Portal.displayName = "@optiaxiom/react/Portal";

--- a/packages/react/src/portal/PortalContext.ts
+++ b/packages/react/src/portal/PortalContext.ts
@@ -1,0 +1,7 @@
+"use client";
+
+import { createContext } from "@radix-ui/react-context";
+
+export const [PortalProvider, usePortalContext] = createContext<{
+  container: ShadowRoot | undefined;
+}>("@optiaxiom/react/Portal");

--- a/packages/react/src/portal/index.ts
+++ b/packages/react/src/portal/index.ts
@@ -1,0 +1,1 @@
+export * from "./Portal";

--- a/packages/react/src/portal/internals.ts
+++ b/packages/react/src/portal/internals.ts
@@ -1,0 +1,1 @@
+export * from "./PortalContext";

--- a/packages/react/src/select/SelectContent.tsx
+++ b/packages/react/src/select/SelectContent.tsx
@@ -1,5 +1,4 @@
 import { PopperContent } from "@radix-ui/react-popper";
-import { Portal } from "@radix-ui/react-portal";
 import {
   type ComponentPropsWithoutRef,
   forwardRef,
@@ -13,6 +12,7 @@ import { type BoxProps } from "../box";
 import { ListboxItemized, ListboxLabel, ListboxSeparator } from "../listbox";
 import { ModalLayer } from "../modal";
 import { ModalListbox } from "../modal/internals";
+import { Portal } from "../portal";
 import { TransitionGroup } from "../transition";
 import {
   type Group,

--- a/packages/react/src/toast/ToastProvider.tsx
+++ b/packages/react/src/toast/ToastProvider.tsx
@@ -1,7 +1,6 @@
 import { ToastProviderProvider } from "@optiaxiom/globals";
 import { type createToaster, toaster } from "@optiaxiom/globals";
 import { useComposedRefs } from "@radix-ui/react-compose-refs";
-import { Portal } from "@radix-ui/react-portal";
 import * as RadixToast from "@radix-ui/react-toast";
 import {
   type ComponentPropsWithoutRef,
@@ -13,6 +12,7 @@ import { useSyncExternalStore } from "use-sync-external-store/shim";
 
 import { type BoxProps, extractBoxProps } from "../box";
 import { Flex } from "../flex";
+import { Portal } from "../portal";
 import { Toast } from "./Toast";
 import { ToastAction } from "./ToastAction";
 import * as styles from "./ToastProvider.css";
@@ -113,7 +113,7 @@ export const ToastProvider = forwardRef<HTMLOListElement, ToastProps>(
           </ToastProviderProvider>
         ))}
 
-        <Portal asChild container={container}>
+        <Portal asChild {...(container && { container })}>
           <Flex
             alignItems={
               position.endsWith("left")

--- a/packages/react/src/tooltip/Tooltip.spec.tsx
+++ b/packages/react/src/tooltip/Tooltip.spec.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { render, screen, waitForElementToBeRemoved } from "../../vitest.rtl";
+import { render, screen, waitFor } from "../../vitest.rtl";
 import { Tooltip } from "./Tooltip";
 
 describe("Tooltip component", () => {
@@ -37,8 +37,10 @@ describe("Tooltip component", () => {
     ).toBeInTheDocument();
 
     await user.click(screen.getByText("Outside Content"));
-    await waitForElementToBeRemoved(
-      screen.queryByRole("tooltip", { name: "Tooltip Content" }),
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("tooltip", { name: "Tooltip Content" }),
+      ).not.toBeInTheDocument(),
     );
   });
 });

--- a/packages/react/src/tooltip/TooltipContent.tsx
+++ b/packages/react/src/tooltip/TooltipContent.tsx
@@ -5,6 +5,7 @@ import { forwardRef } from "react";
 import type { ExcludeProps } from "../utils";
 
 import { Box, type BoxProps } from "../box";
+import { Portal } from "../portal";
 import { Text } from "../text";
 import { Transition, TransitionGroup } from "../transition";
 import * as styles from "./TooltipContent.css";
@@ -30,7 +31,7 @@ export const TooltipContent = forwardRef<HTMLDivElement, TooltipContentProps>(
 
     return (
       <TransitionGroup open={open}>
-        <RadixTooltip.Portal forceMount>
+        <Portal asChild>
           <Transition duration="sm" type="pop">
             <Box asChild {...styles.content({}, className)} {...props}>
               <RadixTooltip.Content
@@ -52,7 +53,7 @@ export const TooltipContent = forwardRef<HTMLDivElement, TooltipContentProps>(
               </RadixTooltip.Content>
             </Box>
           </Transition>
-        </RadixTooltip.Portal>
+        </Portal>
       </TransitionGroup>
     );
   },

--- a/packages/react/vitest.rtl.ts
+++ b/packages/react/vitest.rtl.ts
@@ -25,5 +25,5 @@ const customRender = (...args: Parameters<typeof render>) => ({
  * "@testing-library/react" to overwrite our custom render.
  * So we explicitly list out the re-exported modules.
  */
-export { screen, waitForElementToBeRemoved } from "@testing-library/react";
+export { screen, waitFor } from "@testing-library/react";
 export { customRender as render };


### PR DESCRIPTION
- switch theme provider selector to host instead of root
- use shadow root as the portal container instead of document.body