### PR TITLE
fix table action focus on initial render

### DIFF
--- a/.changeset/plain-walls-matter.md
+++ b/.changeset/plain-walls-matter.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+fix table action focus on initial render

--- a/packages/react/src/data-table/DataTableAction.tsx
+++ b/packages/react/src/data-table/DataTableAction.tsx
@@ -34,7 +34,9 @@ export const DataTableAction = forwardRef<HTMLDivElement, DataTableActionProps>(
 
       return onActionMount({ primary, ref: innerRef });
     }, [onActionMount, primary]);
-    const index = actions.indexOf(innerRef);
+    const index = actions.includes(innerRef)
+      ? actions.indexOf(innerRef)
+      : undefined;
     useEffect(() => {
       if (highlightedIndex === index) {
         innerRef.current?.focus();
@@ -74,7 +76,7 @@ export const DataTableAction = forwardRef<HTMLDivElement, DataTableActionProps>(
         }}
         onPointerDown={(event) => {
           onPointerDown?.(event);
-          if (event.defaultPrevented) {
+          if (event.defaultPrevented || !index) {
             return;
           }
 


### PR DESCRIPTION
on initial render actions is not yet populated and index will resolve to -1 which will cause all actions to get focus. so we fix that by skipping setting index to -1.

resolves #1035