### PR TITLE
fix module federation usage for AxiomProvider

### DIFF
--- a/.changeset/ninety-tools-relax.md
+++ b/.changeset/ninety-tools-relax.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/globals": patch
+"@optiaxiom/react": patch
+---
+
+fix module federation usage for AxiomProvider

--- a/apps/storybook/src/components/Spotlight.stories.tsx
+++ b/apps/storybook/src/components/Spotlight.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { Kbd, Toast, toaster, ToastTitle } from "@optiaxiom/react";
+import { Kbd, toaster } from "@optiaxiom/react";
 import {
   type MenuOption,
   Spotlight,
@@ -104,13 +104,7 @@ export const Basic: Story = {
           ...items.map<MenuOption>((item) => ({
             description: item.description,
             execute: () => {
-              toaster.create(
-                <Toast intent="success">
-                  <ToastTitle>
-                    Selected <strong>{item.title}</strong>
-                  </ToastTitle>
-                </Toast>,
-              );
+              toaster.create(`Selected "${item.title}"`, { type: "success" });
             },
             group: item.category,
             label: item.title,

--- a/apps/storybook/src/components/Toast.stories.tsx
+++ b/apps/storybook/src/components/Toast.stories.tsx
@@ -7,9 +7,7 @@ import {
   createToaster,
   Flex,
   Toast,
-  ToastAction,
   ToastProvider,
-  ToastTitle,
 } from "@optiaxiom/react";
 import { action } from "storybook/actions";
 import { expect, screen, userEvent, waitFor, within } from "storybook/test";
@@ -20,7 +18,7 @@ type Story = StoryObj<StoryProps>;
 
 export default {
   args: {
-    children: <ToastTitle>This is an example toast message.</ToastTitle>,
+    message: "This is an example toast message.",
   },
   argTypes: {
     position: {
@@ -59,15 +57,15 @@ export default {
   parameters: {
     useAxiomProvider: false,
   },
-  render: (args) => (
-    <Button onClick={() => toaster.create(<Toast {...args} />)}>
-      Show Toast
-    </Button>
+  render: ({ message, ...args }) => (
+    <Button onClick={() => toaster.create(message, args)}>Show Toast</Button>
   ),
 } as Meta<StoryProps>;
 
-type StoryProps = ComponentPropsWithoutRef<typeof Toast> &
-  Pick<ComponentPropsWithoutRef<typeof ToastProvider>, "position">;
+type StoryProps = Parameters<typeof toaster.create>[1] &
+  Pick<ComponentPropsWithoutRef<typeof ToastProvider>, "position"> & {
+    message: string;
+  };
 
 export const Basic: Story = {
   play: async ({ canvas }) => {
@@ -106,33 +104,33 @@ export const Appearance: Story = {
       ).toHaveLength(5),
     );
   },
-  render: (args) => {
+  render: ({ message, ...args }) => {
     return (
       <Flex flexDirection="row">
         <Button
-          onClick={() => toaster.create(<Toast {...args} intent="neutral" />)}
+          onClick={() => toaster.create(message, { ...args, type: "neutral" })}
         >
           Neutral
         </Button>
         <Button
           onClick={() =>
-            toaster.create(<Toast {...args} intent="information" />)
+            toaster.create(message, { ...args, type: "information" })
           }
         >
           Information
         </Button>
         <Button
-          onClick={() => toaster.create(<Toast {...args} intent="warning" />)}
+          onClick={() => toaster.create(message, { ...args, type: "warning" })}
         >
           Warning
         </Button>
         <Button
-          onClick={() => toaster.create(<Toast {...args} intent="danger" />)}
+          onClick={() => toaster.create(message, { ...args, type: "danger" })}
         >
           Danger
         </Button>
         <Button
-          onClick={() => toaster.create(<Toast {...args} intent="success" />)}
+          onClick={() => toaster.create(message, { ...args, type: "success" })}
         >
           Success
         </Button>
@@ -156,14 +154,8 @@ export const Position: Story = {
 
 export const Action: Story = {
   args: {
-    children: (
-      <>
-        <ToastTitle>This is an example toast message.</ToastTitle>
-        <ToastAction altText="Undo" onClick={action("undo")}>
-          Undo
-        </ToastAction>
-      </>
-    ),
+    action: "Undo",
+    onAction: action("undo"),
   },
   play: async ({ canvas }) => {
     await userEvent.click(canvas.getByText("Show Toast"));
@@ -177,33 +169,9 @@ export const Action: Story = {
   },
 };
 
-export const Link: Story = {
-  args: {
-    children: (
-      <>
-        <ToastTitle>
-          This is an <a href="data:,">example toast</a> message.
-        </ToastTitle>
-      </>
-    ),
-  },
-  play: async ({ canvas }) => {
-    await userEvent.click(canvas.getByText("Show Toast"));
-
-    const toast = await within(await screen.findByRole("list")).findByRole(
-      "status",
-    );
-    await expect(toast).toHaveTextContent("This is an example toast message.");
-  },
-};
-
 export const LongContent: Story = {
   args: {
-    children: (
-      <ToastTitle>
-        This is an example toast message that should span two lines.
-      </ToastTitle>
-    ),
+    message: "This is an example toast message that should span two lines.",
   },
   play: async ({ canvas }) => {
     await userEvent.click(canvas.getByText("Show Toast"));

--- a/packages/globals/src/toaster.ts
+++ b/packages/globals/src/toaster.ts
@@ -1,10 +1,10 @@
-import type { ReactElement, RefObject } from "react";
+import type { RefObject } from "react";
 
 type ToastItem = {
   id: string;
   open: boolean;
   ref: RefObject<HTMLElement>;
-  toast: ReactElement | (ToastOptions & { title: string });
+  toast: ToastOptions & { title: string };
 };
 
 type ToastOptions = {
@@ -22,9 +22,7 @@ const genId = () => {
 
 type Toaster = {
   clear: () => void;
-  create: (
-    ...args: [message: string, options?: ToastOptions] | [toast: ReactElement]
-  ) => string;
+  create: (message: string, options?: ToastOptions) => string;
   remove: (id: string) => void;
   store: [
     subscribe: (onStoreChange: () => void) => () => void,
@@ -60,14 +58,7 @@ export const createToaster = (): Toaster => {
       emit();
     },
 
-    create: (...args) => {
-      const toast =
-        typeof args[0] === "string"
-          ? {
-              ...args[1],
-              title: args[0],
-            }
-          : args[0];
+    create: (message, options) => {
       const id = genId();
 
       queue = queue.then(async () => {
@@ -75,7 +66,10 @@ export const createToaster = (): Toaster => {
           id,
           open: true,
           ref: { current: null },
-          toast,
+          toast: {
+            ...options,
+            title: message,
+          },
         };
         snapshot = [...snapshot, item];
         emit();

--- a/packages/react/src/axiom-provider/AxiomProvider.tsx
+++ b/packages/react/src/axiom-provider/AxiomProvider.tsx
@@ -40,19 +40,19 @@ export function AxiomProvider({
   tooltip,
 }: AxiomProviderProps) {
   const axiom = useContext(AxiomVersionContext);
-  if (axiom) {
-    return <>{children}</>;
+  if (!axiom) {
+    children = (
+      <ThemeProvider>
+        {children}
+
+        <ToastProvider {...toast} />
+      </ThemeProvider>
+    );
   }
 
   return (
     <AxiomVersionContext.Provider value={version}>
-      <TooltipProvider {...tooltip}>
-        <ThemeProvider>
-          {children}
-
-          <ToastProvider {...toast} />
-        </ThemeProvider>
-      </TooltipProvider>
+      <TooltipProvider {...tooltip}>{children}</TooltipProvider>
     </AxiomVersionContext.Provider>
   );
 }

--- a/packages/react/src/toast/ToastProvider.tsx
+++ b/packages/react/src/toast/ToastProvider.tsx
@@ -2,12 +2,7 @@ import { ToastProviderProvider } from "@optiaxiom/globals";
 import { type createToaster, toaster } from "@optiaxiom/globals";
 import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import * as RadixToast from "@radix-ui/react-toast";
-import {
-  type ComponentPropsWithoutRef,
-  forwardRef,
-  isValidElement,
-  useRef,
-} from "react";
+import { type ComponentPropsWithoutRef, forwardRef, useRef } from "react";
 import { useSyncExternalStore } from "use-sync-external-store/shim";
 
 import { type BoxProps, extractBoxProps } from "../box";
@@ -92,24 +87,14 @@ export const ToastProvider = forwardRef<HTMLOListElement, ToastProviderProps>(
             open={open}
             toastRef={ref}
           >
-            {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/microsoft/TypeScript/issues/53178
-              isValidElement<any>(toast) ? (
-                toast
-              ) : (
-                <Toast intent={toast.type} key={id}>
-                  <ToastTitle>{toast.title}</ToastTitle>
-                  {toast.action && (
-                    <ToastAction
-                      altText={toast.action}
-                      onClick={toast.onAction}
-                    >
-                      {toast.action}
-                    </ToastAction>
-                  )}
-                </Toast>
-              )
-            }
+            <Toast intent={toast.type} key={id}>
+              <ToastTitle>{toast.title}</ToastTitle>
+              {toast.action && (
+                <ToastAction altText={toast.action} onClick={toast.onAction}>
+                  {toast.action}
+                </ToastAction>
+              )}
+            </Toast>
           </ToastProviderProvider>
         ))}
 


### PR DESCRIPTION
only Theme and Toast are global - Tooltip uses local context and provider must be included for each island

for Toast we can only support object usage rather than Toast/ToastTitle react elements since they are also local context dependent

we should also include the version context since that will be local to each island as well