### PR TITLE
fix(proteus): respect dark mode in document editor and sample data

### DIFF
--- a/apps/docs/components/proteus-designer/JsonEditor.tsx
+++ b/apps/docs/components/proteus-designer/JsonEditor.tsx
@@ -2,6 +2,7 @@
 
 import Editor, { loader, type OnMount } from "@monaco-editor/react";
 import { Box, Group, Heading } from "@optiaxiom/react";
+import { useTheme } from "next-themes";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { safeParseDocument } from "./schemaUtils";
@@ -31,6 +32,9 @@ export function JsonEditor({
   onDocumentChange,
   onDocumentError,
 }: JsonEditorProps) {
+  const { resolvedTheme } = useTheme();
+  const monacoTheme = resolvedTheme === "dark" ? "vs-dark" : "light";
+
   const [docText, setDocText] = useState(() =>
     JSON.stringify(document, null, 2),
   );
@@ -143,6 +147,7 @@ export function JsonEditor({
               fontSize: 12,
               minimap: { enabled: false },
             }}
+            theme={monacoTheme}
           />
         </Box>
       </Group>
@@ -160,6 +165,7 @@ export function JsonEditor({
               fontSize: 12,
               minimap: { enabled: false },
             }}
+            theme={monacoTheme}
           />
         </Box>
       </Group>


### PR DESCRIPTION
<img width="1436" height="913" alt="image" src="https://github.com/user-attachments/assets/270bdeb3-d586-4e0a-8e6e-08436df64e54" />


to this 

<img width="1436" height="889" alt="image" src="https://github.com/user-attachments/assets/3fcef338-d2cb-42f6-b4b6-9e8cec72a577" />
