### PR TITLE
fix focus scope to not auto focus on mount/unmount

### DIFF
--- a/.changeset/young-worlds-sink.md
+++ b/.changeset/young-worlds-sink.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+fix focus scope to not auto focus on mount/unmount

--- a/packages/react/src/modal/ModalLayer.tsx
+++ b/packages/react/src/modal/ModalLayer.tsx
@@ -63,7 +63,12 @@ export const ModalLayer = forwardRef<HTMLDivElement, ModalLayerProps>(
     if (guards) {
       result = (
         <FocusGuards>
-          <FocusScope>{result}</FocusScope>
+          <FocusScope
+            onMountAutoFocus={(event) => event.preventDefault()}
+            onUnmountAutoFocus={(event) => event.preventDefault()}
+          >
+            {result}
+          </FocusScope>
         </FocusGuards>
       );
     }


### PR DESCRIPTION
focus scope is only there to correctly allow focusing inside portals nested inside dialogs

so we can skip the auto focusing behavior which breaks things like react-select