### PR TITLE
fix overflow scroll issue with visually hidden elements

### DIFF
--- a/.changeset/gentle-candies-sip.md
+++ b/.changeset/gentle-candies-sip.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+fix overflow scroll issue with visually hidden elements

--- a/packages/react/src/visually-hidden/VisuallyHidden.tsx
+++ b/packages/react/src/visually-hidden/VisuallyHidden.tsx
@@ -13,9 +13,17 @@ export type VisuallyHiddenProps = ComponentPropsWithoutRef<
 };
 
 export const VisuallyHidden = forwardRef<HTMLSpanElement, VisuallyHiddenProps>(
-  ({ asChild, children, disabled, ...props }, ref) => {
+  ({ asChild, children, disabled, style, ...props }, ref) => {
     return (
-      <RadixVisuallyHidden.Root asChild ref={ref} {...props}>
+      <RadixVisuallyHidden.Root
+        asChild
+        ref={ref}
+        style={{
+          position: "fixed",
+          ...style,
+        }}
+        {...props}
+      >
         <FilteredSlot exclude={disabled ? "style" : undefined}>
           {asChild ? children : <span>{children}</span>}
         </FilteredSlot>


### PR DESCRIPTION
visually hidden elements are absolutely positioned but because there is no top/left specified it is causing overflow in some cases when placed inside scrollable containers