### PR TITLE
allow disclosure to always be present in DOM

### DIFF
--- a/.changeset/great-states-sink.md
+++ b/.changeset/great-states-sink.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+allow disclosure to always be present in DOM

--- a/apps/storybook/src/components/Disclosure.stories.tsx
+++ b/apps/storybook/src/components/Disclosure.stories.tsx
@@ -7,6 +7,7 @@ import {
   Flex,
 } from "@optiaxiom/react";
 import { useState } from "react";
+import { expect } from "storybook/test";
 
 export default {
   args: {
@@ -88,5 +89,25 @@ export const LongContentTrigger: Story = {
         </DisclosureContent>
       </>
     ),
+  },
+};
+
+export const ForceMount: Story = {
+  args: {
+    children: (
+      <>
+        <DisclosureTrigger>Summary item</DisclosureTrigger>
+        <DisclosureContent hiddenUntilFound>
+          Content for the item. Contains multiple lines of lorem ipsum.
+        </DisclosureContent>
+      </>
+    ),
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByText(
+        "Content for the item. Contains multiple lines of lorem ipsum.",
+      ),
+    ).toBeInTheDocument();
   },
 };

--- a/packages/react/src/disclosure/Disclosure.tsx
+++ b/packages/react/src/disclosure/Disclosure.tsx
@@ -43,7 +43,7 @@ export const Disclosure = forwardRef<HTMLDivElement, DisclosureProps>(
     });
 
     return (
-      <DisclosureProvider open={open}>
+      <DisclosureProvider open={open} setOpen={setOpen}>
         <Box asChild color="fg.default" fontSize="md" ref={ref} {...props}>
           <RadixCollapsible.Root
             asChild={asChild}

--- a/packages/react/src/disclosure/DisclosureContext.ts
+++ b/packages/react/src/disclosure/DisclosureContext.ts
@@ -4,4 +4,5 @@ import { createContext } from "@radix-ui/react-context";
 
 export const [DisclosureProvider, useDisclosureContext] = createContext<{
   open: boolean | undefined;
+  setOpen: (open: boolean) => void;
 }>("@optiaxiom/react/Disclosure");

--- a/packages/react/src/transition/TransitionGroup.tsx
+++ b/packages/react/src/transition/TransitionGroup.tsx
@@ -17,11 +17,13 @@ import { waitForAnimation } from "./waitForAnimation";
 
 export function TransitionGroup({
   children,
+  forceMount,
   onPresenceChange,
   open: openProp,
   presence: presenceProp,
 }: {
   children?: ReactNode;
+  forceMount?: boolean;
   onPresenceChange?: (presence: boolean) => void;
   open?: boolean;
   presence?: boolean;
@@ -82,7 +84,7 @@ export function TransitionGroup({
       presence={presence}
       register={register}
     >
-      {(open || presence) && childrenRef.current}
+      {(open || presence || forceMount) && childrenRef.current}
     </TransitionGroupProvider>
   );
 }

--- a/packages/react/src/transition/useTransitionStatus.ts
+++ b/packages/react/src/transition/useTransitionStatus.ts
@@ -22,9 +22,5 @@ export const useTransitionStatus = (ref: RefObject<HTMLElement>) => {
     }
   }, [open]);
 
-  return open && !mounted
-    ? "starting"
-    : !open && mounted
-      ? "ending"
-      : undefined;
+  return open && !mounted ? "starting" : !open ? "ending" : undefined;
 };


### PR DESCRIPTION
sometimes we need the content to be present in DOM - in case it has side effects for example - and only visually hide it