### PR TITLE
Add SEO improvements for better search engine discoverability

### DIFF
--- a/apps/docs/app/(docs)/components/alert-dialog/page.mdx
+++ b/apps/docs/app/(docs)/components/alert-dialog/page.mdx
@@ -1,3 +1,11 @@
+---
+title: AlertDialog
+description: Display a modal with important content that expects confirmation from the user. Learn how to use AlertDialog component in React with Axiom Design System.
+openGraph:
+  title: AlertDialog – Axiom Design System
+  description: Display a modal with important content that expects confirmation from the user. Learn how to use AlertDialog component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
 import { Badge, Flex, Kbd } from "@optiaxiom/react";
 

--- a/apps/docs/app/(docs)/components/alert/page.mdx
+++ b/apps/docs/app/(docs)/components/alert/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Alert
+description: Keeps users informed of important and sometimes time-sensitive changes. Learn how to use Alert component in React with Axiom Design System.
+openGraph:
+  title: Alert – Axiom Design System
+  description: Keeps users informed of important and sometimes time-sensitive changes. Learn how to use Alert component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
 import { Alert } from "@optiaxiom/react";
+
 
 # Alert
 

--- a/apps/docs/app/(docs)/components/auth-provider/page.mdx
+++ b/apps/docs/app/(docs)/components/auth-provider/page.mdx
@@ -1,4 +1,13 @@
+---
+title: AuthProvider
+description: AuthProvider is used to pass down the user credentials to all components. It should be rendered near the root of your application and should be used only once. Learn how to use AuthProvider component in React with Axiom Design System.
+openGraph:
+  title: AuthProvider – Axiom Design System
+  description: AuthProvider is used to pass down the user credentials to all components. It should be rendered near the root of your application and should be used only once. Learn how to use AuthProvider component in React with Axiom Design System.
+---
+
 import { Cards, Links, PropsTable } from "@/components";
+
 
 # AuthProvider
 

--- a/apps/docs/app/(docs)/components/avatar/page.mdx
+++ b/apps/docs/app/(docs)/components/avatar/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Avatar
+description: Avatar is an image element with a fallback for representing the user. Learn how to use Avatar component in React with Axiom Design System.
+openGraph:
+  title: Avatar – Axiom Design System
+  description: Avatar is an image element with a fallback for representing the user. Learn how to use Avatar component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
+
 
 # Avatar
 

--- a/apps/docs/app/(docs)/components/axiom-provider/page.mdx
+++ b/apps/docs/app/(docs)/components/axiom-provider/page.mdx
@@ -1,4 +1,13 @@
+---
+title: AxiomProvider
+description: AxiomProvider provides all the context managers required for our components to work. It must be rendered at the root of your application and should be used only once. Learn how to use AxiomProvider component in React with Axiom Design System.
+openGraph:
+  title: AxiomProvider – Axiom Design System
+  description: AxiomProvider provides all the context managers required for our components to work. It must be rendered at the root of your application and should be used only once. Learn how to use AxiomProvider component in React with Axiom Design System.
+---
+
 import { Cards, Links, PropsTable } from "@/components";
+
 
 # AxiomProvider
 

--- a/apps/docs/app/(docs)/components/badge/page.mdx
+++ b/apps/docs/app/(docs)/components/badge/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Badge
+description: Use Badge component to emphasize a status, count, state or value in your React application. Learn about different badge variants, colors, and use cases.
+openGraph:
+  title: Badge – Axiom Design System
+  description: Use Badge component to emphasize a status, count, state or value in your React application. Learn about different badge variants, colors, and use cases.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Badge
 

--- a/apps/docs/app/(docs)/components/banner/page.mdx
+++ b/apps/docs/app/(docs)/components/banner/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Banner
+description: Display a prominent message at the top of the screen. Learn how to use Banner component in React with Axiom Design System.
+openGraph:
+  title: Banner – Axiom Design System
+  description: Display a prominent message at the top of the screen. Learn how to use Banner component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Banner
 

--- a/apps/docs/app/(docs)/components/breadcrumb/page.mdx
+++ b/apps/docs/app/(docs)/components/breadcrumb/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Breadcrumb
+description: Display a list of links showing the location of the current page in the navigational hierarchy. Learn how to use Breadcrumb component in React with Axiom Design System.
+openGraph:
+  title: Breadcrumb – Axiom Design System
+  description: Display a list of links showing the location of the current page in the navigational hierarchy. Learn how to use Breadcrumb component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { Callout } from "nextra/components";
+
 
 # Breadcrumb
 

--- a/apps/docs/app/(docs)/components/button/page.mdx
+++ b/apps/docs/app/(docs)/components/button/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Button
+description: Button component is used to trigger actions in React applications. Explore different button variants, sizes, states, and accessibility features in Axiom Design System.
+openGraph:
+  title: Button – Axiom Design System
+  description: Button component is used to trigger actions in React applications. Explore different button variants, sizes, states, and accessibility features in Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Button
 

--- a/apps/docs/app/(docs)/components/calendar/page.mdx
+++ b/apps/docs/app/(docs)/components/calendar/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Calendar
+description: Base date picker component. Learn how to use Calendar component in React with Axiom Design System.
+openGraph:
+  title: Calendar – Axiom Design System
+  description: Base date picker component. Learn how to use Calendar component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { Flex, Kbd } from "@optiaxiom/react";
+
 
 # Calendar
 

--- a/apps/docs/app/(docs)/components/card/page.mdx
+++ b/apps/docs/app/(docs)/components/card/page.mdx
@@ -1,6 +1,15 @@
+---
+title: Card
+description: Generic container for grouping related components together. Learn how to use Card component in React with Axiom Design System.
+openGraph:
+  title: Card – Axiom Design System
+  description: Generic container for grouping related components together. Learn how to use Card component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { App as AnatomyUsage } from "@/demos/card/anatomy-usage/App";
 import { Alert } from "@optiaxiom/react";
+
 
 # Card
 

--- a/apps/docs/app/(docs)/components/checkbox/page.mdx
+++ b/apps/docs/app/(docs)/components/checkbox/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Checkbox
+description: Basic control to allow selecting one or more items from a set. Learn how to use Checkbox component in React with Axiom Design System.
+openGraph:
+  title: Checkbox – Axiom Design System
+  description: Basic control to allow selecting one or more items from a set. Learn how to use Checkbox component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Checkbox
 

--- a/apps/docs/app/(docs)/components/code/page.mdx
+++ b/apps/docs/app/(docs)/components/code/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Code
+description: Display inline code. Learn how to use Code component in React with Axiom Design System.
+openGraph:
+  title: Code – Axiom Design System
+  description: Display inline code. Learn how to use Code component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
+
 
 # Code
 

--- a/apps/docs/app/(docs)/components/cover/page.mdx
+++ b/apps/docs/app/(docs)/components/cover/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Cover
+description: "Use Cover to to expand and fill up the whole area of the parent which has position: relative using the ::before pseudo element. Learn how to use Cover component in React with Axiom Design System."
+openGraph:
+  title: "Cover – Axiom Design System"
+  description: "Use Cover to to expand and fill up the whole area of the parent which has position: relative using the ::before pseudo element. Learn how to use Cover component in React with Axiom Design System."
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Cover
 

--- a/apps/docs/app/(docs)/components/data-table/page.mdx
+++ b/apps/docs/app/(docs)/components/data-table/page.mdx
@@ -1,5 +1,14 @@
+---
+title: DataTable
+description: Easy to use table and datagrids built using [TanStack Table](https://tanstack.com/table/latest). Learn how to use DataTable component in React with Axiom Design System.
+openGraph:
+  title: DataTable – Axiom Design System
+  description: Easy to use table and datagrids built using [TanStack Table](https://tanstack.com/table/latest). Learn how to use DataTable component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
 import { Alert, Badge } from "@optiaxiom/react";
+
 
 # DataTable
 

--- a/apps/docs/app/(docs)/components/date-input/page.mdx
+++ b/apps/docs/app/(docs)/components/date-input/page.mdx
@@ -1,5 +1,14 @@
+---
+title: DateInput
+description: Input field with calendar that lets user enter dates. Learn how to use DateInput component in React with Axiom Design System.
+openGraph:
+  title: DateInput – Axiom Design System
+  description: Input field with calendar that lets user enter dates. Learn how to use DateInput component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { Flex, Kbd } from "@optiaxiom/react";
+
 
 # DateInput
 

--- a/apps/docs/app/(docs)/components/date-range-picker/page.mdx
+++ b/apps/docs/app/(docs)/components/date-range-picker/page.mdx
@@ -1,5 +1,14 @@
+---
+title: DateRangePicker
+description: Calendar popover that lets user pick date ranges. Learn how to use DateRangePicker component in React with Axiom Design System.
+openGraph:
+  title: DateRangePicker – Axiom Design System
+  description: Calendar popover that lets user pick date ranges. Learn how to use DateRangePicker component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { Flex, Kbd } from "@optiaxiom/react";
+
 
 # DateRangePicker
 

--- a/apps/docs/app/(docs)/components/details-panel/page.mdx
+++ b/apps/docs/app/(docs)/components/details-panel/page.mdx
@@ -1,5 +1,14 @@
+---
+title: DetailsPanel
+description: Panel for showing additional content on the right side of the page. Learn how to use DetailsPanel component in React with Axiom Design System.
+openGraph:
+  title: DetailsPanel – Axiom Design System
+  description: Panel for showing additional content on the right side of the page. Learn how to use DetailsPanel component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { Alert } from "@optiaxiom/react";
+
 
 # DetailsPanel
 

--- a/apps/docs/app/(docs)/components/dialog/page.mdx
+++ b/apps/docs/app/(docs)/components/dialog/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Dialog
+description: Display a modal dialog box. Learn how to use Dialog component in React with Axiom Design System.
+openGraph:
+  title: Dialog – Axiom Design System
+  description: Display a modal dialog box. Learn how to use Dialog component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
 import { Alert, Badge, Flex, Kbd } from "@optiaxiom/react";
+
 
 # Dialog
 

--- a/apps/docs/app/(docs)/components/disclosure/page.mdx
+++ b/apps/docs/app/(docs)/components/disclosure/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Disclosure
+description: An interactive component which expands/collapses a panel. Learn how to use Disclosure component in React with Axiom Design System.
+openGraph:
+  title: Disclosure – Axiom Design System
+  description: An interactive component which expands/collapses a panel. Learn how to use Disclosure component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { Flex, Kbd } from "@optiaxiom/react";
+
 
 # Disclosure
 

--- a/apps/docs/app/(docs)/components/dropdown-menu/page.mdx
+++ b/apps/docs/app/(docs)/components/dropdown-menu/page.mdx
@@ -1,5 +1,14 @@
+---
+title: DropdownMenu
+description: Display a dropdown menu. Learn how to use DropdownMenu component in React with Axiom Design System.
+openGraph:
+  title: DropdownMenu – Axiom Design System
+  description: Display a dropdown menu. Learn how to use DropdownMenu component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
 import { Alert } from "@optiaxiom/react";
+
 
 # DropdownMenu
 

--- a/apps/docs/app/(docs)/components/field/page.mdx
+++ b/apps/docs/app/(docs)/components/field/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Field
+description: Wrapper for inputs to provide context such as label/help/required etc. Learn how to use Field component in React with Axiom Design System.
+openGraph:
+  title: Field – Axiom Design System
+  description: Wrapper for inputs to provide context such as label/help/required etc. Learn how to use Field component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
+
 
 # Field
 

--- a/apps/docs/app/(docs)/components/file-upload/page.mdx
+++ b/apps/docs/app/(docs)/components/file-upload/page.mdx
@@ -1,5 +1,14 @@
+---
+title: FileUpload
+description: Capture file input from users with drag and drop. Learn how to use FileUpload component in React with Axiom Design System.
+openGraph:
+  title: FileUpload – Axiom Design System
+  description: Capture file input from users with drag and drop. Learn how to use FileUpload component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { Alert } from "@optiaxiom/react";
+
 
 # FileUpload
 

--- a/apps/docs/app/(docs)/components/flex/page.mdx
+++ b/apps/docs/app/(docs)/components/flex/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Flex
+description: Use Flex component to stack items vertically or horizontally. Learn how to use Flex component in React with Axiom Design System.
+openGraph:
+  title: Flex – Axiom Design System
+  description: Use Flex component to stack items vertically or horizontally. Learn how to use Flex component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Flex
 

--- a/apps/docs/app/(docs)/components/grid/page.mdx
+++ b/apps/docs/app/(docs)/components/grid/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Grid
+description: Use Grid component to place items in a grid using equal width columns. Learn how to use Grid component in React with Axiom Design System.
+openGraph:
+  title: Grid – Axiom Design System
+  description: Use Grid component to place items in a grid using equal width columns. Learn how to use Grid component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Grid
 

--- a/apps/docs/app/(docs)/components/heading/page.mdx
+++ b/apps/docs/app/(docs)/components/heading/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Heading
+description: Heading component is used to display page title and section headings. The default root element is h1 which can be configured using the level prop. Learn how to use Heading component in React with Axiom Design System.
+openGraph:
+  title: Heading – Axiom Design System
+  description: Heading component is used to display page title and section headings. The default root element is h1 which can be configured using the level prop. Learn how to use Heading component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Heading
 

--- a/apps/docs/app/(docs)/components/hover-card/page.mdx
+++ b/apps/docs/app/(docs)/components/hover-card/page.mdx
@@ -1,4 +1,13 @@
+---
+title: HoverCard
+description: Display helpful text or previews inside a dialog when hovering over a link or button. Learn how to use HoverCard component in React with Axiom Design System.
+openGraph:
+  title: HoverCard – Axiom Design System
+  description: Display helpful text or previews inside a dialog when hovering over a link or button. Learn how to use HoverCard component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
+
 
 # HoverCard
 

--- a/apps/docs/app/(docs)/components/indicator/page.mdx
+++ b/apps/docs/app/(docs)/components/indicator/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Indicator
+description: Display a badge at the corner of another element. Learn how to use Indicator component in React with Axiom Design System.
+openGraph:
+  title: Indicator – Axiom Design System
+  description: Display a badge at the corner of another element. Learn how to use Indicator component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
+
 
 # Indicator
 

--- a/apps/docs/app/(docs)/components/inline-input/page.mdx
+++ b/apps/docs/app/(docs)/components/inline-input/page.mdx
@@ -1,5 +1,14 @@
+---
+title: InlineInput
+description: Seamless textbox for capturing user input with completely customizable visual styles. Learn how to use InlineInput component in React with Axiom Design System.
+openGraph:
+  title: InlineInput – Axiom Design System
+  description: Seamless textbox for capturing user input with completely customizable visual styles. Learn how to use InlineInput component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { Alert } from "@optiaxiom/react";
+
 
 # InlineInput
 

--- a/apps/docs/app/(docs)/components/input/page.mdx
+++ b/apps/docs/app/(docs)/components/input/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Input
+description: Basic text field component for capturing user input in React. Learn how to use Input with validation, different states, and accessibility best practices.
+openGraph:
+  title: Input – Axiom Design System
+  description: Basic text field component for capturing user input in React. Learn how to use Input with validation, different states, and accessibility best practices.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Input
 

--- a/apps/docs/app/(docs)/components/kbd/page.mdx
+++ b/apps/docs/app/(docs)/components/kbd/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Kbd
+description: Inline text representing keyboard input. Learn how to use Kbd component in React with Axiom Design System.
+openGraph:
+  title: Kbd – Axiom Design System
+  description: Inline text representing keyboard input. Learn how to use Kbd component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
+
 
 # Kbd
 

--- a/apps/docs/app/(docs)/components/layout/page.mdx
+++ b/apps/docs/app/(docs)/components/layout/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Layout
+description: Implement a basic page layout with multiple content areas. Learn how to use Layout component in React with Axiom Design System.
+openGraph:
+  title: Layout – Axiom Design System
+  description: Implement a basic page layout with multiple content areas. Learn how to use Layout component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { Alert } from "@optiaxiom/react";
+
 
 # Layout
 

--- a/apps/docs/app/(docs)/components/link/page.mdx
+++ b/apps/docs/app/(docs)/components/link/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Link
+description: Anchor element for creating hyperlinks. Learn how to use Link component in React with Axiom Design System.
+openGraph:
+  title: Link – Axiom Design System
+  description: Anchor element for creating hyperlinks. Learn how to use Link component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
+
 
 # Link
 

--- a/apps/docs/app/(docs)/components/menu/page.mdx
+++ b/apps/docs/app/(docs)/components/menu/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Menu
+description: Dropdown menu for displaying actions. Learn how to use Menu component in React with Axiom Design System.
+openGraph:
+  title: Menu – Axiom Design System
+  description: Dropdown menu for displaying actions. Learn how to use Menu component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
 import { Alert, Flex, Kbd } from "@optiaxiom/react";
+
 
 # Menu
 

--- a/apps/docs/app/(docs)/components/modal-layer/page.mdx
+++ b/apps/docs/app/(docs)/components/modal-layer/page.mdx
@@ -1,4 +1,13 @@
+---
+title: ModalLayer
+description: ModalLayer is a helper component intended to wrap components that are rendered inside portals inside other dialogs or popovers. Learn how to use ModalLayer component in React with Axiom Design System.
+openGraph:
+  title: ModalLayer – Axiom Design System
+  description: ModalLayer is a helper component intended to wrap components that are rendered inside portals inside other dialogs or popovers. Learn how to use ModalLayer component in React with Axiom Design System.
+---
+
 import { Demo, PropsTable } from "@/components";
+
 
 # ModalLayer
 

--- a/apps/docs/app/(docs)/components/page.mdx
+++ b/apps/docs/app/(docs)/components/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Box
+description: Box is the base component for all our other components and provides a convenient way to use our design tokens and set element styles without having to write any custom CSS. Learn how to use Box in React.
+openGraph:
+  title: Box – Axiom Design System
+  description: Box is the base component for all our other components and provides a convenient way to use our design tokens and set element styles without having to write any custom CSS. Learn how to use Box in React.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Box
 

--- a/apps/docs/app/(docs)/components/pagination/page.mdx
+++ b/apps/docs/app/(docs)/components/pagination/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Pagination
+description: Display active page and navigate between multiple pages. Learn how to use Pagination component in React with Axiom Design System.
+openGraph:
+  title: Pagination – Axiom Design System
+  description: Display active page and navigate between multiple pages. Learn how to use Pagination component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Pagination
 

--- a/apps/docs/app/(docs)/components/pill-menu/page.mdx
+++ b/apps/docs/app/(docs)/components/pill-menu/page.mdx
@@ -1,4 +1,13 @@
+---
+title: PillMenu
+description: Dropdown menu for making selections with pills showing the selected items. Learn how to use PillMenu component for multi-select interactions in React.
+openGraph:
+  title: PillMenu – Axiom Design System
+  description: Dropdown menu for making selections with pills showing the selected items. Learn how to use PillMenu component for multi-select interactions in React.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
+
 
 # PillMenu
 

--- a/apps/docs/app/(docs)/components/pill/page.mdx
+++ b/apps/docs/app/(docs)/components/pill/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Pill
+description: A pill is a visual representation of an attribute, usually representing tags or metrics. Learn how to use the Pill component with different sizes, dismissible options, and grouping in React.
+openGraph:
+  title: Pill – Axiom Design System
+  description: A pill is a visual representation of an attribute, usually representing tags or metrics. Learn how to use the Pill component with different sizes, dismissible options, and grouping in React.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Pill
 

--- a/apps/docs/app/(docs)/components/popover/page.mdx
+++ b/apps/docs/app/(docs)/components/popover/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Popover
+description: Display arbitrary rich content inside a non-modal dialog triggered by a button. Learn how to use Popover component in React with Axiom Design System.
+openGraph:
+  title: Popover – Axiom Design System
+  description: Display arbitrary rich content inside a non-modal dialog triggered by a button. Learn how to use Popover component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { Flex, Kbd } from "@optiaxiom/react";
+
 
 # Popover
 

--- a/apps/docs/app/(docs)/components/progress/page.mdx
+++ b/apps/docs/app/(docs)/components/progress/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Progress
+description: Display feedback on status of task or length of a process. Learn how to use Progress component in React with Axiom Design System.
+openGraph:
+  title: Progress – Axiom Design System
+  description: Display feedback on status of task or length of a process. Learn how to use Progress component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Progress
 

--- a/apps/docs/app/(docs)/components/radio-group/page.mdx
+++ b/apps/docs/app/(docs)/components/radio-group/page.mdx
@@ -1,4 +1,13 @@
+---
+title: RadioGroup
+description: Basic control to allow selecting only one item from a set. Learn how to use RadioGroup component in React with Axiom Design System.
+openGraph:
+  title: RadioGroup – Axiom Design System
+  description: Basic control to allow selecting only one item from a set. Learn how to use RadioGroup component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # RadioGroup
 

--- a/apps/docs/app/(docs)/components/range/page.mdx
+++ b/apps/docs/app/(docs)/components/range/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Range
+description: Allow users to select a numeric value within a range. Learn how to use Range component in React with Axiom Design System.
+openGraph:
+  title: Range – Axiom Design System
+  description: Allow users to select a numeric value within a range. Learn how to use Range component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
 import { Flex, Kbd } from "@optiaxiom/react";
+
 
 # Range
 

--- a/apps/docs/app/(docs)/components/search-input/page.mdx
+++ b/apps/docs/app/(docs)/components/search-input/page.mdx
@@ -1,4 +1,13 @@
+---
+title: SearchInput
+description: Basic search input field with clear button. Learn how to use SearchInput component in React with Axiom Design System.
+openGraph:
+  title: SearchInput – Axiom Design System
+  description: Basic search input field with clear button. Learn how to use SearchInput component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # SearchInput
 

--- a/apps/docs/app/(docs)/components/segmented-control/page.mdx
+++ b/apps/docs/app/(docs)/components/segmented-control/page.mdx
@@ -1,5 +1,14 @@
+---
+title: SegmentedControl
+description: Toggle buttons for switching between different values or views. Learn how to use SegmentedControl component in React with Axiom Design System.
+openGraph:
+  title: SegmentedControl – Axiom Design System
+  description: Toggle buttons for switching between different values or views. Learn how to use SegmentedControl component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
 import { Flex, Kbd } from "@optiaxiom/react";
+
 
 # SegmentedControl
 

--- a/apps/docs/app/(docs)/components/select/page.mdx
+++ b/apps/docs/app/(docs)/components/select/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Select
+description: Select a value from a list of options inside a dropdown menu. This is an alternative to radios when you have a large number of options. Learn how to use Select component in React with Axiom Design System.
+openGraph:
+  title: Select – Axiom Design System
+  description: Select a value from a list of options inside a dropdown menu. This is an alternative to radios when you have a large number of options. Learn how to use Select component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
 import { Alert, Flex, Kbd } from "@optiaxiom/react";
+
 
 # Select
 

--- a/apps/docs/app/(docs)/components/separator/page.mdx
+++ b/apps/docs/app/(docs)/components/separator/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Separator
+description: Separator component is used to visually separate items in a list or group. By default the orientation is set to horizontal. Learn how to use Separator component in React with Axiom Design System.
+openGraph:
+  title: Separator – Axiom Design System
+  description: Separator component is used to visually separate items in a list or group. By default the orientation is set to horizontal. Learn how to use Separator component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { Alert } from "@optiaxiom/react";
+
 
 # Separator
 

--- a/apps/docs/app/(docs)/components/sidebar/page.mdx
+++ b/apps/docs/app/(docs)/components/sidebar/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Sidebar
+description: Primary navigation menu for left side of the page that includes support for branding, links, etc. Learn how to use Sidebar component in React with Axiom Design System.
+openGraph:
+  title: Sidebar – Axiom Design System
+  description: Primary navigation menu for left side of the page that includes support for branding, links, etc. Learn how to use Sidebar component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
+
 
 # Sidebar
 

--- a/apps/docs/app/(docs)/components/skeleton/page.mdx
+++ b/apps/docs/app/(docs)/components/skeleton/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Skeleton
+description: Display placeholder content while data is loading. Learn how to use Skeleton component in React with Axiom Design System.
+openGraph:
+  title: Skeleton – Axiom Design System
+  description: Display placeholder content while data is loading. Learn how to use Skeleton component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Skeleton
 

--- a/apps/docs/app/(docs)/components/sortable/page.mdx
+++ b/apps/docs/app/(docs)/components/sortable/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Sortable
+description: Basic building blocks for sortable interfaces. Learn how to use Sortable component in React with Axiom Design System.
+openGraph:
+  title: Sortable – Axiom Design System
+  description: Basic building blocks for sortable interfaces. Learn how to use Sortable component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { Alert } from "@optiaxiom/react";
+
 
 # Sortable
 

--- a/apps/docs/app/(docs)/components/spinner/page.mdx
+++ b/apps/docs/app/(docs)/components/spinner/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Spinner
+description: Used for indicating an unspecified wait time. Learn how to use Spinner component in React with Axiom Design System.
+openGraph:
+  title: Spinner – Axiom Design System
+  description: Used for indicating an unspecified wait time. Learn how to use Spinner component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Spinner
 

--- a/apps/docs/app/(docs)/components/switch/page.mdx
+++ b/apps/docs/app/(docs)/components/switch/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Switch
+description: Control to allow toggling between checked and not checked state. Learn how to use Switch component in React with Axiom Design System.
+openGraph:
+  title: Switch – Axiom Design System
+  description: Control to allow toggling between checked and not checked state. Learn how to use Switch component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Switch
 

--- a/apps/docs/app/(docs)/components/table/page.mdx
+++ b/apps/docs/app/(docs)/components/table/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Table
+description: Display tabular data using rows and columns. Learn how to use Table component in React with Axiom Design System.
+openGraph:
+  title: Table – Axiom Design System
+  description: Display tabular data using rows and columns. Learn how to use Table component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
 import { Alert } from "@optiaxiom/react";
+
 
 # Table
 

--- a/apps/docs/app/(docs)/components/tabs/page.mdx
+++ b/apps/docs/app/(docs)/components/tabs/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Tabs
+description: Set of content sections to be displayed one at a time. Learn how to use Tabs component in React with Axiom Design System.
+openGraph:
+  title: Tabs – Axiom Design System
+  description: Set of content sections to be displayed one at a time. Learn how to use Tabs component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
 import { Flex, Kbd } from "@optiaxiom/react";
+
 
 # Tabs
 

--- a/apps/docs/app/(docs)/components/text/page.mdx
+++ b/apps/docs/app/(docs)/components/text/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Text
+description: Display body or any other form of text. By default it outputs the <p> paragraph element. Learn how to use Text component in React with Axiom Design System.
+openGraph:
+  title: Text – Axiom Design System
+  description: Display body or any other form of text. By default it outputs the <p> paragraph element. Learn how to use Text component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Text
 

--- a/apps/docs/app/(docs)/components/textarea/page.mdx
+++ b/apps/docs/app/(docs)/components/textarea/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Textarea
+description: Multi-line text field for capturing user input. Learn how to use Textarea component in React with Axiom Design System.
+openGraph:
+  title: Textarea – Axiom Design System
+  description: Multi-line text field for capturing user input. Learn how to use Textarea component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Textarea
 

--- a/apps/docs/app/(docs)/components/toast/page.mdx
+++ b/apps/docs/app/(docs)/components/toast/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Toast
+description: Display a brief notification. Learn how to use Toast component in React with Axiom Design System.
+openGraph:
+  title: Toast – Axiom Design System
+  description: Display a brief notification. Learn how to use Toast component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # Toast
 

--- a/apps/docs/app/(docs)/components/toggle-button/page.mdx
+++ b/apps/docs/app/(docs)/components/toggle-button/page.mdx
@@ -1,4 +1,13 @@
+---
+title: ToggleButton
+description: ToggleButton component represents a button that can be toggled on or off. Learn how to use ToggleButton component in React with Axiom Design System.
+openGraph:
+  title: ToggleButton – Axiom Design System
+  description: ToggleButton component represents a button that can be toggled on or off. Learn how to use ToggleButton component in React with Axiom Design System.
+---
+
 import { Cards, Demo, Links, PropsTable } from "@/components";
+
 
 # ToggleButton
 

--- a/apps/docs/app/(docs)/components/tooltip/page.mdx
+++ b/apps/docs/app/(docs)/components/tooltip/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Tooltip
+description: Popup with brief information shown when user interacts with an element using keyboard focus or mouse hover. Learn how to use Tooltip component in React with Axiom Design System.
+openGraph:
+  title: Tooltip – Axiom Design System
+  description: Popup with brief information shown when user interacts with an element using keyboard focus or mouse hover. Learn how to use Tooltip component in React with Axiom Design System.
+---
+
 import { Demo, Links, PropsTable } from "@/components";
+
 
 # Tooltip
 

--- a/apps/docs/app/(docs)/guides/css-imports/page.mdx
+++ b/apps/docs/app/(docs)/guides/css-imports/page.mdx
@@ -1,4 +1,13 @@
+---
+title: CSS Imports
+description: All Axiom components import their own CSS files via import statements from within the JS code. Learn how to use CSS Imports  in React with Axiom Design System.
+openGraph:
+  title: CSS Imports – Development Guide
+  description: All Axiom components import their own CSS files via import statements from within the JS code. Learn how to use CSS Imports  in React with Axiom Design System.
+---
+
 import { Alert } from "@optiaxiom/react";
+
 
 # CSS Imports
 

--- a/apps/docs/app/(docs)/guides/icons/page.mdx
+++ b/apps/docs/app/(docs)/guides/icons/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Icons (Optimizely staff only)
+description: We use a licensed **Font Awesome** icon kit with our Optimizely Design System. Learn how to use Icons (Optimizely staff only)  in React with Axiom Design System.
+openGraph:
+  title: Icons (Optimizely staff only) – Development Guide
+  description: We use a licensed **Font Awesome** icon kit with our Optimizely Design System. Learn how to use Icons (Optimizely staff only)  in React with Axiom Design System.
+---
+
 import { Alert, Heading } from "@optiaxiom/react";
+
 
 # Icons (Optimizely staff only)
 

--- a/apps/docs/app/(docs)/guides/page.mdx
+++ b/apps/docs/app/(docs)/guides/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Getting Started
+description: "Install the @optiaxiom/react package using your package manager of choice: Learn how to use Getting Started in React with Axiom Design System."
+openGraph:
+  title: "Getting Started – Development Guide"
+  description: "Install the @optiaxiom/react package using your package manager of choice: Learn how to use Getting Started in React with Axiom Design System."
+---
+
 import { Cards } from "@/components";
 import { Steps } from "nextra/components";
+
 
 # Getting Started
 

--- a/apps/docs/app/(docs)/guides/test-environments/page.mdx
+++ b/apps/docs/app/(docs)/guides/test-environments/page.mdx
@@ -1,3 +1,11 @@
+---
+title: Test Environments
+description: Axiom should work out of the box with most testing libraries. But certain test environments may require custom configuration to work. Learn how to use Test Environments  in React with Axiom Design System.
+openGraph:
+  title: Test Environments – Development Guide
+  description: Axiom should work out of the box with most testing libraries. But certain test environments may require custom configuration to work. Learn how to use Test Environments  in React with Axiom Design System.
+---
+
 # Test Environments
 
 Axiom should work out of the box with most testing libraries. But certain test environments may require custom configuration to work.
@@ -13,6 +21,7 @@ For example if you're using [React Testing Library](https://testing-library.com/
 ```ts
 import { AxiomProvider } from "@optiaxiom/react";
 import { render } from "@testing-library/react";
+
 
 const customRender = (...args: Parameters<typeof render>) => ({
   ...render(args[0], {

--- a/apps/docs/app/(docs)/styling/align-items/page.mdx
+++ b/apps/docs/app/(docs)/styling/align-items/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Align Items
+description: Use alignItems prop to control how flex items are aligned on the cross axis. Learn how to use Align Items  in React with Axiom Design System.
+openGraph:
+  title: Align Items – Styling Guide
+  description: Use alignItems prop to control how flex items are aligned on the cross axis. Learn how to use Align Items  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Align Items
 

--- a/apps/docs/app/(docs)/styling/align-self/page.mdx
+++ b/apps/docs/app/(docs)/styling/align-self/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Align Self
+description: Use alignSelf prop to control how individual flex items are aligned on the cross axis. Learn how to use Align Self  in React with Axiom Design System.
+openGraph:
+  title: Align Self – Styling Guide
+  description: Use alignSelf prop to control how individual flex items are aligned on the cross axis. Learn how to use Align Self  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Align Self
 

--- a/apps/docs/app/(docs)/styling/animation/page.mdx
+++ b/apps/docs/app/(docs)/styling/animation/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Animation
+description: Use animation prop to apply CSS animations to an element. Learn how to use Animation  in React with Axiom Design System.
+openGraph:
+  title: Animation – Styling Guide
+  description: Use animation prop to apply CSS animations to an element. Learn how to use Animation  in React with Axiom Design System.
+---
+
 import { Demo } from "@/components";
+
 
 # Animation
 

--- a/apps/docs/app/(docs)/styling/background-color/page.mdx
+++ b/apps/docs/app/(docs)/styling/background-color/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Background Color
+description: Use bg prop to control the background color of an element. Learn how to use Background Color  in React with Axiom Design System.
+openGraph:
+  title: Background Color – Styling Guide
+  description: Use bg prop to control the background color of an element. Learn how to use Background Color  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Background Color
 

--- a/apps/docs/app/(docs)/styling/border-color/page.mdx
+++ b/apps/docs/app/(docs)/styling/border-color/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Border Color
+description: Use borderColor prop to control the border color of an element. Learn how to use Border Color  in React with Axiom Design System.
+openGraph:
+  title: Border Color – Styling Guide
+  description: Use borderColor prop to control the border color of an element. Learn how to use Border Color  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Border Color
 

--- a/apps/docs/app/(docs)/styling/border-radius/page.mdx
+++ b/apps/docs/app/(docs)/styling/border-radius/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Border Radius
+description: Use rounded prop to control the border radius of an element. Learn how to use Border Radius  in React with Axiom Design System.
+openGraph:
+  title: Border Radius – Styling Guide
+  description: Use rounded prop to control the border radius of an element. Learn how to use Border Radius  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Border Radius
 

--- a/apps/docs/app/(docs)/styling/border-width/page.mdx
+++ b/apps/docs/app/(docs)/styling/border-width/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Border Width
+description: Use border prop to control the border width of an element. Learn how to use Border Width  in React with Axiom Design System.
+openGraph:
+  title: Border Width – Styling Guide
+  description: Use border prop to control the border width of an element. Learn how to use Border Width  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Border Width
 

--- a/apps/docs/app/(docs)/styling/box-shadow/page.mdx
+++ b/apps/docs/app/(docs)/styling/box-shadow/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Box Shadow
+description: Use shadow prop to control the box shadow of an element. Learn how to use Box Shadow  in React with Axiom Design System.
+openGraph:
+  title: Box Shadow – Styling Guide
+  description: Use shadow prop to control the box shadow of an element. Learn how to use Box Shadow  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Box Shadow
 

--- a/apps/docs/app/(docs)/styling/colors/page.mdx
+++ b/apps/docs/app/(docs)/styling/colors/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Colors
+description: Box component supports multiple props for controlling an element's background, border, and text colors. Learn how to use Colors  in React with Axiom Design System.
+openGraph:
+  title: Colors – Styling Guide
+  description: Box component supports multiple props for controlling an element's background, border, and text colors. Learn how to use Colors  in React with Axiom Design System.
+---
+
 import { theme } from "@optiaxiom/react";
 import { Demo, Scale } from "@/components";
+
 
 # Colors
 

--- a/apps/docs/app/(docs)/styling/design-tokens/page.mdx
+++ b/apps/docs/app/(docs)/styling/design-tokens/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Design Tokens
+description: Axiom uses **CSS variables** to declare design tokens and also conveniently exports the variable names in the theme object. Learn how to use Design Tokens  in React with Axiom Design System.
+openGraph:
+  title: Design Tokens – Styling Guide
+  description: Axiom uses **CSS variables** to declare design tokens and also conveniently exports the variable names in the theme object. Learn how to use Design Tokens  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
 import { theme } from "@optiaxiom/react";
+
 
 # Design Tokens
 

--- a/apps/docs/app/(docs)/styling/display/page.mdx
+++ b/apps/docs/app/(docs)/styling/display/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Display
+description: Use display prop to control the display type of an element. Learn how to use Display  in React with Axiom Design System.
+openGraph:
+  title: Display – Styling Guide
+  description: Use display prop to control the display type of an element. Learn how to use Display  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Display
 

--- a/apps/docs/app/(docs)/styling/flex-direction/page.mdx
+++ b/apps/docs/app/(docs)/styling/flex-direction/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Flex Direction
+description: Use flexDirection prop to control direction of flex items. Learn how to use Flex Direction  in React with Axiom Design System.
+openGraph:
+  title: Flex Direction – Styling Guide
+  description: Use flexDirection prop to control direction of flex items. Learn how to use Flex Direction  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Flex Direction
 

--- a/apps/docs/app/(docs)/styling/flex-wrap/page.mdx
+++ b/apps/docs/app/(docs)/styling/flex-wrap/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Flex Wrap
+description: Use flexWrap prop to control how flex items wrap. Learn how to use Flex Wrap  in React with Axiom Design System.
+openGraph:
+  title: Flex Wrap – Styling Guide
+  description: Use flexWrap prop to control how flex items wrap. Learn how to use Flex Wrap  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Flex Wrap
 

--- a/apps/docs/app/(docs)/styling/flex/page.mdx
+++ b/apps/docs/app/(docs)/styling/flex/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Flex
+description: Use flex prop to control how flex items grow and shrink. Learn how to use Flex  in React with Axiom Design System.
+openGraph:
+  title: Flex – Styling Guide
+  description: Use flex prop to control how flex items grow and shrink. Learn how to use Flex  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Flex
 

--- a/apps/docs/app/(docs)/styling/font-family/page.mdx
+++ b/apps/docs/app/(docs)/styling/font-family/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Font Family
+description: Use fontFamily prop to control the font-family of an element. Learn how to use Font Family  in React with Axiom Design System.
+openGraph:
+  title: Font Family – Styling Guide
+  description: Use fontFamily prop to control the font-family of an element. Learn how to use Font Family  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Font Family
 

--- a/apps/docs/app/(docs)/styling/font-size/page.mdx
+++ b/apps/docs/app/(docs)/styling/font-size/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Font Size
+description: Use fontSize prop to control the font-size of an element. Learn how to use Font Size  in React with Axiom Design System.
+openGraph:
+  title: Font Size – Styling Guide
+  description: Use fontSize prop to control the font-size of an element. Learn how to use Font Size  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Font Size
 

--- a/apps/docs/app/(docs)/styling/font-weight/page.mdx
+++ b/apps/docs/app/(docs)/styling/font-weight/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Font Weight
+description: Use fontWeight prop to control the font-weight of an element. Learn how to use Font Weight  in React with Axiom Design System.
+openGraph:
+  title: Font Weight – Styling Guide
+  description: Use fontWeight prop to control the font-weight of an element. Learn how to use Font Weight  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Font Weight
 

--- a/apps/docs/app/(docs)/styling/gap/page.mdx
+++ b/apps/docs/app/(docs)/styling/gap/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Gap
+description: Box component supports gap prop for controlling gutters between items. Learn how to use Gap  in React with Axiom Design System.
+openGraph:
+  title: Gap – Styling Guide
+  description: Box component supports gap prop for controlling gutters between items. Learn how to use Gap  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Gap
 

--- a/apps/docs/app/(docs)/styling/grid-column/page.mdx
+++ b/apps/docs/app/(docs)/styling/grid-column/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Grid Column
+description: Use gridColumn prop to control how elements are sized across grid columns. Learn how to use Grid Column  in React with Axiom Design System.
+openGraph:
+  title: Grid Column – Styling Guide
+  description: Use gridColumn prop to control how elements are sized across grid columns. Learn how to use Grid Column  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Grid Column
 

--- a/apps/docs/app/(docs)/styling/grid-template-columns/page.mdx
+++ b/apps/docs/app/(docs)/styling/grid-template-columns/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Grid Template Columns
+description: Use gridTemplateColumns prop to create equally sized columns in a grid layout. Learn how to use Grid Template Columns  in React with Axiom Design System.
+openGraph:
+  title: Grid Template Columns – Styling Guide
+  description: Use gridTemplateColumns prop to create equally sized columns in a grid layout. Learn how to use Grid Template Columns  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Grid Template Columns
 

--- a/apps/docs/app/(docs)/styling/height/page.mdx
+++ b/apps/docs/app/(docs)/styling/height/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Height
+description: Use h prop to control the height of an element. Learn how to use Height  in React with Axiom Design System.
+openGraph:
+  title: Height – Styling Guide
+  description: Use h prop to control the height of an element. Learn how to use Height  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Height
 

--- a/apps/docs/app/(docs)/styling/justify-content/page.mdx
+++ b/apps/docs/app/(docs)/styling/justify-content/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Justify Content
+description: Use justifyContent prop to control how flex items are aligned on the main axis. Learn how to use Justify Content  in React with Axiom Design System.
+openGraph:
+  title: Justify Content – Styling Guide
+  description: Use justifyContent prop to control how flex items are aligned on the main axis. Learn how to use Justify Content  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Justify Content
 

--- a/apps/docs/app/(docs)/styling/margin/page.mdx
+++ b/apps/docs/app/(docs)/styling/margin/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Margin
+description: Box component supports multiple props for controlling an element's margin. Learn how to use Margin  in React with Axiom Design System.
+openGraph:
+  title: Margin – Styling Guide
+  description: Box component supports multiple props for controlling an element's margin. Learn how to use Margin  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Margin
 

--- a/apps/docs/app/(docs)/styling/max-height/page.mdx
+++ b/apps/docs/app/(docs)/styling/max-height/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Max Height
+description: Use maxH prop to control the max-height of an element. Learn how to use Max Height  in React with Axiom Design System.
+openGraph:
+  title: Max Height – Styling Guide
+  description: Use maxH prop to control the max-height of an element. Learn how to use Max Height  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Max Height
 

--- a/apps/docs/app/(docs)/styling/max-width/page.mdx
+++ b/apps/docs/app/(docs)/styling/max-width/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Max Width
+description: Use maxW prop to control the max-width of an element. Learn how to use Max Width  in React with Axiom Design System.
+openGraph:
+  title: Max Width – Styling Guide
+  description: Use maxW prop to control the max-width of an element. Learn how to use Max Width  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Max Width
 

--- a/apps/docs/app/(docs)/styling/object-fit/page.mdx
+++ b/apps/docs/app/(docs)/styling/object-fit/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Object Fit
+description: Use objectFit prop to control the object-fit of an element. Learn how to use Object Fit  in React with Axiom Design System.
+openGraph:
+  title: Object Fit – Styling Guide
+  description: Use objectFit prop to control the object-fit of an element. Learn how to use Object Fit  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Object Fit
 

--- a/apps/docs/app/(docs)/styling/overflow/page.mdx
+++ b/apps/docs/app/(docs)/styling/overflow/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Overflow
+description: Use overflow prop to control the overflow of an element. Learn how to use Overflow  in React with Axiom Design System.
+openGraph:
+  title: Overflow – Styling Guide
+  description: Use overflow prop to control the overflow of an element. Learn how to use Overflow  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Overflow
 

--- a/apps/docs/app/(docs)/styling/padding/page.mdx
+++ b/apps/docs/app/(docs)/styling/padding/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Padding
+description: Box component supports multiple props for controlling an element's padding. Learn how to use Padding  in React with Axiom Design System.
+openGraph:
+  title: Padding – Styling Guide
+  description: Box component supports multiple props for controlling an element's padding. Learn how to use Padding  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Padding
 

--- a/apps/docs/app/(docs)/styling/page.mdx
+++ b/apps/docs/app/(docs)/styling/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Style Props
+description: The [Box](/components/) component provides a minimal zero-runtime styling solution built with [Vanilla Extract](https://vanilla-extract.style/). Learn how to use Style Props  in React with Axiom Design System.
+openGraph:
+  title: Style Props – Styling Guide
+  description: The [Box](/components/) component provides a minimal zero-runtime styling solution built with [Vanilla Extract](https://vanilla-extract.style/). Learn how to use Style Props  in React with Axiom Design System.
+---
+
 import { Demo } from "@/components";
 import { Alert } from "@optiaxiom/react";
+
 
 # Style Props
 

--- a/apps/docs/app/(docs)/styling/responsive-styles/page.mdx
+++ b/apps/docs/app/(docs)/styling/responsive-styles/page.mdx
@@ -1,5 +1,14 @@
+---
+title: Responsive Styles
+description: Box component support responsive styles for all layout related props. Learn how to use Responsive Styles  in React with Axiom Design System.
+openGraph:
+  title: Responsive Styles – Styling Guide
+  description: Box component support responsive styles for all layout related props. Learn how to use Responsive Styles  in React with Axiom Design System.
+---
+
 import { tokens } from "@optiaxiom/react";
 import { Demo, Scale } from "@/components";
+
 
 # Responsive Styles
 

--- a/apps/docs/app/(docs)/styling/size/page.mdx
+++ b/apps/docs/app/(docs)/styling/size/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Size
+description: Use size prop to control both the width and height of an element. Learn how to use Size  in React with Axiom Design System.
+openGraph:
+  title: Size – Styling Guide
+  description: Use size prop to control both the width and height of an element. Learn how to use Size  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Size
 

--- a/apps/docs/app/(docs)/styling/text-align/page.mdx
+++ b/apps/docs/app/(docs)/styling/text-align/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Text Align
+description: Use textAlign prop to control the text-align of an element. Learn how to use Text Align  in React with Axiom Design System.
+openGraph:
+  title: Text Align – Styling Guide
+  description: Use textAlign prop to control the text-align of an element. Learn how to use Text Align  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Text Align
 

--- a/apps/docs/app/(docs)/styling/text-color/page.mdx
+++ b/apps/docs/app/(docs)/styling/text-color/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Text Color
+description: Use color prop to control the text color of an element. Learn how to use Text Color  in React with Axiom Design System.
+openGraph:
+  title: Text Color – Styling Guide
+  description: Use color prop to control the text color of an element. Learn how to use Text Color  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Text Color
 

--- a/apps/docs/app/(docs)/styling/transition-property/page.mdx
+++ b/apps/docs/app/(docs)/styling/transition-property/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Transition Property
+description: Use transition prop to control the transition-property of an element. Learn how to use Transition Property  in React with Axiom Design System.
+openGraph:
+  title: Transition Property – Styling Guide
+  description: Use transition prop to control the transition-property of an element. Learn how to use Transition Property  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Transition Property
 

--- a/apps/docs/app/(docs)/styling/width/page.mdx
+++ b/apps/docs/app/(docs)/styling/width/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Width
+description: Use w prop to control the width of an element. Learn how to use Width  in React with Axiom Design System.
+openGraph:
+  title: Width – Styling Guide
+  description: Use w prop to control the width of an element. Learn how to use Width  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Width
 

--- a/apps/docs/app/(docs)/styling/z-index/page.mdx
+++ b/apps/docs/app/(docs)/styling/z-index/page.mdx
@@ -1,4 +1,13 @@
+---
+title: Z-Index
+description: Use z prop to control the z-index of an element. Learn how to use Z-Index  in React with Axiom Design System.
+openGraph:
+  title: Z-Index – Styling Guide
+  description: Use z prop to control the z-index of an element. Learn how to use Z-Index  in React with Axiom Design System.
+---
+
 import { Demo, Scale } from "@/components";
+
 
 # Z-Index
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "next build",
     "dev": "concurrently --raw \"sleep 3 && node -e \\\"require('better-opn')('http://localhost:5055')\\\"\" \"next dev -p 5055\"",
-    "postbuild": "pagefind --site .next/server/app --output-path out/_pagefind"
+    "postbuild": "pagefind --site .next/server/app --output-path out/_pagefind && node scripts/generate-sitemap.mjs"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.9.0",

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://optimizely-axiom.github.io/optiaxiom/sitemap.xml

--- a/apps/docs/public/sitemap.xml
+++ b/apps/docs/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://optimizely-axiom.github.io/optiaxiom/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+
+</urlset>

--- a/apps/docs/scripts/generate-sitemap.mjs
+++ b/apps/docs/scripts/generate-sitemap.mjs
@@ -1,0 +1,43 @@
+import fg from "fast-glob";
+import fs from "fs";
+
+const baseUrl = "https://optimizely-axiom.github.io/optiaxiom";
+
+// Find all HTML files in the build output
+const htmlFiles = fg.globSync("out/**/*.html");
+
+const urls = htmlFiles
+  .map((file) => {
+    // Convert "out/components/pill/index.html" to "/components/pill/"
+    let url = file
+      .replace("out", "")
+      .replace("/index.html", "/")
+      .replace(".html", "/");
+
+    // Ensure URL starts with /
+    if (!url.startsWith("/")) {
+      url = "/" + url;
+    }
+
+    // Skip files that shouldn't be in sitemap
+    if (url.includes("404") || url.includes("_next")) {
+      return null;
+    }
+
+    return `  <url>
+    <loc>${baseUrl}${url}</loc>
+    <changefreq>weekly</changefreq>
+    <priority>${url === "/" ? "1.0" : "0.8"}</priority>
+  </url>`;
+  })
+  .filter(Boolean)
+  .join("\n");
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>`;
+
+fs.writeFileSync("./out/sitemap.xml", sitemap);
+
+console.log(`Generated sitemap with ${htmlFiles.length} pages`);


### PR DESCRIPTION
resolves #1237

## Problem
When searching for specific components (e.g., "pill optiaxiom"), Google only shows the main page instead of component-specific pages. This is because all pages shared the same generic meta description.

## Solution
Add comprehensive SEO improvements following Next.js and Google Search best practices:

### Changes
- ✅ Added unique `metadata` exports to 99 pages (components, styling, guides)
- ✅ Added `robots.txt` allowing search engine crawling
- ✅ Automated `sitemap.xml` generation in postbuild script
- ✅ Added Open Graph tags for better social media sharing


### References
- [Next.js Metadata API](https://nextjs.org/docs/app/building-your-application/optimizing/metadata)
- [Google Search Central - Sitemaps](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
- [Open Graph Protocol](https://ogp.me/)

### Testing
Build the site and verify:
```bash
cd apps/docs
pnpm build
# Check metadata in built HTML
grep '<meta name="description"' out/components/pill/index.html
# Verify sitemap
cat out/sitemap.xml | grep pill