### PR TITLE
enforce exporting prop types using eslint rule

### DIFF
--- a/packages/react/src/actions/ActionsContent.tsx
+++ b/packages/react/src/actions/ActionsContent.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./ActionsContent.css";
 
-type ActionsContentProps = BoxProps<"div", styles.ContentVariants>;
+export type ActionsContentProps = BoxProps<"div", styles.ContentVariants>;
 
 export const ActionsContent = forwardRef<HTMLDivElement, ActionsContentProps>(
   ({ children, className, visible = false, ...props }, ref) => {

--- a/packages/react/src/actions/ActionsRoot.tsx
+++ b/packages/react/src/actions/ActionsRoot.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./ActionsRoot.css";
 
-type ActionsRootProps = BoxProps<"div">;
+export type ActionsRootProps = BoxProps<"div">;
 
 export const ActionsRoot = forwardRef<HTMLDivElement, ActionsRootProps>(
   ({ children, className, ...props }, ref) => {

--- a/packages/react/src/alert-dialog/AlertDialog.tsx
+++ b/packages/react/src/alert-dialog/AlertDialog.tsx
@@ -8,7 +8,7 @@ import {
 } from "../nested-dialog-context";
 import { AlertDialogProvider } from "./AlertDialogContext";
 
-type AlertDialogProps = {
+export type AlertDialogProps = {
   children?: React.ReactNode;
   /**
    * The initial open state in uncontrolled mode.

--- a/packages/react/src/alert-dialog/AlertDialogAction.tsx
+++ b/packages/react/src/alert-dialog/AlertDialogAction.tsx
@@ -3,7 +3,9 @@ import { forwardRef } from "react";
 
 import { Button, type ButtonProps } from "../button";
 
-type AlertDialogActionProps = ButtonProps<typeof RadixAlertDialog.Action>;
+export type AlertDialogActionProps = ButtonProps<
+  typeof RadixAlertDialog.Action
+>;
 
 export const AlertDialogAction = forwardRef<
   HTMLButtonElement,

--- a/packages/react/src/alert-dialog/AlertDialogBody.tsx
+++ b/packages/react/src/alert-dialog/AlertDialogBody.tsx
@@ -4,7 +4,9 @@ import { forwardRef } from "react";
 import { type BoxProps } from "../box";
 import { Flex } from "../flex";
 
-type AlertDialogBodyProps = BoxProps<typeof RadixAlertDialog.Description>;
+export type AlertDialogBodyProps = BoxProps<
+  typeof RadixAlertDialog.Description
+>;
 
 export const AlertDialogBody = forwardRef<HTMLDivElement, AlertDialogBodyProps>(
   ({ children, ...props }, ref) => (

--- a/packages/react/src/alert-dialog/AlertDialogCancel.tsx
+++ b/packages/react/src/alert-dialog/AlertDialogCancel.tsx
@@ -3,7 +3,9 @@ import { forwardRef } from "react";
 
 import { Button, type ButtonProps } from "../button";
 
-type AlertDialogCancelProps = ButtonProps<typeof RadixAlertDialog.Cancel>;
+export type AlertDialogCancelProps = ButtonProps<
+  typeof RadixAlertDialog.Cancel
+>;
 
 export const AlertDialogCancel = forwardRef<
   HTMLButtonElement,

--- a/packages/react/src/alert-dialog/AlertDialogContent.tsx
+++ b/packages/react/src/alert-dialog/AlertDialogContent.tsx
@@ -15,7 +15,7 @@ import { Transition, TransitionGroup } from "../transition";
 import * as styles from "./AlertDialogContent.css";
 import { useAlertDialogContext } from "./AlertDialogContext";
 
-type AlertDialogContentProps = ExcludeProps<
+export type AlertDialogContentProps = ExcludeProps<
   BoxProps<typeof RadixAlertDialog.Content, styles.DialogVariants>,
   "forceMount"
 >;

--- a/packages/react/src/alert-dialog/AlertDialogFooter.tsx
+++ b/packages/react/src/alert-dialog/AlertDialogFooter.tsx
@@ -4,7 +4,7 @@ import { ButtonProvider } from "../button/internals";
 import { Flex } from "../flex";
 import * as styles from "./AlertDialogFooter.css";
 
-type AlertDialogFooterProps = ComponentPropsWithRef<typeof Flex>;
+export type AlertDialogFooterProps = ComponentPropsWithRef<typeof Flex>;
 
 export const AlertDialogFooter = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/alert-dialog/AlertDialogHeader.tsx
+++ b/packages/react/src/alert-dialog/AlertDialogHeader.tsx
@@ -9,7 +9,7 @@ import { Icon } from "../icon";
 import { IconTriangleExclamationSolid } from "../icons/IconTriangleExclamationSolid";
 import { fallbackSpan } from "../utils";
 
-type AlertDialogHeaderProps = BoxProps<
+export type AlertDialogHeaderProps = BoxProps<
   "div",
   {
     /**

--- a/packages/react/src/alert-dialog/AlertDialogTrigger.tsx
+++ b/packages/react/src/alert-dialog/AlertDialogTrigger.tsx
@@ -3,7 +3,9 @@ import { forwardRef } from "react";
 
 import { Button, type ButtonProps } from "../button";
 
-type AlertDialogTriggerProps = ButtonProps<typeof RadixAlertDialog.Trigger>;
+export type AlertDialogTriggerProps = ButtonProps<
+  typeof RadixAlertDialog.Trigger
+>;
 
 export const AlertDialogTrigger = forwardRef<
   HTMLButtonElement,

--- a/packages/react/src/alert/Alert.tsx
+++ b/packages/react/src/alert/Alert.tsx
@@ -12,7 +12,7 @@ import { IconTriangleExclamationSolid } from "../icons/IconTriangleExclamationSo
 import { IconX } from "../icons/IconX";
 import * as styles from "./Alert.css";
 
-type AlertProps = BoxProps<
+export type AlertProps = BoxProps<
   "div",
   styles.AlertVariants & {
     /**

--- a/packages/react/src/angle-menu-button/AngleMenuButton.tsx
+++ b/packages/react/src/angle-menu-button/AngleMenuButton.tsx
@@ -3,7 +3,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { Button } from "../button";
 import { IconAngleDown } from "../icons/IconAngleDown";
 
-type AngleMenuButtonProps = ComponentPropsWithoutRef<typeof Button>;
+export type AngleMenuButtonProps = ComponentPropsWithoutRef<typeof Button>;
 
 export const AngleMenuButton = forwardRef<
   HTMLButtonElement,

--- a/packages/react/src/avatar/Avatar.tsx
+++ b/packages/react/src/avatar/Avatar.tsx
@@ -7,7 +7,7 @@ import { IconUsersSolid } from "../icons/IconUsersSolid";
 import * as styles from "./Avatar.css";
 import { useAvatarContext } from "./AvatarContext";
 
-type AvatarProps = BoxProps<
+export type AvatarProps = BoxProps<
   "span",
   styles.AvatarVariants & {
     /**

--- a/packages/react/src/avatar/AvatarGroup.tsx
+++ b/packages/react/src/avatar/AvatarGroup.tsx
@@ -5,7 +5,7 @@ import { Avatar } from "./Avatar";
 import { AvatarProvider } from "./AvatarContext";
 import * as styles from "./AvatarGroup.css";
 
-type AvatarGroupProps = BoxProps<
+export type AvatarGroupProps = BoxProps<
   "div",
   {
     /**

--- a/packages/react/src/axiom-provider/AxiomProvider.tsx
+++ b/packages/react/src/axiom-provider/AxiomProvider.tsx
@@ -10,7 +10,7 @@ import { ThemeProvider } from "../theme-provider";
 import { ToastProvider } from "../toast";
 import { TooltipProvider } from "../tooltip";
 
-type AxiomProviderProps = {
+export type AxiomProviderProps = {
   children?: ReactNode;
   /**
    * Props for the `ToastProvider` component

--- a/packages/react/src/backdrop/Backdrop.tsx
+++ b/packages/react/src/backdrop/Backdrop.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./Backdrop.css";
 
-type BackdropProps = BoxProps;
+export type BackdropProps = BoxProps;
 
 export const Backdrop = forwardRef<HTMLDivElement, BackdropProps>(
   ({ className, ...props }, ref) => (

--- a/packages/react/src/badge/Badge.tsx
+++ b/packages/react/src/badge/Badge.tsx
@@ -6,7 +6,7 @@ import * as styles from "./Badge.css";
 
 const Slot = createSlot("@optiaxiom/react/Badge");
 
-type BadgeProps = TextProps<"span", styles.BadgeVariants>;
+export type BadgeProps = TextProps<"span", styles.BadgeVariants>;
 
 export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
   (

--- a/packages/react/src/banner/Banner.tsx
+++ b/packages/react/src/banner/Banner.tsx
@@ -12,7 +12,7 @@ import { IconTriangleExclamationSolid } from "../icons/IconTriangleExclamationSo
 import { IconX } from "../icons/IconX";
 import * as styles from "./Banner.css";
 
-type BannerProps = BoxProps<
+export type BannerProps = BoxProps<
   "div",
   styles.BannerVariants & {
     /**

--- a/packages/react/src/button/ButtonAddon.tsx
+++ b/packages/react/src/button/ButtonAddon.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import { ButtonLoadable } from "./ButtonLoadable";
 
-type ButtonAddonProps = BoxProps<"div">;
+export type ButtonAddonProps = BoxProps<"div">;
 
 export const ButtonAddon = forwardRef<HTMLDivElement, ButtonAddonProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/button/ButtonGroup.tsx
+++ b/packages/react/src/button/ButtonGroup.tsx
@@ -5,7 +5,7 @@ import type { BoxProps } from "../box";
 import { Flex } from "../flex";
 import * as styles from "./ButtonGroup.css";
 
-type ButtonGroupProps = BoxProps<
+export type ButtonGroupProps = BoxProps<
   "div",
   {
     /**

--- a/packages/react/src/button/ButtonLabel.tsx
+++ b/packages/react/src/button/ButtonLabel.tsx
@@ -4,7 +4,7 @@ import { type BoxProps } from "../box";
 import { Flex } from "../flex";
 import { ButtonLoadable } from "./ButtonLoadable";
 
-type ButtonLabelProps = BoxProps<"div">;
+export type ButtonLabelProps = BoxProps<"div">;
 
 export const ButtonLabel = forwardRef<HTMLDivElement, ButtonLabelProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/button/ButtonLoadable.tsx
+++ b/packages/react/src/button/ButtonLoadable.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./ButtonLoadable.css";
 
-type ButtonLoadableProps = BoxProps<"div">;
+export type ButtonLoadableProps = BoxProps<"div">;
 
 export const ButtonLoadable = forwardRef<HTMLDivElement, ButtonLoadableProps>(
   ({ children, className, ...props }, ref) => {

--- a/packages/react/src/calendar/Calendar.tsx
+++ b/packages/react/src/calendar/Calendar.tsx
@@ -31,7 +31,7 @@ import { CalendarWeekday } from "./CalendarWeekday";
 import { CalendarWeekdays } from "./CalendarWeekdays";
 import { toTimeZoneName } from "./toTimeZoneName";
 
-type CalendarProps = BoxProps<
+export type CalendarProps = BoxProps<
   "div",
   Pick<
     ComponentPropsWithoutRef<typeof DayPicker>,

--- a/packages/react/src/calendar/CalendarChevron.tsx
+++ b/packages/react/src/calendar/CalendarChevron.tsx
@@ -5,7 +5,7 @@ import { Chevron } from "react-day-picker";
 import { IconAngleLeft } from "../icons/IconAngleLeft";
 import { IconAngleRight } from "../icons/IconAngleRight";
 
-type CalendarChevronProps = ComponentPropsWithoutRef<typeof Chevron>;
+export type CalendarChevronProps = ComponentPropsWithoutRef<typeof Chevron>;
 
 export function CalendarChevron({
   orientation,

--- a/packages/react/src/calendar/CalendarDay.tsx
+++ b/packages/react/src/calendar/CalendarDay.tsx
@@ -4,7 +4,7 @@ import { Day } from "react-day-picker";
 
 import { Box } from "../box";
 
-type CalendarDayProps = ComponentPropsWithoutRef<typeof Day>;
+export type CalendarDayProps = ComponentPropsWithoutRef<typeof Day>;
 
 export function CalendarDay({ children, ...props }: CalendarDayProps) {
   return (

--- a/packages/react/src/calendar/CalendarDayButton.tsx
+++ b/packages/react/src/calendar/CalendarDayButton.tsx
@@ -4,7 +4,7 @@ import { DayButton } from "react-day-picker";
 import { Box } from "../box";
 import * as styles from "./CalendarDayButton.css";
 
-type CalendarDayButtonProps = ComponentPropsWithoutRef<typeof DayButton>;
+export type CalendarDayButtonProps = ComponentPropsWithoutRef<typeof DayButton>;
 
 export function CalendarDayButton({
   children,

--- a/packages/react/src/calendar/CalendarMonthCaption.tsx
+++ b/packages/react/src/calendar/CalendarMonthCaption.tsx
@@ -4,7 +4,9 @@ import { MonthCaption } from "react-day-picker";
 
 import { Box } from "../box";
 
-type CalendarMonthCaptionProps = ComponentPropsWithoutRef<typeof MonthCaption>;
+export type CalendarMonthCaptionProps = ComponentPropsWithoutRef<
+  typeof MonthCaption
+>;
 
 export function CalendarMonthCaption({
   children,

--- a/packages/react/src/calendar/CalendarMonthGrid.tsx
+++ b/packages/react/src/calendar/CalendarMonthGrid.tsx
@@ -4,7 +4,7 @@ import { MonthGrid } from "react-day-picker";
 
 import { Box } from "../box";
 
-type CalendarMonthGridProps = ComponentPropsWithoutRef<typeof MonthGrid>;
+export type CalendarMonthGridProps = ComponentPropsWithoutRef<typeof MonthGrid>;
 
 export function CalendarMonthGrid({
   children,

--- a/packages/react/src/calendar/CalendarMonths.tsx
+++ b/packages/react/src/calendar/CalendarMonths.tsx
@@ -5,7 +5,7 @@ import { Months } from "react-day-picker";
 import { Flex } from "../flex";
 import * as styles from "./CalendarMonths.css";
 
-type CalendarMonthsProps = ComponentPropsWithoutRef<typeof Months>;
+export type CalendarMonthsProps = ComponentPropsWithoutRef<typeof Months>;
 
 export function CalendarMonths({ children, ...props }: CalendarMonthsProps) {
   return (

--- a/packages/react/src/calendar/CalendarNav.tsx
+++ b/packages/react/src/calendar/CalendarNav.tsx
@@ -5,7 +5,7 @@ import { Nav } from "react-day-picker";
 import { Box } from "../box";
 import * as styles from "./CalendarNav.css";
 
-type CalendarNavProps = ComponentPropsWithoutRef<typeof Nav>;
+export type CalendarNavProps = ComponentPropsWithoutRef<typeof Nav>;
 
 export function CalendarNav({ children, ...props }: CalendarNavProps) {
   return (

--- a/packages/react/src/calendar/CalendarNextMonthButton.tsx
+++ b/packages/react/src/calendar/CalendarNextMonthButton.tsx
@@ -4,7 +4,7 @@ import { NextMonthButton } from "react-day-picker";
 
 import { Button } from "../button";
 
-type CalendarNextMonthButtonProps = ComponentPropsWithoutRef<
+export type CalendarNextMonthButtonProps = ComponentPropsWithoutRef<
   typeof NextMonthButton
 >;
 

--- a/packages/react/src/calendar/CalendarPreviousMonthButton.tsx
+++ b/packages/react/src/calendar/CalendarPreviousMonthButton.tsx
@@ -4,7 +4,7 @@ import { PreviousMonthButton } from "react-day-picker";
 
 import { Button } from "../button";
 
-type CalendarPreviousMonthButtonProps = ComponentPropsWithoutRef<
+export type CalendarPreviousMonthButtonProps = ComponentPropsWithoutRef<
   typeof PreviousMonthButton
 >;
 

--- a/packages/react/src/calendar/CalendarWeek.tsx
+++ b/packages/react/src/calendar/CalendarWeek.tsx
@@ -4,7 +4,7 @@ import { Week } from "react-day-picker";
 
 import { Box } from "../box";
 
-type CalendarWeekProps = ComponentPropsWithoutRef<typeof Week>;
+export type CalendarWeekProps = ComponentPropsWithoutRef<typeof Week>;
 
 export function CalendarWeek({ children, ...props }: CalendarWeekProps) {
   return (

--- a/packages/react/src/calendar/CalendarWeekday.tsx
+++ b/packages/react/src/calendar/CalendarWeekday.tsx
@@ -4,7 +4,7 @@ import { Weekday } from "react-day-picker";
 
 import { Box } from "../box";
 
-type CalendarWeekdayProps = ComponentPropsWithoutRef<typeof Weekday>;
+export type CalendarWeekdayProps = ComponentPropsWithoutRef<typeof Weekday>;
 
 export function CalendarWeekday({ children, ...props }: CalendarWeekdayProps) {
   return (

--- a/packages/react/src/calendar/CalendarWeekdays.tsx
+++ b/packages/react/src/calendar/CalendarWeekdays.tsx
@@ -4,7 +4,7 @@ import { Weekdays } from "react-day-picker";
 
 import { Box } from "../box";
 
-type CalendarWeekdaysProps = ComponentPropsWithoutRef<typeof Weekdays>;
+export type CalendarWeekdaysProps = ComponentPropsWithoutRef<typeof Weekdays>;
 
 export function CalendarWeekdays({
   children,

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -7,7 +7,7 @@ import { Flex } from "../flex";
 import * as styles from "./Card.css";
 import { CardProvider } from "./CardContext";
 
-type CardProps = BoxProps<
+export type CardProps = BoxProps<
   "div",
   {
     /**

--- a/packages/react/src/card/CardAction.tsx
+++ b/packages/react/src/card/CardAction.tsx
@@ -4,7 +4,7 @@ import { ActionsContent } from "../actions";
 import { type BoxProps } from "../box";
 import * as styles from "./CardAction.css";
 
-type CardActionProps = BoxProps<"div">;
+export type CardActionProps = BoxProps<"div">;
 
 export const CardAction = forwardRef<HTMLDivElement, CardActionProps>(
   ({ children, className, ...props }, ref) => {

--- a/packages/react/src/card/CardCheckbox.tsx
+++ b/packages/react/src/card/CardCheckbox.tsx
@@ -12,7 +12,7 @@ import { CheckboxRoot } from "../checkbox/CheckboxRoot";
 import { VisuallyHidden } from "../visually-hidden";
 import { useCardContext } from "./CardContext";
 
-type CardCheckboxProps = ExcludeProps<
+export type CardCheckboxProps = ExcludeProps<
   ComponentPropsWithoutRef<typeof Checkbox>,
   "description"
 >;

--- a/packages/react/src/card/CardContent.tsx
+++ b/packages/react/src/card/CardContent.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { type BoxProps } from "../box";
 import { Flex } from "../flex";
 
-type CardContentProps = BoxProps<"div">;
+export type CardContentProps = BoxProps<"div">;
 
 export const CardContent = forwardRef<HTMLDivElement, CardContentProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/card/CardDescription.tsx
+++ b/packages/react/src/card/CardDescription.tsx
@@ -3,7 +3,7 @@ import { type ComponentPropsWithRef, forwardRef } from "react";
 import { Text } from "../text";
 import { useCardContext } from "./CardContext";
 
-type CardDescriptionProps = ComponentPropsWithRef<typeof Text>;
+export type CardDescriptionProps = ComponentPropsWithRef<typeof Text>;
 
 export const CardDescription = forwardRef<
   HTMLParagraphElement,

--- a/packages/react/src/card/CardImage.tsx
+++ b/packages/react/src/card/CardImage.tsx
@@ -4,7 +4,7 @@ import { Box, type BoxProps } from "../box";
 import { useCardContext } from "./CardContext";
 import * as styles from "./CardImage.css";
 
-type CardImageProps = BoxProps<"img">;
+export type CardImageProps = BoxProps<"img">;
 
 export const CardImage = forwardRef<HTMLImageElement, CardImageProps>(
   ({ alt = "", asChild, children, className, src, ...props }, ref) => {

--- a/packages/react/src/card/CardLink.tsx
+++ b/packages/react/src/card/CardLink.tsx
@@ -2,7 +2,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 import { Link } from "../link";
 
-type CardLinkProps = ComponentPropsWithoutRef<typeof Link>;
+export type CardLinkProps = ComponentPropsWithoutRef<typeof Link>;
 
 export const CardLink = forwardRef<HTMLAnchorElement, CardLinkProps>(
   ({ ...props }, ref) => {

--- a/packages/react/src/card/CardOverflow.tsx
+++ b/packages/react/src/card/CardOverflow.tsx
@@ -4,7 +4,7 @@ import { Box } from "../box";
 import { useCardContext } from "./CardContext";
 import * as styles from "./CardOverflow.css";
 
-type CardOverflowProps = ComponentPropsWithRef<typeof Box>;
+export type CardOverflowProps = ComponentPropsWithRef<typeof Box>;
 
 export const CardOverflow = forwardRef<HTMLDivElement, CardOverflowProps>(
   ({ children, className, ...props }, ref) => {

--- a/packages/react/src/card/CardTitle.tsx
+++ b/packages/react/src/card/CardTitle.tsx
@@ -6,7 +6,7 @@ import { useCardContext } from "./CardContext";
 
 const Slot = createSlot("@optiaxiom/react/CardTitle");
 
-type CardTitleProps = HeadingProps<"h2">;
+export type CardTitleProps = HeadingProps<"h2">;
 
 export const CardTitle = forwardRef<HTMLDivElement, CardTitleProps>(
   ({ asChild, children, ...props }, ref) => {

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -6,7 +6,7 @@ import { CheckboxContent } from "./CheckboxContent";
 import { CheckboxControl } from "./CheckboxControl";
 import { CheckboxRoot } from "./CheckboxRoot";
 
-type CheckboxProps = BoxProps<
+export type CheckboxProps = BoxProps<
   typeof ToggleInputHiddenInput,
   Pick<ComponentPropsWithoutRef<typeof CheckboxContent>, "description"> &
     Pick<ComponentPropsWithoutRef<typeof CheckboxControl>, "indeterminate">

--- a/packages/react/src/checkbox/CheckboxContent.tsx
+++ b/packages/react/src/checkbox/CheckboxContent.tsx
@@ -8,7 +8,7 @@ import {
   ToggleInputLabel,
 } from "../toggle-input";
 
-type CheckboxContentProps = BoxProps<
+export type CheckboxContentProps = BoxProps<
   typeof ToggleInputHiddenInput,
   {
     /**

--- a/packages/react/src/checkbox/CheckboxControl.tsx
+++ b/packages/react/src/checkbox/CheckboxControl.tsx
@@ -6,7 +6,7 @@ import { IconMinus } from "../icons/IconMinus";
 import { ToggleInputControl } from "../toggle-input";
 import * as styles from "./CheckboxControl.css";
 
-type CheckboxControlProps = BoxProps<
+export type CheckboxControlProps = BoxProps<
   typeof ToggleInputControl,
   {
     /**

--- a/packages/react/src/checkbox/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/CheckboxRoot.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { type BoxProps, extractBoxProps } from "../box";
 import { ToggleInput, ToggleInputHiddenInput } from "../toggle-input";
 
-type CheckboxRootProps = BoxProps<
+export type CheckboxRootProps = BoxProps<
   typeof ToggleInputHiddenInput,
   {
     description?: boolean;

--- a/packages/react/src/clock/Clock.tsx
+++ b/packages/react/src/clock/Clock.tsx
@@ -7,7 +7,7 @@ import { Flex } from "../flex";
 import { Select, SelectContent, SelectTrigger } from "../select";
 import { format, parse, range } from "./utils";
 
-type ClockProps = BoxProps<
+export type ClockProps = BoxProps<
   "div",
   {
     defaultValue?: string;

--- a/packages/react/src/code/Code.tsx
+++ b/packages/react/src/code/Code.tsx
@@ -6,7 +6,7 @@ import * as styles from "./Code.css";
 
 const Slot = createSlot("@optiaxiom/react/Code");
 
-type CodeProps = BoxProps<"code">;
+export type CodeProps = BoxProps<"code">;
 
 export const Code = forwardRef<HTMLElement, CodeProps>(
   ({ asChild, children, className, ...props }, ref) => {

--- a/packages/react/src/command/Command.tsx
+++ b/packages/react/src/command/Command.tsx
@@ -10,7 +10,7 @@ import {
 } from "./CommandContext";
 import { useCommandItems } from "./useCommandItems";
 
-type CommandProps = {
+export type CommandProps = {
   children?: ReactNode;
   /**
    * Custom empty state content.

--- a/packages/react/src/command/CommandContext.ts
+++ b/packages/react/src/command/CommandContext.ts
@@ -29,7 +29,7 @@ export type CommandOption = {
   /**
    * Group item belongs to.
    */
-  group?: Group;
+  group?: CommandOptionGroup;
   /**
    * Return a unique key for each item (otherwise label is used).
    */
@@ -71,7 +71,7 @@ export type CommandOption = {
     | boolean;
 };
 
-export type Group = {
+type CommandOptionGroup = {
   hidden?: boolean;
   name: string;
   separator?: boolean;

--- a/packages/react/src/command/CommandInput.tsx
+++ b/packages/react/src/command/CommandInput.tsx
@@ -5,7 +5,7 @@ import { IconMagnifyingGlass } from "../icons/IconMagnifyingGlass";
 import { Input } from "../input";
 import { useCommandContext } from "./CommandContext";
 
-type CommandInputProps = ComponentPropsWithoutRef<typeof Input>;
+export type CommandInputProps = ComponentPropsWithoutRef<typeof Input>;
 
 export const CommandInput = forwardRef<HTMLInputElement, CommandInputProps>(
   ({ onKeyDown, size, ...props }, ref) => {

--- a/packages/react/src/command/CommandItem.tsx
+++ b/packages/react/src/command/CommandItem.tsx
@@ -10,7 +10,7 @@ import {
   useCommandContext,
 } from "./CommandContext";
 
-type CommandItemProps = BoxProps<
+export type CommandItemProps = BoxProps<
   "div",
   {
     /**

--- a/packages/react/src/command/CommandListbox.tsx
+++ b/packages/react/src/command/CommandListbox.tsx
@@ -9,7 +9,7 @@ import {
   useCommandContext,
 } from "./CommandContext";
 
-type CommandListboxProps = ExcludeProps<
+export type CommandListboxProps = ExcludeProps<
   ComponentPropsWithoutRef<typeof ListboxItemized>,
   "highlightedItem" | "items" | "itemToKey" | "onPlacedChange"
 >;

--- a/packages/react/src/command/CommandToggleButton.tsx
+++ b/packages/react/src/command/CommandToggleButton.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps, extractBoxProps } from "../box";
 import { useCommandContext } from "./CommandContext";
 
-type CommandToggleButtonProps = BoxProps<"button">;
+export type CommandToggleButtonProps = BoxProps<"button">;
 
 export const CommandToggleButton = forwardRef<
   HTMLButtonElement,

--- a/packages/react/src/command/useCommandItems.ts
+++ b/packages/react/src/command/useCommandItems.ts
@@ -6,7 +6,7 @@ import { useEffectEvent } from "../hooks";
 import { type CommandOption, resolveItemProperty } from "./CommandContext";
 import { fuzzysearch } from "./fuzzysearch";
 
-type useCommandItemsProps = Pick<
+export type useCommandItemsProps = Pick<
   ComponentPropsWithoutRef<typeof Command>,
   "inputValue" | "options"
 >;

--- a/packages/react/src/cover/Cover.tsx
+++ b/packages/react/src/cover/Cover.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./Cover.css";
 
-type CoverProps = BoxProps<"div", styles.CoverVariants>;
+export type CoverProps = BoxProps<"div", styles.CoverVariants>;
 
 export const Cover = forwardRef<HTMLDivElement, CoverProps>(
   ({ className, disabled = false, inset = false, ...props }, ref) => (

--- a/packages/react/src/data-table/DataTable.tsx
+++ b/packages/react/src/data-table/DataTable.tsx
@@ -6,7 +6,7 @@ import { type BoxProps } from "../box";
 import { Flex } from "../flex";
 import { DataTableProvider } from "./DataTableContext";
 
-type DataTableProps = BoxProps<
+export type DataTableProps = BoxProps<
   "div",
   {
     /**

--- a/packages/react/src/data-table/DataTableBody.tsx
+++ b/packages/react/src/data-table/DataTableBody.tsx
@@ -18,7 +18,7 @@ import * as styles from "./DataTableBody.css";
 import { useDataTableContext } from "./DataTableContext";
 import { DataTableHeaderCell } from "./DataTableHeaderCell";
 
-type DataTableBodyProps = BoxProps<
+export type DataTableBodyProps = BoxProps<
   "div",
   {
     /**

--- a/packages/react/src/data-table/DataTableFooter.tsx
+++ b/packages/react/src/data-table/DataTableFooter.tsx
@@ -9,7 +9,7 @@ import { Text } from "../text";
 import { useDataTableContext } from "./DataTableContext";
 import * as styles from "./DataTableFooter.css";
 
-type DataTableFooterProps = BoxProps<
+export type DataTableFooterProps = BoxProps<
   "div",
   {
     pageSizeOptions?: Array<{ label: string; value: string }>;

--- a/packages/react/src/data-table/DataTableHeaderCell.tsx
+++ b/packages/react/src/data-table/DataTableHeaderCell.tsx
@@ -13,7 +13,7 @@ import { TableHeaderCell } from "../table";
 import { VisuallyHidden } from "../visually-hidden";
 import * as styles from "./DataTableHeaderCell.css";
 
-type DataTableHeaderCellProps = BoxProps<
+export type DataTableHeaderCellProps = BoxProps<
   "th",
   {
     header: Header<unknown, unknown>;

--- a/packages/react/src/date-input/DateInput.tsx
+++ b/packages/react/src/date-input/DateInput.tsx
@@ -23,7 +23,7 @@ import { type ExtendProps, toPlainDate, toPlainDateTime } from "../utils";
 import * as styles from "./DateInput.css";
 import { toInstant } from "./utils";
 
-type DateInputProps = ExtendProps<
+export type DateInputProps = ExtendProps<
   ComponentPropsWithoutRef<typeof Input>,
   Pick<ComponentPropsWithoutRef<typeof Calendar>, "holiday" | "weekend"> & {
     type?: "date" | "datetime-local";

--- a/packages/react/src/date-range-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.tsx
@@ -4,9 +4,7 @@ import { type ComponentPropsWithRef } from "react";
 import { Popover } from "../popover";
 import { DateRangePickerProvider } from "./DateRangePickerContext";
 
-type DateRange = { from: Date; to: Date };
-
-type DateRangePickerProps = ComponentPropsWithRef<typeof Popover> & {
+export type DateRangePickerProps = ComponentPropsWithRef<typeof Popover> & {
   /**
    * The initial selected value in uncontrolled mode.
    */
@@ -21,6 +19,8 @@ type DateRangePickerProps = ComponentPropsWithRef<typeof Popover> & {
    */
   value?: DateRange | null;
 };
+
+type DateRange = { from: Date; to: Date };
 
 export function DateRangePicker({
   children,

--- a/packages/react/src/date-range-picker/DateRangePickerContent.tsx
+++ b/packages/react/src/date-range-picker/DateRangePickerContent.tsx
@@ -10,7 +10,7 @@ import { PopoverContent } from "../popover";
 import * as styles from "./DateRangePickerContent.css";
 import { useDateRangePickerContext } from "./DateRangePickerContext";
 
-type DateRangePickerContentProps = ComponentPropsWithoutRef<
+export type DateRangePickerContentProps = ComponentPropsWithoutRef<
   typeof PopoverContent
 > &
   Pick<

--- a/packages/react/src/date-range-picker/DateRangePickerTrigger.tsx
+++ b/packages/react/src/date-range-picker/DateRangePickerTrigger.tsx
@@ -13,7 +13,7 @@ const dateFormatter = new Intl.DateTimeFormat(undefined, {
   year: "numeric",
 });
 
-type DateRangePickerTriggerProps = ComponentPropsWithoutRef<
+export type DateRangePickerTriggerProps = ComponentPropsWithoutRef<
   typeof PopoverTrigger
 > & {
   formatRange?: Intl.DateTimeFormat["formatRange"];

--- a/packages/react/src/dialog/Dialog.tsx
+++ b/packages/react/src/dialog/Dialog.tsx
@@ -7,7 +7,7 @@ import {
 } from "../nested-dialog-context";
 import { DialogProvider } from "./DialogContext";
 
-type DialogProps = {
+export type DialogProps = {
   children?: React.ReactNode;
   /**
    * The initial open state in uncontrolled mode.

--- a/packages/react/src/dialog/DialogBody.tsx
+++ b/packages/react/src/dialog/DialogBody.tsx
@@ -4,7 +4,7 @@ import { Box } from "../box";
 import { Flex } from "../flex";
 import * as styles from "./DialogBody.css";
 
-type DialogBodyProps = ComponentPropsWithRef<typeof Box>;
+export type DialogBodyProps = ComponentPropsWithRef<typeof Box>;
 
 export const DialogBody = forwardRef<HTMLDivElement, DialogBodyProps>(
   ({ children, className, ...props }, ref) => {

--- a/packages/react/src/dialog/DialogClose.tsx
+++ b/packages/react/src/dialog/DialogClose.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 
 import { Button, type ButtonProps } from "../button";
 
-type DialogCloseProps = ButtonProps<typeof RadixDialog.Close>;
+export type DialogCloseProps = ButtonProps<typeof RadixDialog.Close>;
 
 export const DialogClose = forwardRef<HTMLButtonElement, DialogCloseProps>(
   ({ appearance = "subtle", asChild, children, ...props }, ref) => {

--- a/packages/react/src/dialog/DialogContent.tsx
+++ b/packages/react/src/dialog/DialogContent.tsx
@@ -13,7 +13,7 @@ import { type ExcludeProps, onReactSelectInputBlur } from "../utils";
 import * as styles from "./DialogContent.css";
 import { useDialogContext } from "./DialogContext";
 
-type DialogContentProps = ExcludeProps<
+export type DialogContentProps = ExcludeProps<
   BoxProps<
     typeof RadixDialog.Content,
     styles.DialogVariants & {

--- a/packages/react/src/dialog/DialogFooter.tsx
+++ b/packages/react/src/dialog/DialogFooter.tsx
@@ -4,7 +4,7 @@ import { ButtonProvider } from "../button/internals";
 import { Flex } from "../flex";
 import * as styles from "./DialogFooter.css";
 
-type DialogFooterProps = ComponentPropsWithRef<typeof Flex>;
+export type DialogFooterProps = ComponentPropsWithRef<typeof Flex>;
 
 export const DialogFooter = forwardRef<HTMLDivElement, DialogFooterProps>(
   ({ children, className, ...props }, ref) => {

--- a/packages/react/src/dialog/DialogForm.tsx
+++ b/packages/react/src/dialog/DialogForm.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from "react";
 
 import { Box, type BoxProps, extractBoxProps } from "../box";
 
-type DialogFormProps = BoxProps<"form">;
+export type DialogFormProps = BoxProps<"form">;
 
 export const DialogForm = forwardRef<HTMLFormElement, DialogFormProps>(
   ({ children, className, ...props }, ref) => {

--- a/packages/react/src/dialog/DialogHeader.tsx
+++ b/packages/react/src/dialog/DialogHeader.tsx
@@ -10,7 +10,7 @@ import { Text } from "../text";
 import { VisuallyHidden } from "../visually-hidden";
 import * as styles from "./DialogHeader.css";
 
-type DialogHeaderProps = BoxProps<
+export type DialogHeaderProps = BoxProps<
   "div",
   {
     addonAfter?: ReactNode;

--- a/packages/react/src/dialog/DialogTrigger.tsx
+++ b/packages/react/src/dialog/DialogTrigger.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 
 import { Button, type ButtonProps } from "../button";
 
-type DialogTriggerProps = ButtonProps<typeof RadixDialog.Trigger>;
+export type DialogTriggerProps = ButtonProps<typeof RadixDialog.Trigger>;
 
 export const DialogTrigger = forwardRef<HTMLButtonElement, DialogTriggerProps>(
   ({ asChild, children, ...props }, ref) => {

--- a/packages/react/src/disclosure/Disclosure.tsx
+++ b/packages/react/src/disclosure/Disclosure.tsx
@@ -5,7 +5,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import { DisclosureProvider } from "./DisclosureContext";
 
-type DisclosureProps = BoxProps<
+export type DisclosureProps = BoxProps<
   typeof RadixCollapsible.Root,
   {
     /**

--- a/packages/react/src/disclosure/DisclosureContent.tsx
+++ b/packages/react/src/disclosure/DisclosureContent.tsx
@@ -13,7 +13,7 @@ import { Transition, TransitionGroup } from "../transition";
 import * as styles from "./DisclosureContent.css";
 import { useDisclosureContext } from "./DisclosureContext";
 
-type DisclosureContentProps = ExcludeProps<
+export type DisclosureContentProps = ExcludeProps<
   BoxProps<
     typeof RadixCollapsible.Content,
     {

--- a/packages/react/src/disclosure/DisclosureTrigger.tsx
+++ b/packages/react/src/disclosure/DisclosureTrigger.tsx
@@ -9,7 +9,7 @@ import { IconAngleRight } from "../icons/IconAngleRight";
 import { useDisclosureContext } from "./DisclosureContext";
 import * as styles from "./DisclosureTrigger.css";
 
-type DisclosureTriggerProps = BoxProps<
+export type DisclosureTriggerProps = BoxProps<
   "div",
   {
     addonAfter?: ReactNode;

--- a/packages/react/src/dropdown-menu/DropdownMenu.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenu.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { DropdownMenuProvider } from "./DropdownMenuContext";
 import { DropdownMenuNestedProvider } from "./DropdownMenuNestedContext";
 
-type MenuProps = {
+export type DropdownMenuProps = {
   children?: React.ReactNode;
   /**
    * The initial open state in uncontrolled mode.
@@ -31,7 +31,7 @@ export function DropdownMenu({
   onOpenChange,
   open: openProp,
   ...props
-}: MenuProps) {
+}: DropdownMenuProps) {
   const [open, setOpen] = useControllableState({
     caller: "@optiaxiom/react/DropdownMenu",
     defaultProp: defaultOpen,

--- a/packages/react/src/dropdown-menu/DropdownMenuCheckboxItem.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuCheckboxItem.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 
 import { type ListboxItemProps, ListboxSwitchItem } from "../listbox";
 
-type DropdownMenuCheckboxItemProps = ListboxItemProps<
+export type DropdownMenuCheckboxItemProps = ListboxItemProps<
   typeof RadixMenu.CheckboxItem
 >;
 

--- a/packages/react/src/dropdown-menu/DropdownMenuContent.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuContent.tsx
@@ -10,7 +10,7 @@ import { Spinner } from "../spinner";
 import { TransitionGroup } from "../transition";
 import { useDropdownMenuContext } from "./DropdownMenuContext";
 
-type DropdownMenuContentProps = ExcludeProps<
+export type DropdownMenuContentProps = ExcludeProps<
   BoxProps<
     typeof RadixMenu.Content,
     Pick<ComponentPropsWithoutRef<typeof ModalListbox>, "maxH" | "minW"> & {

--- a/packages/react/src/dropdown-menu/DropdownMenuGroup.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuGroup.tsx
@@ -3,16 +3,17 @@ import { forwardRef } from "react";
 
 import { Box, type BoxProps } from "../box";
 
-type MenuGroupProps = BoxProps<typeof RadixMenu.Group>;
+export type DropdownMenuGroupProps = BoxProps<typeof RadixMenu.Group>;
 
-export const DropdownMenuGroup = forwardRef<HTMLDivElement, MenuGroupProps>(
-  ({ children, ...props }, ref) => {
-    return (
-      <Box asChild ref={ref} {...props}>
-        <RadixMenu.Group>{children}</RadixMenu.Group>
-      </Box>
-    );
-  },
-);
+export const DropdownMenuGroup = forwardRef<
+  HTMLDivElement,
+  DropdownMenuGroupProps
+>(({ children, ...props }, ref) => {
+  return (
+    <Box asChild ref={ref} {...props}>
+      <RadixMenu.Group>{children}</RadixMenu.Group>
+    </Box>
+  );
+});
 
 DropdownMenuGroup.displayName = "@optiaxiom/react/DropdownMenuGroup";

--- a/packages/react/src/dropdown-menu/DropdownMenuItem.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuItem.tsx
@@ -4,7 +4,7 @@ import { forwardRef } from "react";
 import { ListboxItem, type ListboxItemProps } from "../listbox";
 import { useDropdownMenuContext } from "./DropdownMenuContext";
 
-type DropdownMenuItemProps = ListboxItemProps<typeof RadixMenu.Item>;
+export type DropdownMenuItemProps = ListboxItemProps<typeof RadixMenu.Item>;
 
 export const DropdownMenuItem = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/dropdown-menu/DropdownMenuLabel.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuLabel.tsx
@@ -3,16 +3,17 @@ import { forwardRef } from "react";
 
 import { Box, type BoxProps } from "../box";
 
-type MenuLabelProps = BoxProps<typeof RadixMenu.Label>;
+export type DropdownMenuLabelProps = BoxProps<typeof RadixMenu.Label>;
 
-export const DropdownMenuLabel = forwardRef<HTMLDivElement, MenuLabelProps>(
-  ({ children, ...props }, ref) => {
-    return (
-      <Box asChild color="fg.tertiary" fontSize="sm" p="8" ref={ref} {...props}>
-        <RadixMenu.Label>{children}</RadixMenu.Label>
-      </Box>
-    );
-  },
-);
+export const DropdownMenuLabel = forwardRef<
+  HTMLDivElement,
+  DropdownMenuLabelProps
+>(({ children, ...props }, ref) => {
+  return (
+    <Box asChild color="fg.tertiary" fontSize="sm" p="8" ref={ref} {...props}>
+      <RadixMenu.Label>{children}</RadixMenu.Label>
+    </Box>
+  );
+});
 
 DropdownMenuLabel.displayName = "@optiaxiom/react/DropdownMenuLabel";

--- a/packages/react/src/dropdown-menu/DropdownMenuSeparator.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuSeparator.tsx
@@ -5,11 +5,11 @@ import type { BoxProps } from "../box";
 
 import { ListboxSeparator } from "../listbox";
 
-type MenuSeparatorProps = BoxProps<typeof RadixMenu.Separator>;
+export type DropdownMenuSeparatorProps = BoxProps<typeof RadixMenu.Separator>;
 
 export const DropdownMenuSeparator = forwardRef<
   HTMLDivElement,
-  MenuSeparatorProps
+  DropdownMenuSeparatorProps
 >((props, ref) => (
   <ListboxSeparator asChild {...props}>
     <RadixMenu.Separator ref={ref} />

--- a/packages/react/src/dropdown-menu/DropdownMenuSub.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuSub.tsx
@@ -8,7 +8,7 @@ import {
 } from "./DropdownMenuNestedContext";
 import { DropdownMenuSubProvider } from "./DropdownMenuSubContext";
 
-type MenuSubProps = {
+export type DropdownMenuSubProps = {
   children?: React.ReactNode;
   /**
    * The initial open state in uncontrolled mode.
@@ -30,7 +30,7 @@ export function DropdownMenuSub({
   onOpenChange,
   open: openProp,
   ...props
-}: MenuSubProps) {
+}: DropdownMenuSubProps) {
   const [open, setOpen] = useControllableState({
     caller: "@optiaxiom/react/DropdownMenuSub",
     defaultProp: defaultOpen,

--- a/packages/react/src/dropdown-menu/DropdownMenuSubContent.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuSubContent.tsx
@@ -9,7 +9,7 @@ import { Portal } from "../portal";
 import { TransitionGroup } from "../transition";
 import { useDropdownMenuSubContext } from "./DropdownMenuSubContext";
 
-type MenuSubContentProps = ExcludeProps<
+export type DropdownMenuSubContentProps = ExcludeProps<
   BoxProps<
     typeof RadixMenu.SubContent,
     Pick<ComponentPropsWithoutRef<typeof ModalListbox>, "maxH" | "minW">
@@ -29,7 +29,7 @@ type MenuSubContentProps = ExcludeProps<
 
 export const DropdownMenuSubContent = forwardRef<
   HTMLDivElement,
-  MenuSubContentProps
+  DropdownMenuSubContentProps
 >(({ asChild, children, ...props }, ref) => {
   const { open, setPresence } = useDropdownMenuSubContext(
     "@optiaxiom/react/DropdownMenuSubContent",

--- a/packages/react/src/dropdown-menu/DropdownMenuSubTrigger.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuSubTrigger.tsx
@@ -4,11 +4,13 @@ import { forwardRef } from "react";
 import { IconAngleRight } from "../icons/IconAngleRight";
 import { ListboxItem, type ListboxItemProps } from "../listbox";
 
-type MenuSubTriggerProps = ListboxItemProps<typeof RadixMenu.SubTrigger>;
+export type DropdownMenuSubTriggerProps = ListboxItemProps<
+  typeof RadixMenu.SubTrigger
+>;
 
 export const DropdownMenuSubTrigger = forwardRef<
   HTMLDivElement,
-  MenuSubTriggerProps
+  DropdownMenuSubTriggerProps
 >(({ children, ...props }, ref) => {
   return (
     <ListboxItem addonAfter={<IconAngleRight />} asChild ref={ref} {...props}>

--- a/packages/react/src/dropdown-menu/DropdownMenuTrigger.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuTrigger.tsx
@@ -4,11 +4,11 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { AngleMenuButton } from "../angle-menu-button";
 import { Button } from "../button";
 
-type MenuTriggerProps = ComponentPropsWithoutRef<typeof Button>;
+export type DropdownMenuTriggerProps = ComponentPropsWithoutRef<typeof Button>;
 
 export const DropdownMenuTrigger = forwardRef<
   HTMLButtonElement,
-  MenuTriggerProps
+  DropdownMenuTriggerProps
 >(({ asChild, children, ...props }, ref) => {
   return (
     <RadixMenu.Trigger asChild ref={ref} {...props}>

--- a/packages/react/src/ellipsis-menu-button/EllipsisMenuButton.tsx
+++ b/packages/react/src/ellipsis-menu-button/EllipsisMenuButton.tsx
@@ -3,7 +3,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { Button } from "../button";
 import { IconEllipsisSolid } from "../icons/IconEllipsisSolid";
 
-type EllipsisMenuButtonProps = ComponentPropsWithoutRef<typeof Button>;
+export type EllipsisMenuButtonProps = ComponentPropsWithoutRef<typeof Button>;
 
 export const EllipsisMenuButton = forwardRef<
   HTMLButtonElement,

--- a/packages/react/src/field/Field.tsx
+++ b/packages/react/src/field/Field.tsx
@@ -8,7 +8,7 @@ import { fallbackSpan } from "../utils";
 import { FieldProvider } from "./FieldContext";
 import { FieldLabel } from "./FieldLabel";
 
-type FieldProps = BoxProps<
+export type FieldProps = BoxProps<
   "div",
   {
     /**

--- a/packages/react/src/field/FieldLabel.tsx
+++ b/packages/react/src/field/FieldLabel.tsx
@@ -10,7 +10,7 @@ import { Text } from "../text";
 import { Tooltip } from "../tooltip";
 import { VisuallyHidden } from "../visually-hidden";
 
-type FieldLabelProps = BoxProps<
+export type FieldLabelProps = BoxProps<
   "div",
   {
     info?: ReactNode;

--- a/packages/react/src/filtered-slot/FilteredSlot.tsx
+++ b/packages/react/src/filtered-slot/FilteredSlot.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 
 const Slot = createSlot("@optiaxiom/react/FilteredSlot");
 
-type FilteredSlotProps = SlotProps & {
+export type FilteredSlotProps = SlotProps & {
   exclude?: string;
 };
 

--- a/packages/react/src/flex/Flex.tsx
+++ b/packages/react/src/flex/Flex.tsx
@@ -3,7 +3,7 @@ import { type ComponentPropsWithRef, forwardRef } from "react";
 import { Box } from "../box";
 import { mapResponsiveValue } from "../sprinkles";
 
-type FlexProps = ComponentPropsWithRef<typeof Box>;
+export type FlexProps = ComponentPropsWithRef<typeof Box>;
 
 const mapDirectionToAlign = {
   column: "stretch",

--- a/packages/react/src/grid/Grid.tsx
+++ b/packages/react/src/grid/Grid.tsx
@@ -2,7 +2,7 @@ import { type ComponentPropsWithRef, forwardRef } from "react";
 
 import { Box } from "../box";
 
-type GridProps = ComponentPropsWithRef<typeof Box>;
+export type GridProps = ComponentPropsWithRef<typeof Box>;
 
 export const Grid = forwardRef<HTMLDivElement, GridProps>((props, ref) => {
   return (

--- a/packages/react/src/highlight/Highlight.tsx
+++ b/packages/react/src/highlight/Highlight.tsx
@@ -4,7 +4,7 @@ import { Box, type BoxProps } from "../box";
 import * as styles from "./Highlight.css";
 import { useHighlightedChunks } from "./useHighlightedChunks";
 
-type HighlightProps = BoxProps<
+export type HighlightProps = BoxProps<
   "div",
   {
     children?: (chunk: ReactElement) => ReactNode;

--- a/packages/react/src/icon/Icon.tsx
+++ b/packages/react/src/icon/Icon.tsx
@@ -2,7 +2,7 @@ import { type ComponentPropsWithRef, forwardRef } from "react";
 
 import { Box } from "../box";
 
-type IconProps = ComponentPropsWithRef<typeof Box>;
+export type IconProps = ComponentPropsWithRef<typeof Box>;
 
 export const Icon = forwardRef<HTMLDivElement, IconProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/indicator/Indicator.tsx
+++ b/packages/react/src/indicator/Indicator.tsx
@@ -5,7 +5,7 @@ import { Box, type BoxProps } from "../box";
 import { Flex } from "../flex";
 import * as styles from "./Indicator.css";
 
-type IndicatorProps = BoxProps<
+export type IndicatorProps = BoxProps<
   typeof Badge,
   {
     /**

--- a/packages/react/src/inline-input/InlineInput.tsx
+++ b/packages/react/src/inline-input/InlineInput.tsx
@@ -4,7 +4,7 @@ import { forwardRef, useEffect, useRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./InlineInput.css";
 
-type InlineInputProps = BoxProps<
+export type InlineInputProps = BoxProps<
   "div",
   {
     defaultValue?: string;

--- a/packages/react/src/input/Input.tsx
+++ b/packages/react/src/input/Input.tsx
@@ -14,7 +14,7 @@ import { InputRoot } from "./InputRoot";
 
 const Slot = createSlot("@optiaxiom/react/Input");
 
-type InputProps = InputControlProps<
+export type InputProps = InputControlProps<
   "input",
   Pick<ComponentPropsWithoutRef<typeof InputRoot>, "addonPointerEvents"> &
     styles.InputVariants & {

--- a/packages/react/src/input/InputAddon.tsx
+++ b/packages/react/src/input/InputAddon.tsx
@@ -3,7 +3,7 @@ import { forwardRef, type MouseEvent } from "react";
 import { Box, type BoxProps } from "../box";
 import { useInputContext } from "./InputContext";
 
-type InputAddonProps = BoxProps<"div">;
+export type InputAddonProps = BoxProps<"div">;
 
 export const InputAddon = forwardRef<HTMLDivElement, InputAddonProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/input/InputRoot.tsx
+++ b/packages/react/src/input/InputRoot.tsx
@@ -5,7 +5,7 @@ import { Flex } from "../flex";
 import { InputProvider } from "./InputContext";
 import * as styles from "./InputRoot.css";
 
-type InputRootProps = BoxProps<
+export type InputRootProps = BoxProps<
   "div",
   Pick<ComponentPropsWithoutRef<typeof InputProvider>, "addonPointerEvents">
 >;

--- a/packages/react/src/kbd/Kbd.tsx
+++ b/packages/react/src/kbd/Kbd.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./Kbd.css";
 
-type KbdProps = BoxProps<
+export type KbdProps = BoxProps<
   "kbd",
   styles.KdbVariants & {
     keys?: Array<keyof typeof mapKeyToCode> | keyof typeof mapKeyToCode;

--- a/packages/react/src/label-menu-button/LabelMenuButton.tsx
+++ b/packages/react/src/label-menu-button/LabelMenuButton.tsx
@@ -10,7 +10,9 @@ import { IconAngleDown } from "../icons/IconAngleDown";
 import { Text } from "../text";
 import * as styles from "./LabelMenuButton.css";
 
-type FilterMenuButtonProps = ComponentPropsWithoutRef<typeof ButtonRoot> & {
+export type LabelMenuButtonProps = ComponentPropsWithoutRef<
+  typeof ButtonRoot
+> & {
   appearance?: never;
   label: string;
   size?: never;
@@ -18,7 +20,7 @@ type FilterMenuButtonProps = ComponentPropsWithoutRef<typeof ButtonRoot> & {
 
 export const LabelMenuButton = forwardRef<
   HTMLButtonElement,
-  FilterMenuButtonProps
+  LabelMenuButtonProps
 >(
   (
     { "aria-labelledby": ariaLabelledBy, children, className, label, ...props },

--- a/packages/react/src/layout/Layout.tsx
+++ b/packages/react/src/layout/Layout.tsx
@@ -3,7 +3,7 @@ import { forwardRef, type ReactNode } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./Layouts.css";
 
-type LayoutProps = BoxProps<
+export type LayoutProps = BoxProps<
   "div",
   {
     header?: ReactNode;

--- a/packages/react/src/link/Link.tsx
+++ b/packages/react/src/link/Link.tsx
@@ -9,7 +9,7 @@ import * as styles from "./Link.css";
 
 const Slot = createSlot("@optiaxiom/react/Link");
 
-type LinkProps = BoxProps<
+export type LinkProps = BoxProps<
   "a",
   styles.LinkVariants & {
     /**

--- a/packages/react/src/listbox/Listbox.tsx
+++ b/packages/react/src/listbox/Listbox.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from "react";
 
 import { Box, type BoxProps } from "../box";
 
-type ListboxProps = BoxProps<"div">;
+export type ListboxProps = BoxProps<"div">;
 
 export const Listbox = forwardRef<HTMLDivElement, ListboxProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/listbox/ListboxCheckboxItem.tsx
+++ b/packages/react/src/listbox/ListboxCheckboxItem.tsx
@@ -7,7 +7,9 @@ import { Icon } from "../icon";
 import * as styles from "./ListboxCheckboxItem.css";
 import { ListboxItem } from "./ListboxItem";
 
-type ListboxCheckboxItemProps = ComponentPropsWithoutRef<typeof ListboxItem> &
+export type ListboxCheckboxItemProps = ComponentPropsWithoutRef<
+  typeof ListboxItem
+> &
   Pick<ComponentPropsWithoutRef<typeof Checkbox>, "onCheckedChange">;
 
 export const ListboxCheckboxItem = forwardRef<

--- a/packages/react/src/listbox/ListboxEmpty.tsx
+++ b/packages/react/src/listbox/ListboxEmpty.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from "react";
 
 import { Box, type BoxProps } from "../box";
 
-type ListboxEmptyProps = BoxProps;
+export type ListboxEmptyProps = BoxProps;
 
 export const ListboxEmpty = forwardRef<HTMLDivElement, ListboxEmptyProps>(
   ({ children = "No results found.", ...props }, ref) => {

--- a/packages/react/src/listbox/ListboxFooter.tsx
+++ b/packages/react/src/listbox/ListboxFooter.tsx
@@ -2,7 +2,7 @@ import { type ComponentPropsWithRef, forwardRef } from "react";
 
 import { Flex } from "../flex";
 
-type ListboxFooterProps = ComponentPropsWithRef<typeof Flex>;
+export type ListboxFooterProps = ComponentPropsWithRef<typeof Flex>;
 
 export const ListboxFooter = forwardRef<HTMLDivElement, ListboxFooterProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/listbox/ListboxGroup.tsx
+++ b/packages/react/src/listbox/ListboxGroup.tsx
@@ -4,7 +4,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { Box } from "../box";
 import { ListboxGroupProvider } from "./ListboxGroupContext";
 
-type ListboxGroupProps = ComponentPropsWithoutRef<typeof Box>;
+export type ListboxGroupProps = ComponentPropsWithoutRef<typeof Box>;
 
 export const ListboxGroup = forwardRef<HTMLDivElement, ListboxGroupProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/listbox/ListboxItemIndicator.tsx
+++ b/packages/react/src/listbox/ListboxItemIndicator.tsx
@@ -4,7 +4,7 @@ import { Box, type BoxProps } from "../box";
 import { IconCheck } from "../icons/IconCheck";
 import * as styles from "./ListboxItemIndicator.css";
 
-type ListboxItemIndicatorProps = BoxProps<
+export type ListboxItemIndicatorProps = BoxProps<
   typeof IconCheck,
   {
     active?: boolean;

--- a/packages/react/src/listbox/ListboxItemized.tsx
+++ b/packages/react/src/listbox/ListboxItemized.tsx
@@ -9,7 +9,7 @@ import { ListboxVirtualized } from "./ListboxVirtualized";
 
 const VIRTUALIZE_THRESHOLD = 50;
 
-type ListboxItemizedProps = BoxProps<
+export type ListboxItemizedProps = BoxProps<
   "div",
   {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/react/src/listbox/ListboxLabel.tsx
+++ b/packages/react/src/listbox/ListboxLabel.tsx
@@ -3,7 +3,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { Box } from "../box";
 import { useListboxGroupContext } from "./ListboxGroupContext";
 
-type ListboxLabelProps = ComponentPropsWithoutRef<typeof Box>;
+export type ListboxLabelProps = ComponentPropsWithoutRef<typeof Box>;
 
 export const ListboxLabel = forwardRef<HTMLDivElement, ListboxLabelProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/listbox/ListboxRadioItem.tsx
+++ b/packages/react/src/listbox/ListboxRadioItem.tsx
@@ -4,7 +4,9 @@ import { Flex } from "../flex";
 import { ListboxItem } from "./ListboxItem";
 import { ListboxItemIndicator } from "./ListboxItemIndicator";
 
-type ListboxRadioItemProps = ComponentPropsWithoutRef<typeof ListboxItem>;
+export type ListboxRadioItemProps = ComponentPropsWithoutRef<
+  typeof ListboxItem
+>;
 
 export const ListboxRadioItem = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/listbox/ListboxSeparator.tsx
+++ b/packages/react/src/listbox/ListboxSeparator.tsx
@@ -4,7 +4,7 @@ import type { BoxProps } from "../box";
 
 import { Separator } from "../separator";
 
-type ListboxSeparatorProps = BoxProps<typeof Separator>;
+export type ListboxSeparatorProps = BoxProps<typeof Separator>;
 
 export const ListboxSeparator = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/listbox/ListboxSwitchItem.tsx
+++ b/packages/react/src/listbox/ListboxSwitchItem.tsx
@@ -5,7 +5,9 @@ import { Icon } from "../icon";
 import { Switch } from "../switch";
 import { ListboxItem } from "./ListboxItem";
 
-type ListboxSwitchItemProps = ComponentPropsWithoutRef<typeof ListboxItem>;
+export type ListboxSwitchItemProps = ComponentPropsWithoutRef<
+  typeof ListboxItem
+>;
 
 export const ListboxSwitchItem = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/listbox/ListboxVirtualized.tsx
+++ b/packages/react/src/listbox/ListboxVirtualized.tsx
@@ -15,7 +15,7 @@ import { Box, type BoxProps } from "../box";
 import { useTransitionGroupContext } from "../transition/internals";
 import { Listbox } from "./Listbox";
 
-type ListboxVirtualizedProps<T = unknown> = BoxProps<
+export type ListboxVirtualizedProps<T = unknown> = BoxProps<
   "div",
   {
     children: (item: T, index: number) => ReactNode;

--- a/packages/react/src/menu/Menu.tsx
+++ b/packages/react/src/menu/Menu.tsx
@@ -20,7 +20,7 @@ import { MenuSubProvider } from "./MenuSubContext";
 
 export type MenuOption = CommandOption;
 
-type MenuProps = ExcludeProps<
+export type MenuProps = ExcludeProps<
   ExtendProps<
     ComponentPropsWithoutRef<typeof Command>,
     {

--- a/packages/react/src/menu/MenuCheckboxItem.tsx
+++ b/packages/react/src/menu/MenuCheckboxItem.tsx
@@ -4,7 +4,9 @@ import { CommandItem } from "../command";
 import { resolveItemProperty, useCommandContext } from "../command/internals";
 import { ListboxCheckboxItem } from "../listbox";
 
-type MenuCheckboxItemProps = ComponentPropsWithoutRef<typeof CommandItem> &
+export type MenuCheckboxItemProps = ComponentPropsWithoutRef<
+  typeof CommandItem
+> &
   ComponentPropsWithoutRef<typeof ListboxCheckboxItem>;
 
 export const MenuCheckboxItem = forwardRef<

--- a/packages/react/src/menu/MenuContent.tsx
+++ b/packages/react/src/menu/MenuContent.tsx
@@ -14,7 +14,7 @@ import { MenuListbox } from "./MenuListbox";
 import { MenuPopoverContent } from "./MenuPopoverContent";
 import { useMenuSubContext } from "./MenuSubContext";
 
-type MenuContentProps = ExcludeProps<
+export type MenuContentProps = ExcludeProps<
   ComponentPropsWithoutRef<typeof DialogContent> &
     ComponentPropsWithoutRef<typeof PopoverContent>,
   "minW" | "size" | "transitionType" | "withArrow"

--- a/packages/react/src/menu/MenuDialogContent.tsx
+++ b/packages/react/src/menu/MenuDialogContent.tsx
@@ -5,7 +5,9 @@ import type { MenuContent } from "./MenuContent";
 import { DialogContent, DialogHeader } from "../dialog";
 import { VisuallyHidden } from "../visually-hidden";
 
-type MenuDialogContentProps = ComponentPropsWithoutRef<typeof MenuContent>;
+export type MenuDialogContentProps = ComponentPropsWithoutRef<
+  typeof MenuContent
+>;
 
 export const MenuDialogContent = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/menu/MenuInput.tsx
+++ b/packages/react/src/menu/MenuInput.tsx
@@ -13,7 +13,7 @@ import { useCommandContext } from "../command/internals";
 import { useMenuContext } from "./MenuContext";
 import * as styles from "./MenuInput.css";
 
-type MenuInputProps = ComponentPropsWithoutRef<typeof CommandInput>;
+export type MenuInputProps = ComponentPropsWithoutRef<typeof CommandInput>;
 
 export const MenuInput = forwardRef<HTMLInputElement, MenuInputProps>(
   ({ className, ...props }, outerRef) => {

--- a/packages/react/src/menu/MenuItem.tsx
+++ b/packages/react/src/menu/MenuItem.tsx
@@ -3,7 +3,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { CommandItem } from "../command";
 import { ListboxItem } from "../listbox";
 
-type MenuItemProps = ComponentPropsWithoutRef<typeof CommandItem> &
+export type MenuItemProps = ComponentPropsWithoutRef<typeof CommandItem> &
   ComponentPropsWithoutRef<typeof ListboxItem>;
 
 export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(

--- a/packages/react/src/menu/MenuListbox.tsx
+++ b/packages/react/src/menu/MenuListbox.tsx
@@ -1,7 +1,7 @@
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 import { CommandListbox } from "../command";
-import { type CommandOption, type Group } from "../command/internals";
+import { type CommandOption } from "../command/internals";
 import { ListboxLabel, ListboxSeparator } from "../listbox";
 import { MenuCheckboxItem } from "./MenuCheckboxItem";
 import { useMenuContext } from "./MenuContext";
@@ -16,8 +16,8 @@ export const MenuListbox = forwardRef<HTMLDivElement, MenuListboxProps>(
     const { size } = useMenuContext("@optiaxiom/react/MenuListbox");
 
     let isFirstItem = true;
-    let lastGroup: Group | undefined = undefined;
-    const shouldShowSeparator = (group: Group | undefined) => {
+    let lastGroup: CommandOption["group"] = undefined;
+    const shouldShowSeparator = (group: CommandOption["group"]) => {
       const show = !isFirstItem;
       isFirstItem = false;
       return (
@@ -26,7 +26,9 @@ export const MenuListbox = forwardRef<HTMLDivElement, MenuListboxProps>(
         (group?.separator || lastGroup?.separator)
       );
     };
-    const shouldShowGroup = (group: Group | undefined): group is Group => {
+    const shouldShowGroup = (
+      group: CommandOption["group"],
+    ): group is NonNullable<CommandOption["group"]> => {
       const show = group !== lastGroup;
       lastGroup = group;
       return show && !!group && !group?.hidden;

--- a/packages/react/src/menu/MenuListbox.tsx
+++ b/packages/react/src/menu/MenuListbox.tsx
@@ -9,7 +9,7 @@ import { MenuItem } from "./MenuItem";
 import { MenuRadioItem } from "./MenuRadioItem";
 import { MenuSub } from "./MenuSub";
 
-type MenuListboxProps = ComponentPropsWithoutRef<typeof CommandListbox>;
+export type MenuListboxProps = ComponentPropsWithoutRef<typeof CommandListbox>;
 
 export const MenuListbox = forwardRef<HTMLDivElement, MenuListboxProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/menu/MenuPopover.tsx
+++ b/packages/react/src/menu/MenuPopover.tsx
@@ -2,7 +2,7 @@ import { type ComponentPropsWithoutRef } from "react";
 
 import { Popover } from "../popover";
 
-type MenuPopoverProps = ComponentPropsWithoutRef<typeof Popover>;
+export type MenuPopoverProps = ComponentPropsWithoutRef<typeof Popover>;
 
 export function MenuPopover(props: MenuPopoverProps) {
   return <Popover modal {...props} />;

--- a/packages/react/src/menu/MenuPopoverContent.tsx
+++ b/packages/react/src/menu/MenuPopoverContent.tsx
@@ -4,7 +4,9 @@ import type { MenuContent } from "./MenuContent";
 
 import { PopoverContent } from "../popover";
 
-type MenuPopoverContentProps = ComponentPropsWithoutRef<typeof MenuContent>;
+export type MenuPopoverContentProps = ComponentPropsWithoutRef<
+  typeof MenuContent
+>;
 
 export const MenuPopoverContent = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/menu/MenuRadioItem.tsx
+++ b/packages/react/src/menu/MenuRadioItem.tsx
@@ -3,7 +3,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { CommandItem } from "../command";
 import { ListboxRadioItem } from "../listbox";
 
-type MenuRadioItemProps = ComponentPropsWithoutRef<typeof CommandItem> &
+export type MenuRadioItemProps = ComponentPropsWithoutRef<typeof CommandItem> &
   ComponentPropsWithoutRef<typeof ListboxRadioItem>;
 
 export const MenuRadioItem = forwardRef<HTMLDivElement, MenuRadioItemProps>(

--- a/packages/react/src/menu/MenuSub.tsx
+++ b/packages/react/src/menu/MenuSub.tsx
@@ -6,7 +6,7 @@ import { MenuSubContent } from "./MenuSubContent";
 import { useMenuSubContext } from "./MenuSubContext";
 import { MenuSubTrigger } from "./MenuSubTrigger";
 
-type MenuSubProps = {
+export type MenuSubProps = {
   item: CommandOption;
 };
 

--- a/packages/react/src/menu/MenuSubContent.tsx
+++ b/packages/react/src/menu/MenuSubContent.tsx
@@ -20,7 +20,7 @@ import { useMenuContext } from "./MenuContext";
 import { MenuListbox } from "./MenuListbox";
 import { MenuSubProvider, useMenuSubContext } from "./MenuSubContext";
 
-type MenuSubContentProps = ExcludeProps<
+export type MenuSubContentProps = ExcludeProps<
   BoxProps<
     typeof PopoverContent,
     Pick<ComponentPropsWithoutRef<typeof CommandItem>, "item">

--- a/packages/react/src/menu/MenuSubTrigger.tsx
+++ b/packages/react/src/menu/MenuSubTrigger.tsx
@@ -9,7 +9,7 @@ import { PopoverTrigger } from "../popover";
 import { usePopoverContext } from "../popover/internals";
 import { MenuItem } from "./MenuItem";
 
-type MenuSubTriggerProps = BoxProps<
+export type MenuSubTriggerProps = BoxProps<
   typeof MenuItem,
   {
     contentRef: RefObject<HTMLDivElement>;

--- a/packages/react/src/menu/MenuTrigger.tsx
+++ b/packages/react/src/menu/MenuTrigger.tsx
@@ -7,7 +7,7 @@ import { useFieldLabelTrigger } from "../hooks";
 import { PopoverTrigger } from "../popover";
 import { useMenuContext } from "./MenuContext";
 
-type MenuTriggerProps = ComponentPropsWithoutRef<typeof PopoverTrigger>;
+export type MenuTriggerProps = ComponentPropsWithoutRef<typeof PopoverTrigger>;
 
 export const MenuTrigger = forwardRef<HTMLButtonElement, MenuTriggerProps>(
   (

--- a/packages/react/src/modal/ModalLayer.tsx
+++ b/packages/react/src/modal/ModalLayer.tsx
@@ -17,7 +17,10 @@ import { ModalProvider, useModalContext } from "../modal/ModalContext";
 
 const Slot = createSlot("@optiaxiom/react/ModalLayer");
 
-type ModalLayerProps = Pick<ComponentPropsWithoutRef<typeof Box>, "asChild"> &
+export type ModalLayerProps = Pick<
+  ComponentPropsWithoutRef<typeof Box>,
+  "asChild"
+> &
   Pick<ComponentPropsWithoutRef<typeof DismissableLayer>, "onEscapeKeyDown"> & {
     children?: ReactNode;
   };

--- a/packages/react/src/modal/ModalListbox.tsx
+++ b/packages/react/src/modal/ModalListbox.tsx
@@ -7,12 +7,12 @@ import { Paper } from "../paper";
 import { Transition } from "../transition";
 import * as styles from "./ModalListbox.css";
 
-type OverlayListboxProps = BoxProps<
+export type ModalListboxProps = BoxProps<
   typeof Listbox,
   NonNullable<styles.ListboxVariants>
 >;
 
-export const ModalListbox = forwardRef<HTMLDivElement, OverlayListboxProps>(
+export const ModalListbox = forwardRef<HTMLDivElement, ModalListboxProps>(
   (
     { children, className, maxH, minW, provider = "popover", ...props },
     ref,

--- a/packages/react/src/nav/Nav.tsx
+++ b/packages/react/src/nav/Nav.tsx
@@ -5,7 +5,7 @@ import { Flex } from "../flex";
 import { useSidebarContext } from "../sidebar/internals";
 import * as styles from "./Nav.css";
 
-type NavProps = BoxProps<
+export type NavProps = BoxProps<
   "nav",
   {
     defaultExpanded?: boolean;

--- a/packages/react/src/nav/NavBody.tsx
+++ b/packages/react/src/nav/NavBody.tsx
@@ -5,7 +5,7 @@ import { Flex } from "../flex";
 import { useSidebarContext } from "../sidebar/internals";
 import * as styles from "./NavBody.css";
 
-type NavBodyProps = BoxProps<"div">;
+export type NavBodyProps = BoxProps<"div">;
 
 export const NavBody = forwardRef<HTMLDivElement, NavBodyProps>(
   ({ children, className, ...props }, ref) => {

--- a/packages/react/src/nav/NavFooter.tsx
+++ b/packages/react/src/nav/NavFooter.tsx
@@ -4,7 +4,7 @@ import { type BoxProps } from "../box";
 import { Flex } from "../flex";
 import { useSidebarContext } from "../sidebar/internals";
 
-type NavFooterProps = BoxProps<"div">;
+export type NavFooterProps = BoxProps<"div">;
 
 export const NavFooter = forwardRef<HTMLDivElement, NavFooterProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/nav/NavGroup.tsx
+++ b/packages/react/src/nav/NavGroup.tsx
@@ -4,7 +4,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { Disclosure } from "../disclosure";
 import { NavGroupProvider } from "./NavGroupContext";
 
-type NavGroupProps = ComponentPropsWithoutRef<typeof Disclosure>;
+export type NavGroupProps = ComponentPropsWithoutRef<typeof Disclosure>;
 
 export const NavGroup = forwardRef<HTMLLIElement, NavGroupProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/nav/NavGroupContent.tsx
+++ b/packages/react/src/nav/NavGroupContent.tsx
@@ -4,7 +4,7 @@ import type { BoxProps } from "../box";
 
 import { DisclosureContent } from "../disclosure";
 
-type NavGroupContentProps = BoxProps<"div">;
+export type NavGroupContentProps = BoxProps<"div">;
 
 export const NavGroupContent = forwardRef<
   HTMLUListElement,

--- a/packages/react/src/nav/NavGroupTrigger.tsx
+++ b/packages/react/src/nav/NavGroupTrigger.tsx
@@ -3,7 +3,9 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { DisclosureTrigger } from "../disclosure";
 import { useNavGroupContext } from "./NavGroupContext";
 
-type NavGroupTriggerProps = ComponentPropsWithoutRef<typeof DisclosureTrigger>;
+export type NavGroupTriggerProps = ComponentPropsWithoutRef<
+  typeof DisclosureTrigger
+>;
 
 export const NavGroupTrigger = forwardRef<HTMLDivElement, NavGroupTriggerProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/nav/NavHeader.tsx
+++ b/packages/react/src/nav/NavHeader.tsx
@@ -4,7 +4,7 @@ import { type BoxProps } from "../box";
 import { Flex } from "../flex";
 import { useSidebarContext } from "../sidebar/internals";
 
-type NavHeaderProps = BoxProps<"div">;
+export type NavHeaderProps = BoxProps<"div">;
 
 export const NavHeader = forwardRef<HTMLDivElement, NavHeaderProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/nav/NavList.tsx
+++ b/packages/react/src/nav/NavList.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import { useNavGroupContext } from "./NavGroupContext";
 
-type NavListProps = BoxProps<"div">;
+export type NavListProps = BoxProps<"div">;
 
 export const NavList = forwardRef<HTMLUListElement, NavListProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/nav/NavSeparator.tsx
+++ b/packages/react/src/nav/NavSeparator.tsx
@@ -4,7 +4,7 @@ import type { BoxProps } from "../box";
 
 import { Separator } from "../separator";
 
-type NavSeparatorProps = BoxProps<typeof Separator>;
+export type NavSeparatorProps = BoxProps<typeof Separator>;
 
 export const NavSeparator = forwardRef<HTMLDivElement, NavSeparatorProps>(
   (props, ref) => <Separator flex="none" mx="12" my="8" ref={ref} {...props} />,

--- a/packages/react/src/pagination/Pagination.tsx
+++ b/packages/react/src/pagination/Pagination.tsx
@@ -14,7 +14,7 @@ import { Tooltip } from "../tooltip";
 import { VisuallyHidden } from "../visually-hidden";
 import * as styles from "./Pagination.css";
 
-type PaginationProps = BoxProps<
+export type PaginationProps = BoxProps<
   "nav",
   {
     /**

--- a/packages/react/src/paper/Paper.tsx
+++ b/packages/react/src/paper/Paper.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./Paper.css";
 
-type PaperProps = BoxProps<"div", styles.PaperVariants>;
+export type PaperProps = BoxProps<"div", styles.PaperVariants>;
 
 export const Paper = forwardRef<HTMLDivElement, PaperProps>(
   ({ className, elevation = "menu", ...props }, ref) => (

--- a/packages/react/src/pill/Pill.tsx
+++ b/packages/react/src/pill/Pill.tsx
@@ -9,7 +9,7 @@ import * as styles from "./Pill.css";
 
 const Slot = createSlot("@optiaxiom/react/Pill");
 
-type PillProps = BoxProps<"button", styles.PillVariants>;
+export type PillProps = BoxProps<"button", styles.PillVariants>;
 
 export const Pill = forwardRef<HTMLButtonElement, PillProps>(
   ({ asChild, children, className, disabled, size = "sm", ...props }, ref) => {

--- a/packages/react/src/pill/PillGroup.tsx
+++ b/packages/react/src/pill/PillGroup.tsx
@@ -2,7 +2,7 @@ import { type ComponentPropsWithRef, forwardRef } from "react";
 
 import { Flex } from "../flex";
 
-type PillGroupProps = ComponentPropsWithRef<typeof Flex>;
+export type PillGroupProps = ComponentPropsWithRef<typeof Flex>;
 
 export const PillGroup = forwardRef<HTMLDivElement, PillGroupProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/popover/Popover.tsx
+++ b/packages/react/src/popover/Popover.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 
 import { PopoverProvider } from "./PopoverContext";
 
-type PopoverProps = {
+export type PopoverProps = {
   children?: React.ReactNode;
   /**
    * The initial open state in uncontrolled mode.

--- a/packages/react/src/popover/PopoverAnchor.tsx
+++ b/packages/react/src/popover/PopoverAnchor.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 
 import { Box, type BoxProps } from "../box";
 
-type PopoverAnchorProps = BoxProps<typeof RadixPopover.Anchor>;
+export type PopoverAnchorProps = BoxProps<typeof RadixPopover.Anchor>;
 
 export const PopoverAnchor = forwardRef<HTMLDivElement, PopoverAnchorProps>(
   ({ asChild, children, ...props }, ref) => {

--- a/packages/react/src/popover/PopoverContent.tsx
+++ b/packages/react/src/popover/PopoverContent.tsx
@@ -12,7 +12,7 @@ import { TransitionGroup } from "../transition";
 import { type ExcludeProps, onReactSelectInputBlur } from "../utils";
 import { usePopoverContext } from "./PopoverContext";
 
-type PopoverContentProps = ExcludeProps<
+export type PopoverContentProps = ExcludeProps<
   BoxProps<
     typeof RadixPopover.Content,
     Pick<ComponentPropsWithoutRef<typeof ModalListbox>, "maxH" | "minW"> & {

--- a/packages/react/src/popover/PopoverTrigger.tsx
+++ b/packages/react/src/popover/PopoverTrigger.tsx
@@ -3,7 +3,7 @@ import { forwardRef, useEffect, useState } from "react";
 
 import { Button, type ButtonProps } from "../button";
 
-type PopoverTriggerProps = ButtonProps<
+export type PopoverTriggerProps = ButtonProps<
   typeof RadixPopover.Trigger,
   {
     hasCustomAnchor?: boolean;

--- a/packages/react/src/portal/Portal.tsx
+++ b/packages/react/src/portal/Portal.tsx
@@ -3,7 +3,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 import { usePortalContext } from "./PortalContext";
 
-type PortalProps = ComponentPropsWithoutRef<typeof RadixPortal.Root>;
+export type PortalProps = ComponentPropsWithoutRef<typeof RadixPortal.Root>;
 
 export const Portal = forwardRef<HTMLDivElement, PortalProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/progress/Progress.tsx
+++ b/packages/react/src/progress/Progress.tsx
@@ -4,7 +4,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./Progress.css";
 
-type ProgressProps = BoxProps<typeof ProgressPrimitive.Root> &
+export type ProgressProps = BoxProps<typeof ProgressPrimitive.Root> &
   styles.ProgressVariants;
 
 export const Progress = forwardRef<HTMLDivElement, ProgressProps>(

--- a/packages/react/src/radio/Radio.tsx
+++ b/packages/react/src/radio/Radio.tsx
@@ -12,7 +12,7 @@ import {
 import * as styles from "./Radio.css";
 import { useRadioGroupContext } from "./RadioGroupContext";
 
-type RadioProps = BoxProps<
+export type RadioProps = BoxProps<
   typeof ToggleInputHiddenInput,
   {
     /**

--- a/packages/react/src/radio/RadioGroup.tsx
+++ b/packages/react/src/radio/RadioGroup.tsx
@@ -6,8 +6,7 @@ import { Flex } from "../flex";
 import { mapResponsiveValue } from "../sprinkles";
 import { RadioGroupProvider } from "./RadioGroupContext";
 
-type InputProps = ComponentPropsWithoutRef<"input">;
-type RadioGroupProps = BoxProps<
+export type RadioGroupProps = BoxProps<
   "div",
   {
     defaultValue?: string;
@@ -19,6 +18,7 @@ type RadioGroupProps = BoxProps<
     value?: string;
   }
 >;
+type InputProps = ComponentPropsWithoutRef<"input">;
 
 const mapGapToOrientation = {
   column: "12",

--- a/packages/react/src/search-input/SearchInput.tsx
+++ b/packages/react/src/search-input/SearchInput.tsx
@@ -10,11 +10,11 @@ import { IconX } from "../icons/IconX";
 import { Input } from "../input";
 import * as styles from "./SearchInput.css";
 
-type SearchProps = ComponentPropsWithRef<typeof Input> & {
+export type SearchInputProps = ComponentPropsWithRef<typeof Input> & {
   onValueClear?: () => void;
 };
 
-export const SearchInput = forwardRef<HTMLInputElement, SearchProps>(
+export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
   ({ addonBefore, className, onChange, onValueClear, ...props }, outerRef) => {
     const innerRef = useRef<HTMLInputElement>(null);
     const ref = useComposedRefs(innerRef, outerRef);

--- a/packages/react/src/segmented-control/SegmentedControl.tsx
+++ b/packages/react/src/segmented-control/SegmentedControl.tsx
@@ -5,7 +5,7 @@ import { type BoxProps } from "../box";
 import { Flex } from "../flex";
 import { SegmentedControlProvider } from "./SegmentedControlContext";
 
-type SegmentedControlProps = BoxProps<
+export type SegmentedControlProps = BoxProps<
   typeof RadixSegmentedControl.Root,
   {
     type?: "multiple" | "single";

--- a/packages/react/src/segmented-control/SegmentedControlItem.tsx
+++ b/packages/react/src/segmented-control/SegmentedControlItem.tsx
@@ -4,7 +4,9 @@ import { forwardRef } from "react";
 import { Button, type ButtonProps } from "../button";
 import { useSegmentedControlContext } from "./SegmentedControlContext";
 
-type SegmentedControlItemProps = ButtonProps<typeof RadixSegmentedControl.Item>;
+export type SegmentedControlItemProps = ButtonProps<
+  typeof RadixSegmentedControl.Item
+>;
 
 export const SegmentedControlItem = forwardRef<
   HTMLButtonElement,

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -17,7 +17,7 @@ import { type SelectOption, SelectProvider } from "./SelectContext";
 import { SelectHiddenSelect } from "./SelectHiddenSelect";
 import { useObserveReset } from "./useObserveReset";
 
-type SelectProps = {
+export type SelectProps = {
   children?: ReactNode;
   /**
    * The initial open state in uncontrolled mode.

--- a/packages/react/src/select/SelectContent.tsx
+++ b/packages/react/src/select/SelectContent.tsx
@@ -14,11 +14,7 @@ import { ModalLayer } from "../modal";
 import { ModalListbox } from "../modal/internals";
 import { Portal } from "../portal";
 import { TransitionGroup } from "../transition";
-import {
-  type Group,
-  type SelectOption,
-  useSelectContext,
-} from "./SelectContext";
+import { type SelectOption, useSelectContext } from "./SelectContext";
 import { SelectRadioItem } from "./SelectRadioItem";
 
 export type SelectContentProps = ExcludeProps<
@@ -48,8 +44,8 @@ export const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>(
     const [placed, setPlaced] = useState(false);
 
     let isFirstItem = true;
-    let lastGroup: Group | undefined = undefined;
-    const shouldShowSeparator = (group: Group | undefined) => {
+    let lastGroup: SelectOption["group"] = undefined;
+    const shouldShowSeparator = (group: SelectOption["group"]) => {
       const show = !isFirstItem;
       isFirstItem = false;
       return (
@@ -58,7 +54,9 @@ export const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>(
         (group?.separator || lastGroup?.separator)
       );
     };
-    const shouldShowGroup = (group: Group | undefined): group is Group => {
+    const shouldShowGroup = (
+      group: SelectOption["group"],
+    ): group is NonNullable<SelectOption["group"]> => {
       const show = group !== lastGroup;
       lastGroup = group;
       return show && !!group && !group?.hidden;

--- a/packages/react/src/select/SelectContent.tsx
+++ b/packages/react/src/select/SelectContent.tsx
@@ -21,7 +21,7 @@ import {
 } from "./SelectContext";
 import { SelectRadioItem } from "./SelectRadioItem";
 
-type SelectContentProps = ExcludeProps<
+export type SelectContentProps = ExcludeProps<
   BoxProps<
     typeof PopperContent,
     Pick<ComponentPropsWithoutRef<typeof ModalListbox>, "maxH" | "minW"> & {

--- a/packages/react/src/select/SelectContext.ts
+++ b/packages/react/src/select/SelectContext.ts
@@ -5,21 +5,6 @@ import type { FocusEventHandler, ReactNode } from "react";
 
 import { createContext } from "@radix-ui/react-context";
 
-export type Group = {
-  /**
-   * Whether the group label should be hidden or not.
-   */
-  hidden?: boolean;
-  /**
-   * The label group.
-   */
-  label: string;
-  /**
-   * Whether to display a separator before this group.
-   */
-  separator?: boolean;
-};
-
 export type SelectOption = {
   /**
    * Addons such as avatars or icons to show beside each item label.
@@ -40,7 +25,7 @@ export type SelectOption = {
   /**
    * Provide an optional group that item belongs to.
    */
-  group?: Group;
+  group?: SelectOptionGroup;
   /**
    * String representation of items.
    */
@@ -49,6 +34,21 @@ export type SelectOption = {
    * Return a unique key for each item.
    */
   value: string;
+};
+
+type SelectOptionGroup = {
+  /**
+   * Whether the group label should be hidden or not.
+   */
+  hidden?: boolean;
+  /**
+   * The label group.
+   */
+  label: string;
+  /**
+   * Whether to display a separator before this group.
+   */
+  separator?: boolean;
 };
 
 export const [SelectProvider, useSelectContext] = createContext<{

--- a/packages/react/src/select/SelectGroup.tsx
+++ b/packages/react/src/select/SelectGroup.tsx
@@ -2,7 +2,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 import { ListboxGroup } from "../listbox";
 
-type SelectGroupProps = ComponentPropsWithoutRef<typeof ListboxGroup>;
+export type SelectGroupProps = ComponentPropsWithoutRef<typeof ListboxGroup>;
 
 export const SelectGroup = forwardRef<HTMLDivElement, SelectGroupProps>(
   (props, ref) => {

--- a/packages/react/src/select/SelectItem.tsx
+++ b/packages/react/src/select/SelectItem.tsx
@@ -3,7 +3,7 @@ import { forwardRef, type MouseEvent } from "react";
 import { Box, type BoxProps } from "../box";
 import { type SelectOption, useSelectContext } from "./SelectContext";
 
-type SelectItemProps = BoxProps<
+export type SelectItemProps = BoxProps<
   "div",
   {
     /**

--- a/packages/react/src/select/SelectLabel.tsx
+++ b/packages/react/src/select/SelectLabel.tsx
@@ -2,7 +2,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 import { ListboxLabel } from "../listbox";
 
-type SelectLabelProps = ComponentPropsWithoutRef<typeof ListboxLabel>;
+export type SelectLabelProps = ComponentPropsWithoutRef<typeof ListboxLabel>;
 
 export const SelectLabel = forwardRef<HTMLDivElement, SelectLabelProps>(
   (props, ref) => {

--- a/packages/react/src/select/SelectRadioItem.tsx
+++ b/packages/react/src/select/SelectRadioItem.tsx
@@ -3,7 +3,9 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { ListboxRadioItem } from "../listbox";
 import { SelectItem } from "./SelectItem";
 
-type SelectRadioItemProps = ComponentPropsWithoutRef<typeof ListboxRadioItem> &
+export type SelectRadioItemProps = ComponentPropsWithoutRef<
+  typeof ListboxRadioItem
+> &
   ComponentPropsWithoutRef<typeof SelectItem>;
 
 export const SelectRadioItem = forwardRef<HTMLDivElement, SelectRadioItemProps>(

--- a/packages/react/src/select/SelectSeparator.tsx
+++ b/packages/react/src/select/SelectSeparator.tsx
@@ -2,7 +2,9 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 import { ListboxSeparator } from "../listbox";
 
-type SelectSeparatorProps = ComponentPropsWithoutRef<typeof ListboxSeparator>;
+export type SelectSeparatorProps = ComponentPropsWithoutRef<
+  typeof ListboxSeparator
+>;
 
 export const SelectSeparator = forwardRef<HTMLDivElement, SelectSeparatorProps>(
   (props, ref) => {

--- a/packages/react/src/select/SelectTrigger.tsx
+++ b/packages/react/src/select/SelectTrigger.tsx
@@ -20,7 +20,7 @@ import { useSelectContext } from "./SelectContext";
 
 const Slot = createSlot("@optiaxiom/react/SelectTrigger");
 
-type SelectTriggerProps = ExcludeProps<
+export type SelectTriggerProps = ExcludeProps<
   ButtonProps<
     typeof PopperAnchor,
     {

--- a/packages/react/src/separator/Separator.tsx
+++ b/packages/react/src/separator/Separator.tsx
@@ -5,7 +5,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./Separator.css";
 
-type SeparatorProps = BoxProps<
+export type SeparatorProps = BoxProps<
   typeof RadixSeparator.Root,
   styles.SeparatorVariants
 >;

--- a/packages/react/src/sidebar/Sidebar.tsx
+++ b/packages/react/src/sidebar/Sidebar.tsx
@@ -5,7 +5,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import { SidebarProvider } from "./SidebarContext";
 
-type SidebarProps = BoxProps<
+export type SidebarProps = BoxProps<
   "div",
   {
     /**

--- a/packages/react/src/skeleton/Skeleton.tsx
+++ b/packages/react/src/skeleton/Skeleton.tsx
@@ -6,7 +6,7 @@ import * as styles from "./Skeleton.css";
 
 const Slot = createSlot("@optiaxiom/react/Skeleton");
 
-type SkeletonProps = BoxProps<
+export type SkeletonProps = BoxProps<
   "span",
   {
     children?: ReactElement;

--- a/packages/react/src/spinner/Spinner.tsx
+++ b/packages/react/src/spinner/Spinner.tsx
@@ -4,7 +4,7 @@ import { Box, type BoxProps } from "../box";
 import { Flex } from "../flex";
 import * as styles from "./Spinner.css";
 
-type SpinnerProps = BoxProps<
+export type SpinnerProps = BoxProps<
   "div",
   {
     appearance?: "default" | "inverse";

--- a/packages/react/src/spotlight/Spotlight.tsx
+++ b/packages/react/src/spotlight/Spotlight.tsx
@@ -4,7 +4,7 @@ import type { ExcludeProps } from "../utils";
 
 import { Menu } from "../menu";
 
-type SpotlightProps = ExcludeProps<
+export type SpotlightProps = ExcludeProps<
   ComponentPropsWithoutRef<typeof Menu>,
   "initialInputVisible" | "size"
 >;

--- a/packages/react/src/spotlight/SpotlightContent.tsx
+++ b/packages/react/src/spotlight/SpotlightContent.tsx
@@ -2,7 +2,9 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 import { MenuContent } from "../menu";
 
-type SpotlightContentProps = ComponentPropsWithoutRef<typeof MenuContent>;
+export type SpotlightContentProps = ComponentPropsWithoutRef<
+  typeof MenuContent
+>;
 
 export const SpotlightContent = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/spotlight/SpotlightTrigger.tsx
+++ b/packages/react/src/spotlight/SpotlightTrigger.tsx
@@ -7,7 +7,7 @@ import { IconMagnifyingGlass } from "../icons/IconMagnifyingGlass";
 import { MenuTrigger } from "../menu";
 import { useMenuContext } from "../menu/internals";
 
-type SpotlightTriggerProps = ButtonProps<
+export type SpotlightTriggerProps = ButtonProps<
   typeof MenuTrigger,
   {
     hotkey?: string;

--- a/packages/react/src/sprinkles/sprinkles.ts
+++ b/packages/react/src/sprinkles/sprinkles.ts
@@ -12,8 +12,7 @@ export const sprinkles = createSprinkles(
 );
 export const mapResponsiveValue = createMapValueFn(styles.responsiveProps);
 
-export type Sprinkles = Omit<Parameters<typeof sprinkles>[0], LonghandProps>;
-type LonghandProps = keyof Pick<
+export type LonghandProps = keyof Pick<
   Parameters<typeof sprinkles>[0],
   | "backgroundColor"
   | "borderBottomWidth"
@@ -36,3 +35,4 @@ type LonghandProps = keyof Pick<
   | "width"
   | "zIndex"
 >;
+export type Sprinkles = Omit<Parameters<typeof sprinkles>[0], LonghandProps>;

--- a/packages/react/src/sub-nav/SubNav.tsx
+++ b/packages/react/src/sub-nav/SubNav.tsx
@@ -5,7 +5,7 @@ import { Flex } from "../flex";
 import { SidebarProvider } from "../sidebar/internals";
 import * as styles from "./SubNav.css";
 
-type SubNavProps = BoxProps<"nav">;
+export type SubNavProps = BoxProps<"nav">;
 
 export const SubNav = forwardRef<HTMLDivElement, SubNavProps>(
   ({ children, ...props }, ref) => {

--- a/packages/react/src/switch/Switch.tsx
+++ b/packages/react/src/switch/Switch.tsx
@@ -11,7 +11,7 @@ import {
 } from "../toggle-input";
 import * as styles from "./Switch.css";
 
-type SwitchProps = BoxProps<
+export type SwitchProps = BoxProps<
   typeof ToggleInputHiddenInput,
   styles.SwitchVariants & {
     /**

--- a/packages/react/src/table/Table.tsx
+++ b/packages/react/src/table/Table.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./Table.css";
 
-type TableProps = BoxProps<"div", styles.TableVariants>;
+export type TableProps = BoxProps<"div", styles.TableVariants>;
 
 export const Table = forwardRef<HTMLDivElement, TableProps>(
   ({ children, className, layout = "auto", ...props }, ref) => (

--- a/packages/react/src/table/TableAction.tsx
+++ b/packages/react/src/table/TableAction.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { ActionsContent } from "../actions";
 import { type BoxProps } from "../box";
 
-type TableActionProps = BoxProps<"div">;
+export type TableActionProps = BoxProps<"div">;
 
 export const TableAction = forwardRef<HTMLDivElement, TableActionProps>(
   (props, ref) => {

--- a/packages/react/src/table/TableBody.tsx
+++ b/packages/react/src/table/TableBody.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./TableBody.css";
 
-type TableBodyProps = BoxProps<"tbody">;
+export type TableBodyProps = BoxProps<"tbody">;
 
 export const TableBody = forwardRef<HTMLTableSectionElement, TableBodyProps>(
   ({ children, className, ...props }, ref) => (

--- a/packages/react/src/table/TableCell.tsx
+++ b/packages/react/src/table/TableCell.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./TableCell.css";
 
-type TableCellProps = BoxProps<"td">;
+export type TableCellProps = BoxProps<"td">;
 
 export const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(
   ({ children, className, colSpan, ...props }, ref) => {

--- a/packages/react/src/table/TableHeader.tsx
+++ b/packages/react/src/table/TableHeader.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from "react";
 
 import { Box, type BoxProps } from "../box";
 
-type TableHeaderProps = BoxProps<"thead">;
+export type TableHeaderProps = BoxProps<"thead">;
 
 export const TableHeader = forwardRef<
   HTMLTableSectionElement,

--- a/packages/react/src/table/TableHeaderCell.tsx
+++ b/packages/react/src/table/TableHeaderCell.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./TableHeaderCell.css";
 
-type TableHeaderCellProps = BoxProps<"th">;
+export type TableHeaderCellProps = BoxProps<"th">;
 
 export const TableHeaderCell = forwardRef<
   HTMLTableCellElement,

--- a/packages/react/src/table/TableRow.tsx
+++ b/packages/react/src/table/TableRow.tsx
@@ -4,7 +4,7 @@ import { ActionsRoot } from "../actions";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./TableRow.css";
 
-type TableRowProps = BoxProps<"tr">;
+export type TableRowProps = BoxProps<"tr">;
 
 export const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
   ({ children, className, ...props }, ref) => (

--- a/packages/react/src/tabs/Tabs.tsx
+++ b/packages/react/src/tabs/Tabs.tsx
@@ -4,7 +4,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps, extractBoxProps } from "../box";
 import * as styles from "./Tabs.css";
 
-type TabsProps = BoxProps<typeof RadixTabs.Root>;
+export type TabsProps = BoxProps<typeof RadixTabs.Root>;
 
 export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
   ({ children, className, ...props }, ref) => {

--- a/packages/react/src/tabs/TabsContent.tsx
+++ b/packages/react/src/tabs/TabsContent.tsx
@@ -5,7 +5,7 @@ import type { ExcludeProps } from "../utils";
 
 import { Box, type BoxProps } from "../box";
 
-type TabsContentProps = ExcludeProps<
+export type TabsContentProps = ExcludeProps<
   BoxProps<typeof RadixTabs.TabsContent>,
   "forceMount"
 >;

--- a/packages/react/src/tabs/TabsList.tsx
+++ b/packages/react/src/tabs/TabsList.tsx
@@ -4,7 +4,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./TabsList.css";
 
-type TabsListProps = BoxProps<typeof RadixTabs.List>;
+export type TabsListProps = BoxProps<typeof RadixTabs.List>;
 
 export const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
   ({ children, className, ...props }, ref) => {

--- a/packages/react/src/tabs/TabsTrigger.tsx
+++ b/packages/react/src/tabs/TabsTrigger.tsx
@@ -5,7 +5,7 @@ import { Box, type BoxProps, extractBoxProps } from "../box";
 import { Flex } from "../flex";
 import * as styles from "./TabsTrigger.css";
 
-type TabsTriggerProps = BoxProps<
+export type TabsTriggerProps = BoxProps<
   typeof RadixTabs.Trigger,
   {
     /**

--- a/packages/react/src/textarea/Textarea.tsx
+++ b/packages/react/src/textarea/Textarea.tsx
@@ -18,7 +18,7 @@ import { TextareaAutosize } from "./TextareaAutosize";
 
 const Slot = createSlot("@optiaxiom/react/Textarea");
 
-type TextareaProps = InputControlProps<
+export type TextareaProps = InputControlProps<
   typeof TextareaAutosize,
   Pick<ComponentPropsWithoutRef<typeof InputRoot>, "addonPointerEvents"> & {
     addonAfter?: ReactNode;

--- a/packages/react/src/textarea/TextareaAutosize.tsx
+++ b/packages/react/src/textarea/TextareaAutosize.tsx
@@ -7,7 +7,10 @@ import * as styles from "./TextareaAutosize.css";
 
 const Slot = createSlot("@optiaxiom/react/TextareaAutosize");
 
-type TextareaAutosizeProps = BoxProps<"textarea", styles.WrapperVariants>;
+export type TextareaAutosizeProps = BoxProps<
+  "textarea",
+  styles.WrapperVariants
+>;
 
 export const TextareaAutosize = forwardRef<
   HTMLTextAreaElement,

--- a/packages/react/src/theme-provider/ThemeProvider.tsx
+++ b/packages/react/src/theme-provider/ThemeProvider.tsx
@@ -5,7 +5,7 @@ import { type ReactNode, useEffect, useRef, useState } from "react";
 import { layers } from "../layers";
 import { PortalProvider } from "../portal/internals";
 
-type ThemeProviderProps = {
+export type ThemeProviderProps = {
   children?: ReactNode;
 };
 

--- a/packages/react/src/toast/Toast.tsx
+++ b/packages/react/src/toast/Toast.tsx
@@ -16,7 +16,7 @@ import { IconTriangleExclamationSolid } from "../icons/IconTriangleExclamationSo
 import { IconX } from "../icons/IconX";
 import * as styles from "./Toast.css";
 
-type ToastProps = ExcludeProps<
+export type ToastProps = ExcludeProps<
   BoxProps<typeof RadixToast.Root, styles.RootVariants>,
   "forceMount" | "open"
 >;

--- a/packages/react/src/toast/ToastAction.tsx
+++ b/packages/react/src/toast/ToastAction.tsx
@@ -4,9 +4,9 @@ import { forwardRef } from "react";
 import { Button, type ButtonProps } from "../button";
 import { Separator } from "../separator";
 
-type ToastProps = ButtonProps<typeof RadixToast.Action>;
+export type ToastActionProps = ButtonProps<typeof RadixToast.Action>;
 
-export const ToastAction = forwardRef<HTMLButtonElement, ToastProps>(
+export const ToastAction = forwardRef<HTMLButtonElement, ToastActionProps>(
   (
     { altText, appearance = "inverse", children, size = "sm", ...props },
     ref,

--- a/packages/react/src/toast/ToastProvider.tsx
+++ b/packages/react/src/toast/ToastProvider.tsx
@@ -19,7 +19,7 @@ import * as styles from "./ToastProvider.css";
 import { ToastTitle } from "./ToastTitle";
 import { useOverflowAnchor } from "./useOverflowAnchor";
 
-type ToastProps = BoxProps<
+export type ToastProviderProps = BoxProps<
   typeof RadixToast.Viewport,
   ComponentPropsWithoutRef<typeof RadixToast.ToastProvider> &
     styles.ViewportVariants & {
@@ -41,7 +41,7 @@ const mapPositionToSwipeDirection = {
   "top-right": "right",
 } as const;
 
-export const ToastProvider = forwardRef<HTMLOListElement, ToastProps>(
+export const ToastProvider = forwardRef<HTMLOListElement, ToastProviderProps>(
   (
     {
       className,

--- a/packages/react/src/toast/ToastTitle.tsx
+++ b/packages/react/src/toast/ToastTitle.tsx
@@ -3,9 +3,9 @@ import { forwardRef } from "react";
 
 import { Text, type TextProps } from "../text";
 
-type ToastProps = TextProps<typeof RadixToast.Title>;
+export type ToastTitleProps = TextProps<typeof RadixToast.Title>;
 
-export const ToastTitle = forwardRef<HTMLDivElement, ToastProps>(
+export const ToastTitle = forwardRef<HTMLDivElement, ToastTitleProps>(
   ({ children, ...props }, ref) => {
     return (
       <Text asChild flex="1" {...props}>

--- a/packages/react/src/toggle-button/ToggleButton.tsx
+++ b/packages/react/src/toggle-button/ToggleButton.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 
 import { Button, type ButtonProps } from "../button";
 
-type ToggleButtonProps = ButtonProps<
+export type ToggleButtonProps = ButtonProps<
   typeof RadixToggle.Root,
   {
     /**

--- a/packages/react/src/toggle-input/ToggleInput.tsx
+++ b/packages/react/src/toggle-input/ToggleInput.tsx
@@ -9,7 +9,7 @@ import { ToggleInputProvider } from "./ToggleInputContext";
 
 const Slot = createSlot("@optiaxiom/react/ToggleInput");
 
-type ToggleInputProps = BoxProps<
+export type ToggleInputProps = BoxProps<
   "label",
   {
     description?: boolean;

--- a/packages/react/src/toggle-input/ToggleInputContent.tsx
+++ b/packages/react/src/toggle-input/ToggleInputContent.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from "react";
 
 import { Box, type BoxProps } from "../box";
 
-type ToggleInputContentProps = BoxProps<"div">;
+export type ToggleInputContentProps = BoxProps<"div">;
 
 export const ToggleInputContent = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/toggle-input/ToggleInputControl.tsx
+++ b/packages/react/src/toggle-input/ToggleInputControl.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import * as styles from "./ToggleInputControl.css";
 
-type ToggleInputControlProps = BoxProps<"div">;
+export type ToggleInputControlProps = BoxProps<"div">;
 
 export const ToggleInputControl = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/toggle-input/ToggleInputDescription.tsx
+++ b/packages/react/src/toggle-input/ToggleInputDescription.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import { useToggleInputContext } from "./ToggleInputContext";
 
-type ToggleInputDescriptionProps = BoxProps<"div">;
+export type ToggleInputDescriptionProps = BoxProps<"div">;
 
 export const ToggleInputDescription = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/toggle-input/ToggleInputHiddenInput.tsx
+++ b/packages/react/src/toggle-input/ToggleInputHiddenInput.tsx
@@ -7,7 +7,7 @@ import { VisuallyHidden } from "../visually-hidden";
 import { useToggleInputContext } from "./ToggleInputContext";
 import * as styles from "./ToggleInputHiddenInput.css";
 
-type ToggleInputHiddenInputProps = ExtendProps<
+export type ToggleInputHiddenInputProps = ExtendProps<
   ComponentPropsWithoutRef<"input">,
   {
     onCheckedChange?: (checked: boolean) => void;

--- a/packages/react/src/toggle-input/ToggleInputLabel.tsx
+++ b/packages/react/src/toggle-input/ToggleInputLabel.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Box, type BoxProps } from "../box";
 import { useToggleInputContext } from "./ToggleInputContext";
 
-type ToggleInputLabelProps = BoxProps<"div">;
+export type ToggleInputLabelProps = BoxProps<"div">;
 
 export const ToggleInputLabel = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/tooltip/Tooltip.tsx
+++ b/packages/react/src/tooltip/Tooltip.tsx
@@ -7,7 +7,7 @@ import { TooltipContent } from "./TooltipContent";
 import { TooltipRoot } from "./TooltipRoot";
 import { TooltipTrigger } from "./TooltipTrigger";
 
-type TooltipProps = ExcludeProps<
+export type TooltipProps = ExcludeProps<
   BoxProps<
     typeof TooltipContent,
     Pick<ComponentPropsWithRef<typeof TooltipRoot>, "delayDuration"> & {

--- a/packages/react/src/tooltip/TooltipContent.tsx
+++ b/packages/react/src/tooltip/TooltipContent.tsx
@@ -11,7 +11,7 @@ import { Transition, TransitionGroup } from "../transition";
 import * as styles from "./TooltipContent.css";
 import { useTooltipContext } from "./TooltipContext";
 
-type TooltipContentProps = ExcludeProps<
+export type TooltipContentProps = ExcludeProps<
   BoxProps<typeof RadixTooltip.Content>,
   | "alignOffset"
   | "arrowPadding"

--- a/packages/react/src/tooltip/TooltipProvider.tsx
+++ b/packages/react/src/tooltip/TooltipProvider.tsx
@@ -4,7 +4,7 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 import type { ExtendProps } from "../utils";
 
-type TooltipProviderProps = ExtendProps<
+export type TooltipProviderProps = ExtendProps<
   ComponentPropsWithoutRef<typeof TooltipPrimitive.Provider>,
   {
     /**

--- a/packages/react/src/tooltip/TooltipRoot.tsx
+++ b/packages/react/src/tooltip/TooltipRoot.tsx
@@ -5,7 +5,7 @@ import { useRef } from "react";
 import { type BoxProps } from "../box";
 import { TooltipProvider } from "./TooltipContext";
 
-type TooltipRootProps = BoxProps<
+export type TooltipRootProps = BoxProps<
   typeof RadixTooltip.Root,
   {
     auto?: boolean;

--- a/packages/react/src/tooltip/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/TooltipTrigger.tsx
@@ -6,7 +6,7 @@ import { Button } from "../button";
 import { FilteredSlot } from "../filtered-slot";
 import { useTooltipContext } from "./TooltipContext";
 
-type TooltipTriggerProps = ComponentPropsWithoutRef<
+export type TooltipTriggerProps = ComponentPropsWithoutRef<
   typeof RadixTooltip.Trigger
 >;
 

--- a/packages/react/src/transition/Transition.tsx
+++ b/packages/react/src/transition/Transition.tsx
@@ -8,7 +8,7 @@ import { useTransitionStatus } from "./useTransitionStatus";
 
 const Slot = createSlot("@optiaxiom/react/Transition");
 
-type TransitionProps = styles.TransitionVariants & {
+export type TransitionProps = styles.TransitionVariants & {
   children: ReactElement;
   "data-side"?: "bottom" | "left" | "right" | "top";
   skipAnimations?: boolean;

--- a/packages/react/src/visually-hidden/VisuallyHidden.tsx
+++ b/packages/react/src/visually-hidden/VisuallyHidden.tsx
@@ -3,7 +3,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 import { FilteredSlot } from "../filtered-slot";
 
-type VisuallyHiddenProps = ComponentPropsWithoutRef<
+export type VisuallyHiddenProps = ComponentPropsWithoutRef<
   typeof RadixVisuallyHidden.Root
 > & {
   disabled?: boolean;

--- a/packages/shared/.eslintplugin/consistent-exported-props.js
+++ b/packages/shared/.eslintplugin/consistent-exported-props.js
@@ -1,0 +1,72 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+export default ESLintUtils.RuleCreator.withoutDocs({
+  create(context) {
+    /**
+     * @type {import('@typescript-eslint/utils').TSESTree.TSTypeAliasDeclaration}
+     */
+    let exportedPropTypes;
+    /**
+     * @type {import('@typescript-eslint/utils').TSESTree.TSTypeAliasDeclaration}
+     */
+    let propTypes;
+
+    return {
+      /**
+       * @type {import('@typescript-eslint/utils').TSESLint.RuleListener['TSTypeAliasDeclaration']}
+       */
+      "Program > ExportNamedDeclaration > TSTypeAliasDeclaration[id.name=/Props$/]":
+        (node) => {
+          exportedPropTypes = node;
+        },
+      /**
+       * @type {import('@typescript-eslint/utils').TSESLint.RuleListener['AssignmentExpression']}
+       */
+      'Program > ExpressionStatement > AssignmentExpression[left.type="MemberExpression"][left.object.type="Identifier"][left.property.name="displayName"][right.type="Literal"]':
+        (node) => {
+          if (
+            node.left.type !== "MemberExpression" ||
+            node.left.object.type !== "Identifier" ||
+            node.right.type !== "Literal"
+          ) {
+            return;
+          }
+
+          const component = node.left.object.name;
+          if (
+            exportedPropTypes &&
+            exportedPropTypes.id.name !== `${component}Props`
+          ) {
+            context.report({
+              messageId: "naming",
+              node: exportedPropTypes.id,
+            });
+          } else if (propTypes?.id.name === `${component}Props`) {
+            context.report({
+              fix: (fixer) => fixer.insertTextBefore(propTypes, "export "),
+              messageId: "export",
+              node: propTypes.id,
+            });
+          }
+        },
+      /**
+       * @type {import('@typescript-eslint/utils').TSESLint.RuleListener['TSTypeAliasDeclaration']}
+       */
+      "Program > TSTypeAliasDeclaration[id.name=/Props$/]": (node) => {
+        propTypes = node;
+      },
+    };
+  },
+
+  defaultOptions: [],
+
+  meta: {
+    fixable: "code",
+    messages: {
+      export: "Please export component prop types",
+      naming: "Please prefix the prop type name with the component name",
+    },
+    schema: [],
+    type: "suggestion",
+  },
+});

--- a/packages/shared/configs/eslint.config.base.js
+++ b/packages/shared/configs/eslint.config.base.js
@@ -137,6 +137,7 @@ export default tsEslint.config(
         },
       ],
       "local/consistent-display-name": "error",
+      "local/consistent-exported-props": "error",
       "local/missing-recipe-classname": "error",
       "local/no-useless-clsx": "error",
       "local/prefer-styles-import": "error",


### PR DESCRIPTION
will make it easier for consumers to refer to prop types

and should reduce the file size of generated types