### PR TITLE
Revert "update vitest to latest version"

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -24,6 +24,7 @@
     "@tabler/icons-react": "^3.33.0",
     "@tanstack/react-table": "^8.21.3",
     "@vitejs/plugin-react": "^4.4.1",
+    "@vitest/browser": "3.1.1",
     "chromatic": "^11.28.3",
     "raw-loader": "^4.0.2",
     "react": "^18.3.1",
@@ -31,6 +32,7 @@
     "react-dom": "^18.3.1",
     "storybook": "^8.6.14",
     "storybook-addon-test-codegen": "^1.3.4",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "3.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@vanilla-extract/integration": "^8.0.2",
     "@vanilla-extract/rollup-plugin": "^1.3.15",
     "@vanilla-extract/vite-plugin": "^5.0.2",
-    "@vitest/browser": "^3.1.4",
+    "@vitest/browser": "3.1.1",
     "concurrently": "^9.1.2",
     "esbuild": "0.17.6",
     "happy-dom": "^17.4.7",
@@ -43,7 +43,7 @@
     "rollup-plugin-dts": "^6.2.1",
     "rollup-plugin-esbuild": "^6.2.1",
     "typescript": "^5.8.3",
-    "vitest": "^3.1.4",
+    "vitest": "3.1.1",
     "wait-on": "^8.0.3"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2(@types/node@22.15.21)(babel-plugin-macros@3.1.0)(terser@5.39.2)(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))(yaml@2.8.0)
       '@vitest/browser':
-        specifier: ^3.1.4
-        version: 3.1.4(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))(vitest@3.1.4)(webdriverio@9.12.0)
+        specifier: 3.1.1
+        version: 3.1.1(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))(vitest@3.1.1)(webdriverio@9.12.0)
       concurrently:
         specifier: ^9.1.2
         version: 9.1.2
@@ -98,8 +98,8 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.1.4(@types/debug@4.1.12)(@types/node@22.15.21)(@vitest/browser@3.1.4)(happy-dom@17.4.7)(jsdom@24.1.3)(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(terser@5.39.2)(yaml@2.8.0)
+        specifier: 3.1.1
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.21)(@vitest/browser@3.1.1)(happy-dom@17.4.7)(jsdom@24.1.3)(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(terser@5.39.2)(yaml@2.8.0)
       wait-on:
         specifier: ^8.0.3
         version: 8.0.3
@@ -219,7 +219,7 @@ importers:
         version: 8.6.14(@types/react@18.3.22)(storybook@8.6.14(prettier@3.5.3))
       '@storybook/experimental-addon-test':
         specifier: ^8.6.14
-        version: 8.6.14(@vitest/browser@3.1.4)(@vitest/runner@3.1.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.5.3))(vitest@3.1.4)
+        version: 8.6.14(@vitest/browser@3.1.1)(@vitest/runner@3.1.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.5.3))(vitest@3.1.1)
       '@storybook/react':
         specifier: ^8.6.14
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.5.3))(typescript@5.8.3)
@@ -238,6 +238,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.4.1
         version: 4.4.1(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))
+      '@vitest/browser':
+        specifier: 3.1.1
+        version: 3.1.1(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))(vitest@3.1.1)(webdriverio@9.12.0)
       chromatic:
         specifier: ^11.28.3
         version: 11.28.3
@@ -262,6 +265,9 @@ importers:
       vite:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0)
+      vitest:
+        specifier: 3.1.1
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.21)(@vitest/browser@3.1.1)(happy-dom@17.4.7)(jsdom@24.1.3)(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(terser@5.39.2)(yaml@2.8.0)
 
   packages/globals:
     dependencies:
@@ -2952,12 +2958,12 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
-  '@vitest/browser@3.1.4':
-    resolution: {integrity: sha512-2L4vR/tuUZBxKU72Qe+unIp1P8lZ0T5nlqPegkXxyZFR5gWqItV8VPPR261GOzl49Zw2AhzMABzMMHJagQ0a2g==}
+  '@vitest/browser@3.1.1':
+    resolution: {integrity: sha512-A+A69mMtrj1RPh96LfXGc309KSXhy2MslvyL+cp9+Y5EVdoJD4KfXDx/3SSlRGN70+hIoJ3RRbTidTvj18PZ/A==}
     peerDependencies:
       playwright: '*'
       safaridriver: '*'
-      vitest: 3.1.4
+      vitest: 3.1.1
       webdriverio: ^7.0.0 || ^8.0.0 || ^9.0.0
     peerDependenciesMeta:
       playwright:
@@ -2970,11 +2976,11 @@ packages:
   '@vitest/expect@2.0.5':
     resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
 
-  '@vitest/expect@3.1.4':
-    resolution: {integrity: sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==}
+  '@vitest/expect@3.1.1':
+    resolution: {integrity: sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==}
 
-  '@vitest/mocker@3.1.4':
-    resolution: {integrity: sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==}
+  '@vitest/mocker@3.1.1':
+    resolution: {integrity: sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -2990,20 +2996,29 @@ packages:
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
+  '@vitest/pretty-format@3.1.1':
+    resolution: {integrity: sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==}
+
+  '@vitest/pretty-format@3.1.2':
+    resolution: {integrity: sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==}
+
   '@vitest/pretty-format@3.1.4':
     resolution: {integrity: sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==}
 
-  '@vitest/runner@3.1.4':
-    resolution: {integrity: sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==}
+  '@vitest/runner@3.1.1':
+    resolution: {integrity: sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==}
 
-  '@vitest/snapshot@3.1.4':
-    resolution: {integrity: sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==}
+  '@vitest/runner@3.1.2':
+    resolution: {integrity: sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==}
+
+  '@vitest/snapshot@3.1.1':
+    resolution: {integrity: sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==}
 
   '@vitest/spy@2.0.5':
     resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
 
-  '@vitest/spy@3.1.4':
-    resolution: {integrity: sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==}
+  '@vitest/spy@3.1.1':
+    resolution: {integrity: sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==}
 
   '@vitest/utils@2.0.5':
     resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
@@ -3011,8 +3026,11 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
-  '@vitest/utils@3.1.4':
-    resolution: {integrity: sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==}
+  '@vitest/utils@3.1.1':
+    resolution: {integrity: sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==}
+
+  '@vitest/utils@3.1.2':
+    resolution: {integrity: sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==}
 
   '@wdio/config@9.11.0':
     resolution: {integrity: sha512-lBcmd7r+3nHJwIWDZ/cLIXcIL9rCmQmMvMWQ+Ykcrlc2khePX92VZyd0igptrZATJGD3tQ7VySR5Bozz6uMzyA==}
@@ -7187,6 +7205,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.1.1:
+    resolution: {integrity: sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-node@3.1.4:
     resolution: {integrity: sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -7232,16 +7255,16 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.1.4:
-    resolution: {integrity: sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==}
+  vitest@3.1.1:
+    resolution: {integrity: sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.1.4
-      '@vitest/ui': 3.1.4
+      '@vitest/browser': 3.1.1
+      '@vitest/ui': 3.1.1
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -9446,7 +9469,7 @@ snapshots:
       storybook: 8.6.14(prettier@3.5.3)
       unplugin: 1.16.1
 
-  '@storybook/experimental-addon-test@8.6.14(@vitest/browser@3.1.4)(@vitest/runner@3.1.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.5.3))(vitest@3.1.4)':
+  '@storybook/experimental-addon-test@8.6.14(@vitest/browser@3.1.1)(@vitest/runner@3.1.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.5.3))(vitest@3.1.1)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9457,9 +9480,9 @@ snapshots:
       storybook: 8.6.14(prettier@3.5.3)
       ts-dedent: 2.2.0
     optionalDependencies:
-      '@vitest/browser': 3.1.4(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))(vitest@3.1.4)(webdriverio@9.12.0)
-      '@vitest/runner': 3.1.4
-      vitest: 3.1.4(@types/debug@4.1.12)(@types/node@22.15.21)(@vitest/browser@3.1.4)(happy-dom@17.4.7)(jsdom@24.1.3)(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(terser@5.39.2)(yaml@2.8.0)
+      '@vitest/browser': 3.1.1(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))(vitest@3.1.1)(webdriverio@9.12.0)
+      '@vitest/runner': 3.1.2
+      vitest: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.21)(@vitest/browser@3.1.1)(happy-dom@17.4.7)(jsdom@24.1.3)(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(terser@5.39.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -10104,16 +10127,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.1.4(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))(vitest@3.1.4)(webdriverio@9.12.0)':
+  '@vitest/browser@3.1.1(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))(vitest@3.1.1)(webdriverio@9.12.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.1.4(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))
-      '@vitest/utils': 3.1.4
+      '@vitest/mocker': 3.1.1(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))
+      '@vitest/utils': 3.1.1
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.4(@types/debug@4.1.12)(@types/node@22.15.21)(@vitest/browser@3.1.4)(happy-dom@17.4.7)(jsdom@24.1.3)(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(terser@5.39.2)(yaml@2.8.0)
+      vitest: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.21)(@vitest/browser@3.1.1)(happy-dom@17.4.7)(jsdom@24.1.3)(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(terser@5.39.2)(yaml@2.8.0)
       ws: 8.18.2
     optionalDependencies:
       playwright: 1.52.0
@@ -10131,16 +10154,16 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 1.2.0
 
-  '@vitest/expect@3.1.4':
+  '@vitest/expect@3.1.1':
     dependencies:
-      '@vitest/spy': 3.1.4
-      '@vitest/utils': 3.1.4
+      '@vitest/spy': 3.1.1
+      '@vitest/utils': 3.1.1
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.4(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))':
+  '@vitest/mocker@3.1.1(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))':
     dependencies:
-      '@vitest/spy': 3.1.4
+      '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
@@ -10155,18 +10178,33 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
+  '@vitest/pretty-format@3.1.1':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/pretty-format@3.1.2':
+    dependencies:
+      tinyrainbow: 2.0.0
+    optional: true
+
   '@vitest/pretty-format@3.1.4':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.1.4':
+  '@vitest/runner@3.1.1':
     dependencies:
-      '@vitest/utils': 3.1.4
+      '@vitest/utils': 3.1.1
       pathe: 2.0.3
 
-  '@vitest/snapshot@3.1.4':
+  '@vitest/runner@3.1.2':
     dependencies:
-      '@vitest/pretty-format': 3.1.4
+      '@vitest/utils': 3.1.2
+      pathe: 2.0.3
+    optional: true
+
+  '@vitest/snapshot@3.1.1':
+    dependencies:
+      '@vitest/pretty-format': 3.1.1
       magic-string: 0.30.17
       pathe: 2.0.3
 
@@ -10174,7 +10212,7 @@ snapshots:
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/spy@3.1.4':
+  '@vitest/spy@3.1.1':
     dependencies:
       tinyspy: 3.0.2
 
@@ -10191,11 +10229,18 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 1.2.0
 
-  '@vitest/utils@3.1.4':
+  '@vitest/utils@3.1.1':
     dependencies:
-      '@vitest/pretty-format': 3.1.4
+      '@vitest/pretty-format': 3.1.1
       loupe: 3.1.3
       tinyrainbow: 2.0.0
+
+  '@vitest/utils@3.1.2':
+    dependencies:
+      '@vitest/pretty-format': 3.1.2
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
+    optional: true
 
   '@wdio/config@9.11.0':
     dependencies:
@@ -15499,6 +15544,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
+  vite-node@3.1.1(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.1.4(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
@@ -15534,15 +15600,15 @@ snapshots:
       terser: 5.39.2
       yaml: 2.8.0
 
-  vitest@3.1.4(@types/debug@4.1.12)(@types/node@22.15.21)(@vitest/browser@3.1.4)(happy-dom@17.4.7)(jsdom@24.1.3)(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(terser@5.39.2)(yaml@2.8.0):
+  vitest@3.1.1(@types/debug@4.1.12)(@types/node@22.15.21)(@vitest/browser@3.1.1)(happy-dom@17.4.7)(jsdom@24.1.3)(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(terser@5.39.2)(yaml@2.8.0):
     dependencies:
-      '@vitest/expect': 3.1.4
-      '@vitest/mocker': 3.1.4(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))
+      '@vitest/expect': 3.1.1
+      '@vitest/mocker': 3.1.1(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))
       '@vitest/pretty-format': 3.1.4
-      '@vitest/runner': 3.1.4
-      '@vitest/snapshot': 3.1.4
-      '@vitest/spy': 3.1.4
-      '@vitest/utils': 3.1.4
+      '@vitest/runner': 3.1.1
+      '@vitest/snapshot': 3.1.1
+      '@vitest/spy': 3.1.1
+      '@vitest/utils': 3.1.1
       chai: 5.2.0
       debug: 4.4.1
       expect-type: 1.2.1
@@ -15551,16 +15617,15 @@ snapshots:
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
       vite: 6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0)
-      vite-node: 3.1.4(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0)
+      vite-node: 3.1.1(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.15.21
-      '@vitest/browser': 3.1.4(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))(vitest@3.1.4)(webdriverio@9.12.0)
+      '@vitest/browser': 3.1.1(msw@2.7.3(@types/node@22.15.21)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.21)(terser@5.39.2)(yaml@2.8.0))(vitest@3.1.1)(webdriverio@9.12.0)
       happy-dom: 17.4.7
       jsdom: 24.1.3
     transitivePeerDependencies:


### PR DESCRIPTION
This reverts commit 612c13989a0aa896f545a6a074f8957a6bb522af.

looks like vitest 3.1.1 is still the most stable version and later versions randomly time out