### PR TITLE
feat(proteus): add onDownload prop to ProteusDocumentShell

### DIFF
--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -45,6 +45,12 @@ export type ProteusDocumentShellProps = Pick<
    */
   onDataChange?: (data: Record<string, unknown>) => void;
   /**
+   * Callback when user triggers a download action; receives the resolved URL(s).
+   * When provided, the host is responsible for the actual download/zip.
+   * Falls back to built-in window.open behaviour when absent.
+   */
+  onDownload?: (urls: string[]) => Promise<void> | void;
+  /**
    * Callback when user clicks a Action button with interaction handler
    */
   onInteraction?: (name: string) => Promise<void> | void;
@@ -79,6 +85,7 @@ export function ProteusDocumentShell({
   defaultOpen = true,
   element,
   onDataChange,
+  onDownload,
   onInteraction,
   onMessage,
   onOpenChange,
@@ -117,19 +124,23 @@ export function ProteusDocumentShell({
         } else if ("message" in event) {
           await onMessage?.(event.message);
         } else if (event.action === "download") {
+          const urls: string[] = [];
           if (typeof event.url === "string") {
-            await downloadFile(event.url);
+            urls.push(event.url);
           } else if (Array.isArray(event.url)) {
-            await Promise.all(
-              event.url.map((u) => {
-                if (typeof u !== "string") {
-                  throw new Error("Invalid URL in download array");
-                }
-                return downloadFile(u);
-              }),
-            );
+            for (const u of event.url) {
+              if (typeof u !== "string") {
+                throw new Error("Invalid URL in download array");
+              }
+              urls.push(u);
+            }
           } else {
             throw new Error("Invalid URL for download action");
+          }
+          if (onDownload) {
+            await onDownload(urls);
+          } else {
+            await Promise.all(urls.map((u) => downloadFile(u)));
           }
         }
       })}


### PR DESCRIPTION
## Summary

- Adds an optional `onDownload?: (urls: string[]) => Promise<void> | void` prop to `ProteusDocumentShell` (and by extension `ProteusDocumentRenderer`), parallel to the existing `onMessage` prop
- When provided, download actions (`action: "download"`) delegate URL resolution to the host instead of calling `window.open` internally
- Falls back to the existing `window.open` behaviour when the prop is absent, so no breaking change

## Motivation

Allows host applications (e.g. chat-frontend) to handle downloads themselves — specifically to zip multiple image URLs client-side rather than relying on a pre-built zip from the backend.

## Test plan

- [ ] Existing Proteus consumers with no `onDownload` prop: download behaviour unchanged (`window.open`)
- [ ] Passing `onDownload`: prop is called with the resolved URL array; built-in handler is skipped