### PR TITLE
fix regression from portal refactor

### DIFF
--- a/packages/react/src/dialog/DialogContent.tsx
+++ b/packages/react/src/dialog/DialogContent.tsx
@@ -7,7 +7,7 @@ import { Backdrop } from "../backdrop";
 import { type BoxProps } from "../box";
 import { ModalProvider } from "../modal";
 import { Paper } from "../paper";
-import { Portal } from "../portal";
+import { usePortalContext } from "../portal/internals";
 import { Transition, TransitionGroup } from "../transition";
 import { type ExcludeProps, onReactSelectInputBlur } from "../utils";
 import * as styles from "./DialogContent.css";
@@ -42,9 +42,11 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
     const innerRef = useRef<HTMLDivElement>(null);
     const ref = useComposedRefs(innerRef, outerRef);
 
+    const { container } = usePortalContext("@optiaxiom/react/DialogContent");
+
     return (
       <TransitionGroup open={open}>
-        <Portal>
+        <RadixDialog.Portal container={container} forceMount>
           <Transition>
             <Backdrop
               asChild
@@ -73,7 +75,7 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
               </RadixDialog.Content>
             </Paper>
           </Transition>
-        </Portal>
+        </RadixDialog.Portal>
       </TransitionGroup>
     );
   },


### PR DESCRIPTION
DialogPortal has additional context inside it that we cannot extract

so we have to use it and pass the container manually