### PR TITLE
revert tooltip refactor

### DIFF
--- a/packages/react/src/tooltip/TooltipContext.ts
+++ b/packages/react/src/tooltip/TooltipContext.ts
@@ -1,9 +1,11 @@
 "use client";
 
+import type { RefObject } from "react";
+
 import { createContext } from "@radix-ui/react-context";
 
 export const [TooltipProvider, useTooltipContext] = createContext<{
-  auto: boolean | undefined;
   open: boolean | undefined;
   setOpen: (open: boolean) => void;
+  triggerRef: RefObject<HTMLButtonElement>;
 }>("@optiaxiom/react/Tooltip");

--- a/packages/react/src/tooltip/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/TooltipTrigger.tsx
@@ -1,6 +1,6 @@
 import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import * as RadixTooltip from "@radix-ui/react-tooltip";
-import { type ComponentPropsWithoutRef, forwardRef, useRef } from "react";
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 import { Button } from "../button";
 import { FilteredSlot } from "../filtered-slot";
@@ -13,45 +13,12 @@ export type TooltipTriggerProps = ComponentPropsWithoutRef<
 export const TooltipTrigger = forwardRef<
   HTMLButtonElement,
   TooltipTriggerProps
->(({ asChild, children, onFocus, onPointerMove, ...props }, outerRef) => {
-  const { auto } = useTooltipContext("@optiaxiom/react/TooltipTrigger");
-  const innerRef = useRef<HTMLButtonElement>(null);
-  const ref = useComposedRefs(innerRef, outerRef);
+>(({ asChild, children, ...props }, outerRef) => {
+  const { triggerRef } = useTooltipContext("@optiaxiom/react/TooltipTrigger");
+  const ref = useComposedRefs(triggerRef, outerRef);
 
   return (
-    <RadixTooltip.Trigger
-      asChild
-      onFocus={(event) => {
-        onFocus?.(event);
-        if (event.defaultPrevented) {
-          return;
-        }
-
-        if (
-          auto &&
-          innerRef.current &&
-          !hasTruncatedContent(innerRef.current)
-        ) {
-          event.preventDefault();
-        }
-      }}
-      onPointerMove={(event) => {
-        onPointerMove?.(event);
-        if (event.defaultPrevented) {
-          return;
-        }
-
-        if (
-          auto &&
-          innerRef.current &&
-          !hasTruncatedContent(innerRef.current)
-        ) {
-          event.preventDefault();
-        }
-      }}
-      ref={ref}
-      {...props}
-    >
+    <RadixTooltip.Trigger asChild ref={ref} {...props}>
       <FilteredSlot exclude="data-state">
         {asChild ? children : <Button>{children}</Button>}
       </FilteredSlot>
@@ -60,25 +27,3 @@ export const TooltipTrigger = forwardRef<
 });
 
 TooltipTrigger.displayName = "@optiaxiom/react/TooltipTrigger";
-
-const hasTruncatedContent = (element: HTMLButtonElement) => {
-  let truncated = false;
-
-  const elements: Element[] = [element];
-  while (!truncated && elements.length) {
-    const element = elements.shift();
-    if (!(element instanceof HTMLElement)) {
-      continue;
-    }
-    const { offsetHeight, offsetWidth, scrollHeight, scrollWidth } = element;
-
-    if (offsetWidth < scrollWidth || offsetHeight < scrollHeight) {
-      truncated = true;
-      break;
-    }
-
-    elements.push(...element.children);
-  }
-
-  return truncated;
-};


### PR DESCRIPTION
this reverts commit d0004a182

now we do not render the TooltipTrigger if it's disabled so we can revert back to the better onOpenChange callback to intercept and check if content is truncated or not

otherwise it can interfere with other onPointerMove event handlers on the element