### PR TITLE
add compact body to proteus document shell

### DIFF
--- a/.changeset/truncate-document-body.md
+++ b/.changeset/truncate-document-body.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": patch
+---
+
+add compact body support to proteus document shell

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -521,8 +521,9 @@ export const AskAgentInput: Story = {
         },
       ],
       blocking: true,
-      body: [
-        {
+      body: {
+        $type: "Group",
+        children: {
           $type: "Map",
           children: [
             {
@@ -567,7 +568,9 @@ export const AskAgentInput: Story = {
           ],
           path: "/parameters",
         },
-      ],
+        flexDirection: "column",
+        gap: "24",
+      },
       subtitle: {
         $type: "Value",
         path: "/agent/description",
@@ -578,6 +581,100 @@ export const AskAgentInput: Story = {
       },
       titleIcon:
         "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2221%22%20height%3D%2220%22%20fill%3D%22none%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M9.463%208.198c.184-.052.437-.005.616.064l9.73%203.361c.226.095.4.286.462.507a.87.87%200%200%201-.608%201.09l-3.795%201.374c-.896.286-.934.773-.934.785l-1.177%203.656c-.095.226-.296.364-.517.427-.48.136-.907-.102-1.044-.581l-3.33-9.556c-.136-.48.117-.99.597-1.127M15.972%200a2.45%202.45%200%200%201%202.457%202.457v4.3c0%20.308-.307.615-.614.615a.63.63%200%200%201-.615-.614V2.457c0-.691-.576-1.228-1.228-1.228H2.457c-.691%200-1.228.537-1.228%201.228v13.515c0%20.652.537%201.228%201.228%201.228h4.3c.307%200%20.614.27.614.614%200%20.308-.307.615-.614.615h-4.3A2.45%202.45%200%200%201%200%2015.972V2.457A2.426%202.426%200%200%201%202.457%200zm-3.486%2017.418.767-2.385q.013-.057.031-.119a2%202%200%200%201%20.295-.558c.294-.39.746-.709%201.371-.916l2.859-1.036L9.77%209.627zM3.51%209.762l2.62.824a.63.63%200%200%201%20.422.78.63.63%200%200%201-.78.421l-2.622-.824c-.327-.103-.497-.48-.42-.78.102-.328.48-.497.78-.421m1.832-4.406a.63.63%200%200%201%20.868-.014l1.768%201.707c.22.213.228.648.014.869a.63.63%200%200%201-.869.015L5.356%206.225a.606.606%200%200%201-.014-.869m4.79-2.615a.63.63%200%200%201%20.794.395l.913%202.59a.63.63%200%200%201-.394.795.63.63%200%200%201-.794-.394l-.913-2.59c-.086-.298.07-.682.394-.796%22%2F%3E%3C%2Fsvg%3E",
+    },
+  },
+  render: function Render(args) {
+    const [data, setData] = useState<Record<string, unknown>>(args.data ?? {});
+    return (
+      <ProteusDocumentRenderer {...args} data={data} onDataChange={setData} />
+    );
+  },
+};
+
+export const AskAgentInputTruncate: Story = {
+  args: {
+    ...AskAgentInput.args,
+    data: {
+      ...AskAgentInput.args?.data,
+      parameters: [
+        {
+          name: "Post Topic",
+          placeholder: "e.g., Our new AI-powered Personalization engine launch",
+          required: true,
+          type: "string",
+          value: null,
+        },
+        {
+          name: "Target Audience",
+          placeholder: "e.g., Digital marketing managers and CRO specialists",
+          required: true,
+          type: "string",
+          value: null,
+        },
+        {
+          name: "Channels",
+          placeholder: "e.g., LinkedIn, X, Instagram",
+          required: true,
+          type: "string",
+          value: null,
+        },
+        {
+          name: "Primary CTA",
+          placeholder:
+            "e.g., Read the blog post: https://optimizely.com/blog/ai-personalization",
+          required: true,
+          type: "string",
+          value: null,
+        },
+        {
+          name: "Brand Voice Notes",
+          placeholder:
+            "e.g., Professional, insightful, use 1-2 relevant emojis",
+          required: false,
+          type: "string",
+          value: null,
+        },
+        {
+          name: "Keywords",
+          placeholder: "e.g., personalization, AI, conversion",
+          required: false,
+          type: "string",
+          value: null,
+        },
+        {
+          name: "Publish Date",
+          placeholder: "e.g., 2026-05-01",
+          required: false,
+          type: "string",
+          value: null,
+        },
+        {
+          name: "Campaign Source",
+          placeholder: "e.g., Q2 launch campaign",
+          required: false,
+          type: "string",
+          value: null,
+        },
+        {
+          name: "Tracking ID",
+          placeholder: "e.g., UTM-12345",
+          required: false,
+          type: "string",
+          value: null,
+        },
+        {
+          name: "Include Hashtags",
+          required: false,
+          type: "boolean",
+          value: null,
+        },
+      ],
+    },
+    element: {
+      $type: "Document",
+      body: {},
+      ...AskAgentInput.args?.element,
+      compact: true,
     },
   },
   render: function Render(args) {

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -647,6 +647,11 @@ function generateSpec(additionalProperties = false) {
               $ref: "#/definitions/ProteusNode",
               description: "The main content of the document.",
             },
+            compact: {
+              description:
+                "If true, constrains the body to a max height and makes it scrollable when content overflows.",
+              type: "boolean",
+            },
             subtitle: {
               $ref: "#/definitions/ProteusNode",
               description:

--- a/packages/proteus/src/proteus-document/ProteusDocumentRenderer.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentRenderer.tsx
@@ -25,6 +25,7 @@ type ProteusDocument = {
   appName?: string;
   blocking?: boolean;
   body: unknown;
+  compact?: boolean;
   subtitle?: unknown;
   title?: unknown;
   titleIcon?: string;

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.css.ts
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.css.ts
@@ -1,0 +1,25 @@
+import { recipe, style } from "../vanilla-extract";
+
+export const body = recipe({
+  base: [
+    {
+      flexDirection: "column",
+      gap: "16",
+    },
+  ],
+  variants: {
+    truncate: {
+      false: {},
+      true: [
+        {
+          maxH: "sm",
+          overflow: "auto",
+          p: "4",
+        },
+        style({
+          margin: "-4px",
+        }),
+      ],
+    },
+  },
+});

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.css.ts
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.css.ts
@@ -1,11 +1,14 @@
 import { recipe, style } from "../vanilla-extract";
 
+const marker = style({});
+
 export const body = recipe({
   base: [
     {
       flexDirection: "column",
       gap: "16",
     },
+    marker,
   ],
   variants: {
     truncate: {
@@ -22,4 +25,37 @@ export const body = recipe({
       ],
     },
   },
+});
+
+export const scrollIndicator = recipe({
+  base: [
+    {
+      bg: "bg.secondary",
+      border: "1",
+      borderColor: "border.secondary",
+      color: "fg.secondary",
+      display: "grid",
+      flex: "none",
+      placeItems: "center",
+      pointerEvents: "none",
+      rounded: "full",
+      shadow: "sm",
+      size: "lg",
+      transition: "opacity",
+    },
+    style({
+      alignSelf: "center",
+      bottom: "8px",
+      marginTop: "-56px", // size (40px) + gap (16px) = 56px
+      opacity: 0,
+      position: "sticky",
+      zIndex: 10,
+
+      selectors: {
+        [`${marker}[data-can-scroll] &`]: {
+          opacity: 1,
+        },
+      },
+    }),
+  ],
 });

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -1,3 +1,4 @@
+import { IconSouth } from "@optiaxiom/icons";
 import {
   Box,
   Disclosure,
@@ -108,6 +109,28 @@ export function ProteusDocumentShell({
     onChange: onOpenChange,
     prop: openProp,
   });
+
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const node = bodyRef.current;
+    if (!node) return;
+
+    const update = () => {
+      if (node.scrollHeight - node.scrollTop - node.clientHeight > 1) {
+        node.dataset.canScroll = "";
+      } else {
+        delete node.dataset.canScroll;
+      }
+    };
+
+    const observer = new ResizeObserver(update);
+    observer.observe(node);
+    node.addEventListener("scroll", update, { passive: true });
+    return () => {
+      observer.disconnect();
+      node.removeEventListener("scroll", update);
+    };
+  }, []);
 
   const collapsible = collapsibleProp && element.appName;
   const Trigger = collapsible ? DisclosureTrigger : Box;
@@ -240,8 +263,16 @@ export function ProteusDocumentShell({
               }}
               ref={formRef}
             >
-              <Group {...styles.body({ truncate: element.compact })}>
+              <Group
+                ref={element.compact ? bodyRef : undefined}
+                {...styles.body({ truncate: element.compact })}
+              >
                 {element.body}
+                {element.compact && (
+                  <Box {...styles.scrollIndicator()}>
+                    <IconSouth />
+                  </Box>
+                )}
               </Group>
               {element.actions && !readOnly && (
                 <Group gap="16" justifyContent="end" w="full">

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -23,6 +23,7 @@ import type { ProteusEventHandler } from "./schemas";
 import { useEffectEvent } from "../hooks";
 import { downloadFile } from "../proteus-image/downloadFile";
 import { ProteusDocumentProvider } from "./ProteusDocumentContext";
+import * as styles from "./ProteusDocumentShell.css";
 
 export type ProteusDocumentShellProps = Pick<
   ComponentPropsWithoutRef<typeof Disclosure>,
@@ -74,6 +75,7 @@ type ProteusDocument = {
   appName?: string;
   blocking?: boolean;
   body: ReactNode;
+  compact?: boolean;
   subtitle?: ReactNode;
   title?: ReactNode;
   titleIcon?: string;
@@ -238,7 +240,9 @@ export function ProteusDocumentShell({
               }}
               ref={formRef}
             >
-              {element.body}
+              <Group {...styles.body({ truncate: element.compact })}>
+                {element.body}
+              </Group>
               {element.actions && !readOnly && (
                 <Group gap="16" justifyContent="end" w="full">
                   {element.actions}

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -1275,6 +1275,10 @@
           "$ref": "#/definitions/ProteusNode",
           "description": "The main content of the document."
         },
+        "compact": {
+          "description": "If true, constrains the body to a max height and makes it scrollable when content overflows.",
+          "type": "boolean"
+        },
         "subtitle": {
           "$ref": "#/definitions/ProteusNode",
           "description": "A brief description or tagline that provides additional context about the Proteus document's purpose."

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -1264,6 +1264,10 @@
           "$ref": "#/definitions/ProteusNode",
           "description": "The main content of the document."
         },
+        "compact": {
+          "description": "If true, constrains the body to a max height and makes it scrollable when content overflows.",
+          "type": "boolean"
+        },
         "subtitle": {
           "$ref": "#/definitions/ProteusNode",
           "description": "A brief description or tagline that provides additional context about the Proteus document's purpose."


### PR DESCRIPTION
## Summary
- Add `compact` flag to ProteusDocument; when true, body becomes a flex-column scroll region capped at `maxH="sm"` with negative-margin so input focus rings aren't clipped at the edges.
- Regenerate public/runtime schemas for the new `compact` property.
- New `AskAgentInputTruncate` story demonstrates the behavior with 10 fields so content overflows.

## Test plan
- [ ] Storybook → `ProteusDocumentRenderer/AskAgentInputTruncate` shows a vertical scrollbar within the body, actions stay pinned outside the scroll region.
- [ ] Tab through inputs near the right edge — focus rings render fully (not clipped by scrollbar gutter).
- [ ] Existing non-truncate stories (`AskAgentInput`, `FormWithInputs`, etc.) render unchanged.