### PR TITLE
add dark/light mode theme toggle

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -8,6 +8,7 @@ const config: StorybookConfig = {
     "storybook-addon-test-codegen",
     "@storybook/addon-a11y",
     "@storybook/addon-designs",
+    "@storybook/addon-themes",
   ],
   core: {
     disableTelemetry: true,

--- a/apps/storybook/.storybook/preview.css
+++ b/apps/storybook/.storybook/preview.css
@@ -1,3 +1,8 @@
+.dark {
+  background-color: var(--ax-colors-bg-default);
+  color-scheme: dark;
+}
+
 .tabler-icon {
   stroke-width: 1.5;
 

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import type { Preview } from "@storybook/react-vite";
 
 import { AxiomProvider, TransitionGlobalConfig } from "@optiaxiom/react";
+import { withThemeByClassName } from "@storybook/addon-themes";
 import isChromatic from "chromatic/isChromatic";
 
 import "./preview.css";
@@ -9,6 +10,13 @@ TransitionGlobalConfig.skipAnimations = isChromatic();
 
 export default {
   decorators: [
+    withThemeByClassName({
+      defaultTheme: "light",
+      themes: {
+        dark: "dark",
+        light: "",
+      },
+    }),
     (Story, context) =>
       context.parameters.useAxiomProvider ? (
         <AxiomProvider>

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-visually-hidden": "^1.2.3",
     "@storybook/addon-a11y": "^10.2.8",
     "@storybook/addon-designs": "^11.1.2",
+    "@storybook/addon-themes": "^10.2.10",
     "@storybook/addon-vitest": "^10.2.8",
     "@storybook/react-vite": "^10.2.8",
     "@tabler/icons-react": "^3.34.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       '@storybook/addon-designs':
         specifier: ^11.1.2
         version: 11.1.2(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/addon-themes':
+        specifier: ^10.2.10
+        version: 10.2.10(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-vitest':
         specifier: ^10.2.8
         version: 10.2.8(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@3.2.4)
@@ -2614,6 +2617,11 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  '@storybook/addon-themes@10.2.10':
+    resolution: {integrity: sha512-j7ixCgzpWeTU7K4BkNHtEg3NdmRg9YW7ynvv0OjD3vaz4+FUVWOq7PPwb3SktLS1tOl4UA13IpApD8nSpBiY6A==}
+    peerDependencies:
+      storybook: ^10.2.10
 
   '@storybook/addon-vitest@10.2.8':
     resolution: {integrity: sha512-D+9QWBqURAlS9+js9fvBToe7RzhIM9/ep/q8lunpVvcTkbOxh5++cYWBD8PVqmzZ+U432w9h2UwPuxPsWD/loQ==}
@@ -9938,6 +9946,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
+
+  '@storybook/addon-themes@10.2.10(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      ts-dedent: 2.2.0
 
   '@storybook/addon-vitest@10.2.8(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@3.2.4)':
     dependencies:


### PR DESCRIPTION
- Add `@storybook/addon-themes` with `withThemeByClassName` decorator to enable switching between light and dark mode across all stories
- Dark mode applies `color-scheme: dark` to trigger CSS `light-dark()` tokens and sets a dark background (`#1C2029`)
