### PR TITLE
prevent shifting focus back to trigger in popover

### DIFF
--- a/packages/react/src/popover/Popover.tsx
+++ b/packages/react/src/popover/Popover.tsx
@@ -42,7 +42,6 @@ export function Popover({
   return (
     <RadixPopover.Root modal={modal} onOpenChange={setOpen} open={open}>
       <PopoverProvider
-        modal={modal}
         open={open}
         presence={presence}
         setPresence={setPresence}

--- a/packages/react/src/popover/PopoverContent.tsx
+++ b/packages/react/src/popover/PopoverContent.tsx
@@ -37,7 +37,7 @@ export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>(
     },
     ref,
   ) => {
-    const { modal, open, presence, setPresence } = usePopoverContext(
+    const { open, presence, setPresence } = usePopoverContext(
       "@optiaxiom/react/PopoverContent",
     );
 
@@ -66,16 +66,12 @@ export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>(
                   return;
                 }
 
-                if (modal && document.activeElement !== document.body) {
+                if (document.activeElement !== document.body) {
                   /**
-                   * A modal popover will use a pseudo backdrop to capture
-                   * clicks/focus. Clicking this backdrop typically dismisses
-                   * the popover.
-                   *
-                   * But in case we open a dialog from a popover that has an
-                   * input with autoFocus - or we shift the focus away
-                   * programmatically in some other way we need to handle that
-                   * case and prevent shifting focus back to the trigger.
+                   * In case we open a dialog from a popover that has an <input
+                   * autoFocus /> - or we shift the focus away programmatically
+                   * in some other way we need to handle that case and prevent
+                   * shifting focus back to the trigger.
                    */
                   event.preventDefault();
                 }

--- a/packages/react/src/popover/PopoverContext.ts
+++ b/packages/react/src/popover/PopoverContext.ts
@@ -3,7 +3,6 @@
 import { createContext } from "@radix-ui/react-context";
 
 export const [PopoverProvider, usePopoverContext] = createContext<{
-  modal: boolean | undefined;
   open: boolean | undefined;
   presence: boolean | undefined;
   setPresence: (presence: boolean) => void;


### PR DESCRIPTION
even if used in non-modal way

since we no longer use `modal` mode for Menu popover content