### PR TITLE
disable selection of text inside badges

### DIFF
--- a/.changeset/fifty-words-say.md
+++ b/.changeset/fifty-words-say.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+disable selection of text inside badges

--- a/packages/react/src/badge/Badge.css.ts
+++ b/packages/react/src/badge/Badge.css.ts
@@ -27,6 +27,8 @@ export const badge = recipe({
       vars: {
         [solidColorVar]: theme.colors["fg.white"],
       },
+
+      userSelect: "none",
     }),
   ],
   variants: {


### PR DESCRIPTION
resolves #1074

badges are strictly for display of status or metadata and primary action for user will never be to select the text

so we can safely turn off text selection to ensure the badge color is always consistent (and not changed by text selection color)