### PR TITLE
simply remove TooltipTrigger when tooltip is disabled or empty

### DIFF
--- a/.changeset/all-socks-laugh.md
+++ b/.changeset/all-socks-laugh.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+simply remove TooltipTrigger when tooltip is disabled or empty

--- a/packages/react/src/tooltip/Tooltip.tsx
+++ b/packages/react/src/tooltip/Tooltip.tsx
@@ -61,21 +61,11 @@ export function Tooltip({
       onOpenChange={onOpenChange}
       open={open}
     >
-      <TooltipTrigger
-        asChild
-        onFocus={(event) => {
-          if (disabled || empty) {
-            event.preventDefault();
-          }
-        }}
-        onPointerMove={(event) => {
-          if (disabled || empty) {
-            event.preventDefault();
-          }
-        }}
-      >
-        {children}
-      </TooltipTrigger>
+      {disabled || empty ? (
+        children
+      ) : (
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+      )}
 
       {!disabled && !empty && (
         <TooltipContent maxW="xs" {...props}>


### PR DESCRIPTION
since we do not have access to tooltip context we cannot disable tooltip trigger behavior in any other way without also breaking other components

for example if this composes another element which has it's own onPointerMove event listener - that listener will stop working since we call event.preventDefault() here