### PR TITLE
Add minWidth to `Badge` for fixing single digit value - `1`

### DIFF
--- a/.changeset/shaky-eggs-sell.md
+++ b/.changeset/shaky-eggs-sell.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+restrict badge width to fix shape for narrow content

--- a/apps/storybook/src/components/Badge.stories.tsx
+++ b/apps/storybook/src/components/Badge.stories.tsx
@@ -56,7 +56,7 @@ export const Count: Story = {
         <Button
           addonAfter={
             <Badge intent="information" variant="subtle">
-              8
+              1
             </Badge>
           }
         >
@@ -64,6 +64,10 @@ export const Count: Story = {
         </Button>
 
         <Button addonAfter={<Badge intent="danger">15</Badge>}>Errors</Button>
+        <Button addonAfter={<Badge intent="warning">8</Badge>}>Warnings</Button>
+        <Button addonAfter={<Badge intent="success">123</Badge>}>
+          Success
+        </Button>
       </Flex>
     </>
   ),

--- a/apps/storybook/src/components/Indicator.stories.tsx
+++ b/apps/storybook/src/components/Indicator.stories.tsx
@@ -6,7 +6,7 @@ import { IconBell, IconClockFilled } from "@tabler/icons-react";
 export default {
   args: {
     children: <Button aria-label="Notifications" icon={<IconBell />} />,
-    content: "4",
+    content: "1",
   },
   component: Indicator,
 } as Meta<typeof Indicator>;
@@ -88,7 +88,7 @@ export const Presence: Story = {
       <Avatar name="John Snow" src="https://i.pravatar.cc/150?img=10" />
     ),
     content: (
-      <Box asChild bg="bg.default" color="fg.warning.light">
+      <Box asChild bg="bg.default" color="fg.warning.light" rounded="full">
         <IconClockFilled size="14" />
       </Box>
     ),

--- a/packages/react/src/badge/Badge.css.ts
+++ b/packages/react/src/badge/Badge.css.ts
@@ -29,6 +29,12 @@ export const badge = recipe({
       },
 
       userSelect: "none",
+
+      selectors: {
+        "&:not(:empty)": {
+          minWidth: theme.size["xs"],
+        },
+      },
     }),
   ],
   variants: {

--- a/packages/react/src/indicator/Indicator.tsx
+++ b/packages/react/src/indicator/Indicator.tsx
@@ -1,9 +1,12 @@
+import { createSlot } from "@radix-ui/react-slot";
 import { forwardRef, type ReactNode } from "react";
 
 import { Badge } from "../badge";
 import { Box, type BoxProps } from "../box";
 import { Flex } from "../flex";
 import * as styles from "./Indicator.css";
+
+const Slot = createSlot("@optiaxiom/react/Indicator");
 
 export type IndicatorProps = BoxProps<
   typeof Badge,
@@ -55,25 +58,29 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
         {!disabled && (
           <Box {...styles.floating({ offset, position })}>
             {ping && (
-              <Badge
+              <Slot
                 aria-hidden="true"
-                asChild={asChild}
-                intent={intent}
-                variant={variant}
                 {...styles.badge({ offset, ping: true })}
               >
-                {content}
-              </Badge>
+                {asChild ? (
+                  content
+                ) : (
+                  <Badge intent={intent} variant={variant}>
+                    {content}
+                  </Badge>
+                )}
+              </Slot>
             )}
 
-            <Badge
-              asChild={asChild}
-              intent={intent}
-              variant={variant}
-              {...styles.badge({ offset })}
-            >
-              {content}
-            </Badge>
+            <Slot {...styles.badge({ offset })}>
+              {asChild ? (
+                content
+              ) : (
+                <Badge intent={intent} variant={variant}>
+                  {content}
+                </Badge>
+              )}
+            </Slot>
           </Box>
         )}
       </Flex>


### PR DESCRIPTION
The issue is with `1` only as it takes less width thus shrinking in width. The issue doesn't occur for other single digit values.
Prev:
<img width="145" height="55" alt="image" src="https://github.com/user-attachments/assets/773f442b-e8c2-4c2f-a1ff-b605ae32795d" />

Now:
<img width="152" height="56" alt="image" src="https://github.com/user-attachments/assets/e38fa238-679c-4590-8cc8-02cb9d879dde" />
