### PR TITLE
fix: show field info tooltips immediately without delay

### DIFF
--- a/.changeset/warm-bags-wait.md
+++ b/.changeset/warm-bags-wait.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+show field info tooltips immediately without delay

--- a/packages/react/src/field/FieldLabel.tsx
+++ b/packages/react/src/field/FieldLabel.tsx
@@ -80,7 +80,7 @@ export const FieldLabel = forwardRef<HTMLDivElement, FieldLabelProps>(
           </RadixLabel.Root>
         </Text>
         {info && (
-          <Tooltip content={info}>
+          <Tooltip content={info} delayDuration={0}>
             <Button
               aria-label="Information hover"
               bg="transparent"


### PR DESCRIPTION
## Summary
- Set `delayDuration={0}` on the info tooltip in `FieldLabel` component so tooltips appear immediately on hover
- Improves UX for field info tooltips where users expect instant feedback when hovering the help icon

## Test plan
- [ ] Hover over the info icon on any field with the `info` prop
- [ ] Verify the tooltip appears immediately without the default 700ms delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)