### PR TITLE
set initial value for sm view to true

### DIFF
--- a/packages/react/src/hooks/useResponsiveMatches.ts
+++ b/packages/react/src/hooks/useResponsiveMatches.ts
@@ -11,7 +11,7 @@ export const useResponsiveMatches = <const B, const T>(
 ) => {
   const matches = {
     base: true,
-    sm: useMediaQuery(conditions.conditions.sm["@media"]),
+    sm: useMediaQuery(conditions.conditions.sm["@media"], true),
     md: useMediaQuery(conditions.conditions.md["@media"]),
   };
 


### PR DESCRIPTION
since we are catering for larger devices more than smaller devices

otherwise base condition is met initially and then after useEffect/first mount it is switched to sm - which causes refs to get re-calculated as components are un-mounted and re-mounted