### PR TITLE
handle scroll locking when menu is used within a modal

### DIFF
--- a/.changeset/fifty-rules-lie.md
+++ b/.changeset/fifty-rules-lie.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+handle scroll locking when menu is used within a modal

--- a/packages/react/src/menu/MenuPopoverContent.tsx
+++ b/packages/react/src/menu/MenuPopoverContent.tsx
@@ -1,6 +1,9 @@
+import { useModalContext } from "@optiaxiom/globals";
 import { useId } from "@radix-ui/react-id";
+import { createSlot } from "@radix-ui/react-slot";
 import clsx from "clsx";
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import { RemoveScroll } from "react-remove-scroll";
 
 import type { MenuContent } from "./MenuContent";
 
@@ -8,6 +11,8 @@ import { useFieldContext } from "../field/internals";
 import { PopoverContent } from "../popover";
 import { VisuallyHidden } from "../visually-hidden";
 import { useMenuContext } from "./MenuContext";
+
+const Slot = createSlot("@optiaxiom/react/MenuPopoverContent");
 
 export type MenuPopoverContentProps = ComponentPropsWithoutRef<
   typeof MenuContent
@@ -17,13 +22,14 @@ export const MenuPopoverContent = forwardRef<
   HTMLDivElement,
   MenuPopoverContentProps
 >(({ "aria-label": ariaLabel, children, ...props }, ref) => {
+  const { shardRef } = useModalContext("@optiaxiom/react/MenuPopoverContent");
   const { labelId: fieldLabelId } = useFieldContext(
     "@optiaxiom/react/MenuPopoverContent",
   );
   const { triggerRef } = useMenuContext("@optiaxiom/react/MenuPopoverContent");
   const labelId = useId();
 
-  return (
+  const content = (
     <PopoverContent
       aria-labelledby={clsx(fieldLabelId ?? triggerRef.current?.id, labelId)}
       ref={ref}
@@ -33,6 +39,18 @@ export const MenuPopoverContent = forwardRef<
       {children}
     </PopoverContent>
   );
+  if (shardRef.current) {
+    /**
+     * Handle scroll locking when menu is used within a modal.
+     */
+    return (
+      <RemoveScroll allowPinchZoom as={Slot} shards={[shardRef]}>
+        {content}
+      </RemoveScroll>
+    );
+  } else {
+    return content;
+  }
 });
 
 MenuPopoverContent.displayName = "@optiaxiom/react/MenuPopoverContent";


### PR DESCRIPTION
dialogs introduce a new scroll locking context so we need to compensate for that by checking if menu is being rendered inside a modal and then include RemoveScroll component in such cases