### PR TITLE
refactor: remove tree walker auto-focus from ProteusDocumentShell

### DIFF
--- a/.changeset/remove-tree-walker.md
+++ b/.changeset/remove-tree-walker.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": patch
+---
+
+Remove tree walker auto-focus from ProteusDocumentShell

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -94,25 +94,6 @@ export function ProteusDocumentShell({
     }
   }, []);
 
-  useEffect(() => {
-    if (!element.blocking || !formRef.current) return;
-    const walker = document.createTreeWalker(
-      formRef.current,
-      NodeFilter.SHOW_ELEMENT,
-      {
-        acceptNode: (node: Element) => {
-          if (node instanceof HTMLInputElement && node.type === "hidden")
-            return NodeFilter.FILTER_SKIP;
-          if ((node as HTMLElement).hidden) return NodeFilter.FILTER_SKIP;
-          return (node as HTMLElement).tabIndex >= 0
-            ? NodeFilter.FILTER_ACCEPT
-            : NodeFilter.FILTER_SKIP;
-        },
-      },
-    );
-    (walker.nextNode() as HTMLElement | null)?.focus();
-  }, [element.blocking]);
-
   const [open, setOpen] = useControllableState({
     defaultProp: defaultOpen,
     onChange: onOpenChange,


### PR DESCRIPTION
## Summary
- Remove the `TreeWalker`-based auto-focus `useEffect` from `ProteusDocumentShell`
- `ProteusQuestion` already handles its own focus internally, and `AskAgentInput` uses `autoFocus` on inputs directly, making the tree walker redundant

## Test plan
- [ ] Verify `AskUserQuestion` story still auto-focuses the first option
- [ ] Verify `AskAgentInput` story still auto-focuses the first input