### PR TITLE
fix: add overflow visible to internal SVG icons

### DIFF
--- a/.changeset/fruity-women-live.md
+++ b/.changeset/fruity-women-live.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+fix anti-aliased edge of icons from being clipped

--- a/packages/react/src/icons/withIcon.tsx
+++ b/packages/react/src/icons/withIcon.tsx
@@ -25,6 +25,7 @@ export const withIcon = (
       <svg
         fill={fill}
         height={height}
+        overflow="visible"
         ref={ref}
         viewBox={viewBox ?? `0 0 ${width} ${height}`}
         width={width}


### PR DESCRIPTION
## Summary
- Add `overflow="visible"` to the SVG element in `packages/react/src/icons/withIcon.tsx`
- Prevents anti-aliased edges from being clipped on non-retina (1x DPI) displays
- The SVG spec defaults to `overflow: hidden`, which clips sub-pixel rendering at viewBox boundaries — particularly visible at small icon sizes where stroke paths sit near the viewBox edge (e.g. `IconUpRightFromSquare` used by the `Link` component's `external` prop)
- This mirrors the same fix applied to `@optimizely/axiom-icons` in [optimizely/axiom#1999](https://github.com/optimizely/axiom/pull/1999)

## Test plan
- [ ] Verify external link icons on `Link` components render without clipping on non-retina displays
- [ ] Verify no visual regressions on retina displays