### PR TITLE
freeze children when closing TransitionGroup

### DIFF
--- a/.changeset/major-regions-exist.md
+++ b/.changeset/major-regions-exist.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+freeze children when closing TransitionGroup

--- a/packages/react/src/menu/MenuSubContent.tsx
+++ b/packages/react/src/menu/MenuSubContent.tsx
@@ -25,7 +25,7 @@ export const MenuSubContent = forwardRef<HTMLDivElement, MenuSubContentProps>(
       "@optiaxiom/react/MenuSubContent",
     );
     const {
-      highlightedItem,
+      highlightedItem: item,
       inputValue: parentInputValue,
       setInputValue: setParentInputValue,
     } = useCommandContext("@optiaxiom/react/MenuSubContent");
@@ -39,17 +39,6 @@ export const MenuSubContent = forwardRef<HTMLDivElement, MenuSubContentProps>(
       "@optiaxiom/react/MenuSubContent",
     );
     const ref = useComposedRefs(parentContentRef, outerRef);
-
-    const itemRef = useRef(highlightedItem);
-    if (
-      parentSubMenuOpen &&
-      highlightedItem &&
-      (typeof highlightedItem.subOptions === "function" ||
-        !!highlightedItem.subOptions?.length)
-    ) {
-      itemRef.current = highlightedItem;
-    }
-    const item = itemRef.current;
 
     const [inputValue, setInputValue] = useState("");
     const options = useMemo(

--- a/packages/react/src/transition/TransitionGroup.tsx
+++ b/packages/react/src/transition/TransitionGroup.tsx
@@ -4,6 +4,7 @@ import {
   type RefObject,
   useCallback,
   useEffect,
+  useRef,
   useState,
 } from "react";
 
@@ -60,6 +61,11 @@ export function TransitionGroup({
     }
   }, [open, setPresence, transitions]);
 
+  const childrenRef = useRef(children);
+  if (open) {
+    childrenRef.current = children;
+  }
+
   if (TransitionGlobalConfig.skipAnimations) {
     return <>{open && children}</>;
   }
@@ -71,7 +77,7 @@ export function TransitionGroup({
       open={open}
       presence={presence}
     >
-      {(open || presence) && children}
+      {(open || presence) && childrenRef.current}
     </TransitionGroupProvider>
   );
 }


### PR DESCRIPTION
to prevent content from changing as it exits

typically consumer code will not be written to depend on presence and will instead use the open state which can change the content since it is not open but still present in DOM