### PR TITLE
improve date input invalid date handling

### DIFF
--- a/.changeset/violet-geese-obey.md
+++ b/.changeset/violet-geese-obey.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+date input improve invalid date handling

--- a/packages/react/src/date-input/DateInput.tsx
+++ b/packages/react/src/date-input/DateInput.tsx
@@ -50,8 +50,8 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
       className,
       disabled,
       holiday,
-      max,
-      min,
+      max: maxProp,
+      min: minProp,
       onChange,
       placeholder,
       step,
@@ -82,6 +82,8 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     const instant =
       typeof value === "string" ? (toInstant(value) ?? null) : null;
 
+    const max = maxProp || "2100-12-31";
+    const min = minProp || "1900-01-01";
     const maxDate = max ? toInstant(max) : undefined;
     const minDate = min ? toInstant(min) : undefined;
 


### PR DESCRIPTION
resolves #1218

the max will prevent overflow issues where the date field resets due to years greater than 9999 leading to invalid dates
    
the min is not really needed here - since consumers will still need to handle the validation of the entered data
