### PR TITLE
fix detecting group/separator options in ListboxItemized

### DIFF
--- a/.changeset/true-sloths-think.md
+++ b/.changeset/true-sloths-think.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+fix detecting group/separator options in ListboxItemized

--- a/apps/docs/app/(docs)/components/menu/page.mdx
+++ b/apps/docs/app/(docs)/components/menu/page.mdx
@@ -76,7 +76,7 @@ The following example shows how we can build **creatable** menus by allowing the
 
 We can also manually control `options` in combination with the `inputValue` and `onInputValueChange` prop to load items as the user types.
 
-And we can toggle the `loading` prop to show a loading spinner while the data is loading (an empty state will be shown otherwise).
+And we can toggle the `loading` prop to show a loading state while the data is loading (an empty state will be shown otherwise).
 
 <Demo component="menu/input-controlled-usage" meta="{55,56}" />
 

--- a/apps/docs/demos/menu/group-usage/App.tsx
+++ b/apps/docs/demos/menu/group-usage/App.tsx
@@ -9,11 +9,11 @@ import {
 
 const groups = {
   display: {
-    name: "Publishing Options",
+    label: "Publishing Options",
   },
   divider: {
     hidden: true,
-    name: "Blank",
+    label: "Blank",
     separator: true,
   },
 } satisfies Record<string, MenuOption["group"]>;

--- a/apps/storybook/src/components/Menu.stories.tsx
+++ b/apps/storybook/src/components/Menu.stories.tsx
@@ -181,13 +181,13 @@ export const Multiple: Story = {
 };
 
 const inviteGroup = {
-  name: "Invite",
+  label: "Invite",
   separator: true,
-};
+} satisfies MenuOption["group"];
 const userGroup = {
-  name: "Users",
+  label: "Users",
   separator: true,
-};
+} satisfies MenuOption["group"];
 
 const users = [
   {
@@ -384,7 +384,11 @@ export const Controlled: Story = {
   },
 };
 
-const groups = [{ name: "Fruits" }, { name: "Vegetables" }, { name: "Meats" }];
+const groups = [
+  { label: "Fruits" },
+  { label: "Vegetables" },
+  { label: "Meats" },
+] satisfies Array<MenuOption["group"]>;
 
 const foods = [
   { group: groups[0], label: "Apple" },

--- a/apps/storybook/src/components/Spotlight.stories.tsx
+++ b/apps/storybook/src/components/Spotlight.stories.tsx
@@ -20,15 +20,15 @@ type Story = StoryObj<typeof Spotlight>;
 
 const categories = {
   Layout: {
-    name: "Layout",
+    label: "Layout",
   },
   Sizing: {
-    name: "Sizing",
+    label: "Sizing",
   },
   Typography: {
-    name: "Typography",
+    label: "Typography",
   },
-};
+} satisfies Record<string, MenuOption["group"]>;
 
 const pages = [
   {

--- a/packages/react/src/command/CommandContext.ts
+++ b/packages/react/src/command/CommandContext.ts
@@ -80,7 +80,7 @@ export type CommandOption = {
 
 type CommandOptionGroup = {
   hidden?: boolean;
-  name: string;
+  label: string;
   separator?: boolean;
 };
 

--- a/packages/react/src/listbox/ListboxItemized.tsx
+++ b/packages/react/src/listbox/ListboxItemized.tsx
@@ -14,7 +14,7 @@ export type ListboxItemizedProps = BoxProps<
   "div",
   {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    children?: ((item: any, index: number) => ReactNode) | ReactNode;
+    children?: ((item: any, prevItem: any) => ReactNode) | ReactNode;
     /**
      * Custom empty state content.
      */
@@ -87,7 +87,9 @@ export const ListboxItemized = forwardRef<HTMLDivElement, ListboxItemizedProps>(
             </ListboxVirtualized>
           ) : items.length > 0 ? (
             items.map((item, index) => (
-              <Fragment key={itemToKey(item)}>{children(item, index)}</Fragment>
+              <Fragment key={itemToKey(item)}>
+                {children(item, items[index - 1])}
+              </Fragment>
             ))
           ) : (
             <ListboxEmpty>{empty}</ListboxEmpty>

--- a/packages/react/src/listbox/ListboxVirtualized.tsx
+++ b/packages/react/src/listbox/ListboxVirtualized.tsx
@@ -18,7 +18,7 @@ import { Listbox } from "./Listbox";
 export type ListboxVirtualizedProps<T = unknown> = BoxProps<
   "div",
   {
-    children: (item: T, index: number) => ReactNode;
+    children: (item: T, prevItem: T | undefined) => ReactNode;
     highlightedItem?: T;
     items: readonly T[] | T[];
     ref?: LegacyRef<HTMLDivElement>;
@@ -114,7 +114,7 @@ export const ListboxVirtualized = forwardRef<
             key={virtualItem.key}
             ref={rowVirtualizer.measureElement}
           >
-            {children(items[virtualItem.index], virtualItem.index)}
+            {children(items[virtualItem.index], items[virtualItem.index - 1])}
           </Box>
         ))}
       </Box>

--- a/packages/react/src/listbox/utils.ts
+++ b/packages/react/src/listbox/utils.ts
@@ -1,0 +1,34 @@
+type Option = {
+  group?: {
+    hidden?: boolean;
+    label: string;
+    separator?: boolean;
+  };
+};
+
+export const shouldShowSeparator = (
+  group: Option["group"],
+  prevItem: Option | undefined,
+) => {
+  const isFirstItem = !prevItem;
+  return (
+    !isFirstItem &&
+    !isSameGroup(group, prevItem?.group) &&
+    (group?.separator || prevItem?.group?.separator)
+  );
+};
+
+export const shouldShowGroup = (
+  group: Option["group"],
+  prevItem: Option | undefined,
+): group is NonNullable<Option["group"]> => {
+  const show = !isSameGroup(group, prevItem?.group);
+  return show && !!group && !group.hidden;
+};
+
+const isSameGroup = (group1: Option["group"], group2: Option["group"]) => {
+  if (group1 === group2) {
+    return true;
+  }
+  return group1?.label === group2?.label;
+};

--- a/packages/react/src/menu/MenuListbox.tsx
+++ b/packages/react/src/menu/MenuListbox.tsx
@@ -3,6 +3,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { CommandListbox } from "../command";
 import { type CommandOption, resolveItemProperty } from "../command/internals";
 import { ListboxLabel, ListboxSeparator } from "../listbox";
+import { shouldShowGroup, shouldShowSeparator } from "../listbox/utils";
 import { Tooltip } from "../tooltip";
 import { MenuCheckboxItem } from "./MenuCheckboxItem";
 import { useMenuContext } from "./MenuContext";
@@ -16,34 +17,10 @@ export const MenuListbox = forwardRef<HTMLDivElement, MenuListboxProps>(
   ({ children, ...props }, ref) => {
     const { size } = useMenuContext("@optiaxiom/react/MenuListbox");
 
-    let isFirstItem = true;
-    let lastGroup: CommandOption["group"] = undefined;
-    const shouldShowSeparator = (group: CommandOption["group"]) => {
-      const show = !isFirstItem;
-      isFirstItem = false;
-      return (
-        show &&
-        group !== lastGroup &&
-        (group?.separator || lastGroup?.separator)
-      );
-    };
-    const shouldShowGroup = (
-      group: CommandOption["group"],
-    ): group is NonNullable<CommandOption["group"]> => {
-      const show = group !== lastGroup;
-      lastGroup = group;
-      return show && !!group && !group?.hidden;
-    };
-
     return (
       <CommandListbox ref={ref} {...props}>
         {children ??
-          ((item: CommandOption, index) => {
-            if (index === 0) {
-              isFirstItem = true;
-              lastGroup = undefined;
-            }
-
+          ((item: CommandOption, prevItem: CommandOption | undefined) => {
             const Comp = item.subOptions?.length
               ? size === "sm"
                 ? MenuSub
@@ -56,9 +33,9 @@ export const MenuListbox = forwardRef<HTMLDivElement, MenuListboxProps>(
             const group = item.group;
             return (
               <>
-                {shouldShowSeparator(group) && <ListboxSeparator />}
-                {shouldShowGroup(group) && (
-                  <ListboxLabel>{group.name}</ListboxLabel>
+                {shouldShowSeparator(group, prevItem) && <ListboxSeparator />}
+                {shouldShowGroup(group, prevItem) && (
+                  <ListboxLabel>{group.label}</ListboxLabel>
                 )}
                 {Comp === MenuSub ? (
                   <Comp item={item} />

--- a/packages/react/src/select/SelectContent.tsx
+++ b/packages/react/src/select/SelectContent.tsx
@@ -10,6 +10,7 @@ import type { ExcludeProps } from "../utils";
 
 import { type BoxProps } from "../box";
 import { ListboxItemized, ListboxLabel, ListboxSeparator } from "../listbox";
+import { shouldShowGroup, shouldShowSeparator } from "../listbox/utils";
 import { ModalLayer } from "../modal";
 import { ModalListbox } from "../modal/internals";
 import { Portal } from "../portal";
@@ -44,25 +45,6 @@ export const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>(
 
     const [placed, setPlaced] = useState(false);
 
-    let isFirstItem = true;
-    let lastGroup: SelectOption["group"] = undefined;
-    const shouldShowSeparator = (group: SelectOption["group"]) => {
-      const show = !isFirstItem;
-      isFirstItem = false;
-      return (
-        show &&
-        group !== lastGroup &&
-        (group?.separator || lastGroup?.separator)
-      );
-    };
-    const shouldShowGroup = (
-      group: SelectOption["group"],
-    ): group is NonNullable<SelectOption["group"]> => {
-      const show = group !== lastGroup;
-      lastGroup = group;
-      return show && !!group && !group?.hidden;
-    };
-
     return (
       <TransitionGroup open={isOpen}>
         <Portal asChild>
@@ -87,17 +69,17 @@ export const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>(
                   {...downshift.getMenuProps({}, { suppressRefError: !placed })}
                 >
                   {children ??
-                    ((item: SelectOption, index) => {
-                      if (index === 0) {
-                        isFirstItem = true;
-                        lastGroup = undefined;
-                      }
-
+                    ((
+                      item: SelectOption,
+                      prevItem: SelectOption | undefined,
+                    ) => {
                       const group = item.group;
                       return (
                         <>
-                          {shouldShowSeparator(group) && <ListboxSeparator />}
-                          {shouldShowGroup(group) && (
+                          {shouldShowSeparator(group, prevItem) && (
+                            <ListboxSeparator />
+                          )}
+                          {shouldShowGroup(group, prevItem) && (
                             <ListboxLabel>{group.label}</ListboxLabel>
                           )}
                           <Tooltip content={item.disabledReason}>


### PR DESCRIPTION
by using actual last item instead of index and running variables to determine if we need to show group label or separator

since the render can happen inside virtualized lists which might not display all items and will not reflect previous group correctly this way

also rename group label property to be consistent