### PR TITLE
fix textarea resize in safari

### DIFF
--- a/.changeset/soft-candies-film.md
+++ b/.changeset/soft-candies-film.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+fix textarea resize in safari

--- a/packages/react/src/textarea/TextareaAutosize.css.ts
+++ b/packages/react/src/textarea/TextareaAutosize.css.ts
@@ -47,6 +47,19 @@ export const wrapper = recipe({
       none: {},
       vertical: style({
         resize: "vertical",
+
+        selectors: {
+          "&::after": {
+            bottom: 0,
+            content: "",
+            display: "block",
+            height: 16,
+            pointerEvents: "none",
+            position: "absolute",
+            right: 0,
+            width: 16,
+          },
+        },
       }),
     },
   },


### PR DESCRIPTION
resolves #1241

because of the grid display the native safari resize handler is getting hidden by the textarea so we simply add an empty div at the bottom right corner so the resize layer sits on top of the textarea