### PR TITLE
feat(proteus): add onTrack analytics callback

### DIFF
--- a/.changeset/mighty-mirrors-heal.md
+++ b/.changeset/mighty-mirrors-heal.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": minor
+---
+
+adds onTrack prop for analytics tracking

--- a/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
+++ b/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
@@ -14,7 +14,7 @@ export const [ProteusDocumentProvider, useProteusDocumentContext] =
     data: Record<string, unknown>;
     onDataChange: (path: string, value: unknown) => void;
     onEvent: (event: ProteusEventHandler) => Promise<unknown>;
-    onTrack?: (event: string, properties: Record<string, unknown>) => void;
+    onTrack?: (event: string, properties: Record<string, string>) => void;
     readOnly: boolean | undefined;
     strict: boolean | undefined;
     useResource?: UseResource;

--- a/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
+++ b/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
@@ -14,6 +14,7 @@ export const [ProteusDocumentProvider, useProteusDocumentContext] =
     data: Record<string, unknown>;
     onDataChange: (path: string, value: unknown) => void;
     onEvent: (event: ProteusEventHandler) => Promise<unknown>;
+    onTrack?: (event: string, properties: Record<string, unknown>) => void;
     readOnly: boolean | undefined;
     strict: boolean | undefined;
     useResource?: UseResource;

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -186,7 +186,11 @@ export function ProteusDocumentShell({
         }
         return;
       })}
-      onTrack={onTrack}
+      onTrack={useEffectEvent(
+        (event: string, properties: Record<string, string>) => {
+          onTrack?.(event, properties);
+        },
+      )}
       readOnly={readOnly}
       strict={strict}
       useResource={useResource}

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -69,7 +69,7 @@ export type ProteusDocumentShellProps = Pick<
   /**
    * Callback when an analytics event is fired
    */
-  onTrack?: (event: string, properties: Record<string, unknown>) => void;
+  onTrack?: (event: string, properties: Record<string, string>) => void;
   /**
    * Whether form is readonly
    */

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -67,6 +67,10 @@ export type ProteusDocumentShellProps = Pick<
    */
   onMessage?: (message: string) => Promise<void> | void;
   /**
+   * Callback when an analytics event is fired
+   */
+  onTrack?: (event: string, properties: Record<string, unknown>) => void;
+  /**
    * Whether form is readonly
    */
   readOnly?: boolean;
@@ -102,6 +106,7 @@ export function ProteusDocumentShell({
   onInteraction,
   onMessage,
   onOpenChange,
+  onTrack,
   open: openProp,
   readOnly = false,
   strict,
@@ -181,6 +186,7 @@ export function ProteusDocumentShell({
         }
         return;
       })}
+      onTrack={onTrack}
       readOnly={readOnly}
       strict={strict}
       useResource={useResource}

--- a/packages/proteus/src/proteus-question/ProteusQuestion.tsx
+++ b/packages/proteus/src/proteus-question/ProteusQuestion.tsx
@@ -24,7 +24,7 @@ type QuestionData = {
 };
 
 export function ProteusQuestion({ questions }: ProteusQuestionProps) {
-  const { onEvent } = useProteusDocumentContext(
+  const { onEvent, onTrack } = useProteusDocumentContext(
     "@optiaxiom/proteus/ProteusQuestion",
   );
   const [answers, setAnswers] = useState<Array<null | string[]>>([]);
@@ -34,10 +34,13 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
     Array.isArray(value) && value.length > 0 && value.every(Boolean);
 
   const onDismiss = useCallback(() => {
+    onTrack?.("ask_question_card_dismissed", {
+      question_index_at_dismiss: currentIndex,
+    });
     void onEvent({
       message: "[User declined to answer the question]",
     });
-  }, [onEvent]);
+  }, [currentIndex, onEvent, onTrack]);
 
   const questionRef = useRef<HTMLDivElement>(null);
   const lastIndexRef = useRef(currentIndex);
@@ -79,8 +82,16 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
   const otherValue = value?.find((v) => !options.includes(v));
   const otherChecked = otherValue !== undefined;
 
-  const onComplete = () =>
-    onEvent({
+  const onComplete = () => {
+    const answeredCount = answers.filter(
+      (a) => Array.isArray(a) && a.length > 0,
+    ).length;
+    onTrack?.("ask_user_question_submitted", {
+      answered_count: answeredCount,
+      skipped_count: questions.length - answeredCount,
+      total_questions: questions.length,
+    });
+    return onEvent({
       message: answers
         .map(
           (value, index) =>
@@ -88,6 +99,7 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
         )
         .join("\n\n"),
     });
+  };
 
   const onValueChange = (value: null | string[]) => {
     answers[currentIndex] = value;
@@ -95,6 +107,9 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
   };
 
   const onSkip = () => {
+    onTrack?.("ask_user_question_skipped", {
+      question_index: currentIndex,
+    });
     answers[currentIndex] = null;
     setAnswers([...answers]);
     if (isLast) {
@@ -104,6 +119,16 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
     }
   };
   const onSubmit = () => {
+    const currentValue = answers[currentIndex];
+    if (currentValue) {
+      const indices = currentValue.map((v) => options.indexOf(v));
+      onTrack?.("ask_user_question_selected", {
+        question_index: currentIndex,
+        option_index: indices[0],
+        option_indices: indices,
+        is_custom_text: currentValue.some((v) => !options.includes(v)),
+      });
+    }
     if (isLast) {
       void onComplete();
     } else {
@@ -129,6 +154,10 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
         ) {
           event.preventDefault();
           if (event.key === "ArrowLeft" && currentIndex > 0) {
+            onTrack?.("ask_user_question_back", {
+              from_index: currentIndex,
+              to_index: currentIndex - 1,
+            });
             setCurrentIndex((i) => i - 1);
           } else if (event.key === "ArrowRight" && !isLast) {
             setCurrentIndex((i) => i + 1);
@@ -153,6 +182,10 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
                   icon={<IconAngleLeft />}
                   onClick={(event) => {
                     event.preventDefault();
+                    onTrack?.("ask_user_question_back", {
+                      from_index: currentIndex,
+                      to_index: currentIndex - 1,
+                    });
                     setCurrentIndex((i) => i - 1);
                   }}
                   size="sm"

--- a/packages/proteus/src/proteus-question/ProteusQuestion.tsx
+++ b/packages/proteus/src/proteus-question/ProteusQuestion.tsx
@@ -34,8 +34,8 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
     Array.isArray(value) && value.length > 0 && value.every(Boolean);
 
   const onDismiss = useCallback(() => {
-    onTrack?.("Ask Question Card Dismissed", {
-      question_index_at_dismiss: currentIndex,
+    onTrack?.("ask_question_card_dismissed", {
+      question_index_at_dismiss: String(currentIndex),
     });
     void onEvent({
       message: "[User declined to answer the question]",
@@ -86,10 +86,10 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
     const answeredCount = answers.filter(
       (a) => Array.isArray(a) && a.length > 0,
     ).length;
-    onTrack?.("Ask User Question Submitted", {
-      answered_count: answeredCount,
-      skipped_count: questions.length - answeredCount,
-      total_questions: questions.length,
+    onTrack?.("ask_user_question_submitted", {
+      answered_count: String(answeredCount),
+      skipped_count: String(questions.length - answeredCount),
+      total_questions: String(questions.length),
     });
     return onEvent({
       message: answers
@@ -107,8 +107,8 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
   };
 
   const onSkip = () => {
-    onTrack?.("Ask User Question Skipped", {
-      question_index: currentIndex,
+    onTrack?.("ask_user_question_skipped", {
+      question_index: String(currentIndex),
     });
     answers[currentIndex] = null;
     setAnswers([...answers]);
@@ -122,11 +122,10 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
     const currentValue = answers[currentIndex];
     if (currentValue) {
       const indices = currentValue.map((v) => options.indexOf(v));
-      onTrack?.("Ask User Question Selected", {
-        question_index: currentIndex,
-        option_index: indices[0],
-        option_indices: indices,
-        is_custom_text: currentValue.some((v) => !options.includes(v)),
+      onTrack?.("ask_user_question_option_selected", {
+        question_index: String(currentIndex),
+        option_index: String(indices[0]),
+        is_custom_text: String(currentValue.some((v) => !options.includes(v))),
       });
     }
     if (isLast) {
@@ -182,9 +181,9 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
                   icon={<IconAngleLeft />}
                   onClick={(event) => {
                     event.preventDefault();
-                    onTrack?.("Ask User Question Back", {
-                      from_index: currentIndex,
-                      to_index: currentIndex - 1,
+                    onTrack?.("ask_user_question_back", {
+                      from_index: String(currentIndex),
+                      to_index: String(currentIndex - 1),
                     });
                     setCurrentIndex((i) => i - 1);
                   }}

--- a/packages/proteus/src/proteus-question/ProteusQuestion.tsx
+++ b/packages/proteus/src/proteus-question/ProteusQuestion.tsx
@@ -153,9 +153,9 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
         ) {
           event.preventDefault();
           if (event.key === "ArrowLeft" && currentIndex > 0) {
-            onTrack?.("Ask User Question Back", {
-              from_index: currentIndex,
-              to_index: currentIndex - 1,
+            onTrack?.("ask_user_question_back", {
+              from_index: String(currentIndex),
+              to_index: String(currentIndex - 1),
             });
             setCurrentIndex((i) => i - 1);
           } else if (event.key === "ArrowRight" && !isLast) {

--- a/packages/proteus/src/proteus-question/ProteusQuestion.tsx
+++ b/packages/proteus/src/proteus-question/ProteusQuestion.tsx
@@ -123,9 +123,9 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
     if (currentValue) {
       const indices = currentValue.map((v) => options.indexOf(v));
       onTrack?.("ask_user_question_option_selected", {
-        question_index: String(currentIndex),
-        option_index: String(indices[0]),
         is_custom_text: String(currentValue.some((v) => !options.includes(v))),
+        option_index: String(indices[0]),
+        question_index: String(currentIndex),
       });
     }
     if (isLast) {

--- a/packages/proteus/src/proteus-question/ProteusQuestion.tsx
+++ b/packages/proteus/src/proteus-question/ProteusQuestion.tsx
@@ -34,7 +34,7 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
     Array.isArray(value) && value.length > 0 && value.every(Boolean);
 
   const onDismiss = useCallback(() => {
-    onTrack?.("ask_question_card_dismissed", {
+    onTrack?.("Ask Question Card Dismissed", {
       question_index_at_dismiss: currentIndex,
     });
     void onEvent({
@@ -86,7 +86,7 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
     const answeredCount = answers.filter(
       (a) => Array.isArray(a) && a.length > 0,
     ).length;
-    onTrack?.("ask_user_question_submitted", {
+    onTrack?.("Ask User Question Submitted", {
       answered_count: answeredCount,
       skipped_count: questions.length - answeredCount,
       total_questions: questions.length,
@@ -107,7 +107,7 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
   };
 
   const onSkip = () => {
-    onTrack?.("ask_user_question_skipped", {
+    onTrack?.("Ask User Question Skipped", {
       question_index: currentIndex,
     });
     answers[currentIndex] = null;
@@ -122,7 +122,7 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
     const currentValue = answers[currentIndex];
     if (currentValue) {
       const indices = currentValue.map((v) => options.indexOf(v));
-      onTrack?.("ask_user_question_selected", {
+      onTrack?.("Ask User Question Selected", {
         question_index: currentIndex,
         option_index: indices[0],
         option_indices: indices,
@@ -154,7 +154,7 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
         ) {
           event.preventDefault();
           if (event.key === "ArrowLeft" && currentIndex > 0) {
-            onTrack?.("ask_user_question_back", {
+            onTrack?.("Ask User Question Back", {
               from_index: currentIndex,
               to_index: currentIndex - 1,
             });
@@ -182,7 +182,7 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
                   icon={<IconAngleLeft />}
                   onClick={(event) => {
                     event.preventDefault();
-                    onTrack?.("ask_user_question_back", {
+                    onTrack?.("Ask User Question Back", {
                       from_index: currentIndex,
                       to_index: currentIndex - 1,
                     });

--- a/packages/proteus/src/proteus-question/ProteusQuestion.tsx
+++ b/packages/proteus/src/proteus-question/ProteusQuestion.tsx
@@ -33,6 +33,14 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
   const valid =
     Array.isArray(value) && value.length > 0 && value.every(Boolean);
 
+  const goBack = useCallback(() => {
+    onTrack?.("ask_user_question_back", {
+      from_index: String(currentIndex),
+      to_index: String(currentIndex - 1),
+    });
+    setCurrentIndex((i) => i - 1);
+  }, [currentIndex, onTrack]);
+
   const onDismiss = useCallback(() => {
     onTrack?.("ask_question_card_dismissed", {
       question_index_at_dismiss: String(currentIndex),
@@ -121,10 +129,10 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
   const onSubmit = () => {
     const currentValue = answers[currentIndex];
     if (currentValue) {
-      const indices = currentValue.map((v) => options.indexOf(v));
+      const firstIndex = options.indexOf(currentValue[0]);
       onTrack?.("ask_user_question_option_selected", {
         is_custom_text: String(currentValue.some((v) => !options.includes(v))),
-        option_index: String(indices[0]),
+        option_index: firstIndex === -1 ? "custom" : String(firstIndex),
         question_index: String(currentIndex),
       });
     }
@@ -153,11 +161,7 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
         ) {
           event.preventDefault();
           if (event.key === "ArrowLeft" && currentIndex > 0) {
-            onTrack?.("ask_user_question_back", {
-              from_index: String(currentIndex),
-              to_index: String(currentIndex - 1),
-            });
-            setCurrentIndex((i) => i - 1);
+            goBack();
           } else if (event.key === "ArrowRight" && !isLast) {
             setCurrentIndex((i) => i + 1);
           }
@@ -181,11 +185,7 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
                   icon={<IconAngleLeft />}
                   onClick={(event) => {
                     event.preventDefault();
-                    onTrack?.("ask_user_question_back", {
-                      from_index: String(currentIndex),
-                      to_index: String(currentIndex - 1),
-                    });
-                    setCurrentIndex((i) => i - 1);
+                    goBack();
                   }}
                   size="sm"
                 />

--- a/packages/proteus/src/proteus-question/ProteusQuestion.tsx
+++ b/packages/proteus/src/proteus-question/ProteusQuestion.tsx
@@ -34,16 +34,16 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
     Array.isArray(value) && value.length > 0 && value.every(Boolean);
 
   const goBack = useCallback(() => {
-    onTrack?.("ask_user_question_back", {
-      from_index: String(currentIndex),
-      to_index: String(currentIndex - 1),
+    onTrack?.("Ask User Question Back", {
+      fromIndex: String(currentIndex),
+      toIndex: String(currentIndex - 1),
     });
     setCurrentIndex((i) => i - 1);
   }, [currentIndex, onTrack]);
 
   const onDismiss = useCallback(() => {
-    onTrack?.("ask_question_card_dismissed", {
-      question_index_at_dismiss: String(currentIndex),
+    onTrack?.("Ask Question Card Dismissed", {
+      questionIndex: String(currentIndex),
     });
     void onEvent({
       message: "[User declined to answer the question]",
@@ -92,12 +92,12 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
 
   const onComplete = () => {
     const answeredCount = answers.filter(
-      (a) => Array.isArray(a) && a.length > 0,
+      (answer) => Array.isArray(answer) && answer.length > 0,
     ).length;
-    onTrack?.("ask_user_question_submitted", {
-      answered_count: String(answeredCount),
-      skipped_count: String(questions.length - answeredCount),
-      total_questions: String(questions.length),
+    onTrack?.("Ask User Question Submitted", {
+      answeredCount: String(answeredCount),
+      skippedCount: String(questions.length - answeredCount),
+      totalQuestions: String(questions.length),
     });
     return onEvent({
       message: answers
@@ -115,8 +115,8 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
   };
 
   const onSkip = () => {
-    onTrack?.("ask_user_question_skipped", {
-      question_index: String(currentIndex),
+    onTrack?.("Ask User Question Skipped", {
+      questionIndex: String(currentIndex),
     });
     answers[currentIndex] = null;
     setAnswers([...answers]);
@@ -130,10 +130,10 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
     const currentValue = answers[currentIndex];
     if (currentValue) {
       const firstIndex = options.indexOf(currentValue[0]);
-      onTrack?.("ask_user_question_option_selected", {
-        is_custom_text: String(currentValue.some((v) => !options.includes(v))),
-        option_index: firstIndex === -1 ? "custom" : String(firstIndex),
-        question_index: String(currentIndex),
+      onTrack?.("Ask User Question Option Selected", {
+        isCustomText: String(currentValue.some((v) => !options.includes(v))),
+        optionIndex: String(firstIndex),
+        questionIndex: String(currentIndex),
       });
     }
     if (isLast) {

--- a/packages/proteus/src/proteus-question/ProteusQuestion.tsx
+++ b/packages/proteus/src/proteus-question/ProteusQuestion.tsx
@@ -42,7 +42,7 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
   }, [currentIndex, onTrack]);
 
   const onDismiss = useCallback(() => {
-    onTrack?.("Ask Question Card Dismissed", {
+    onTrack?.("Ask User Question Dismissed", {
       questionIndex: String(currentIndex),
     });
     void onEvent({


### PR DESCRIPTION
## Summary
- Adds `onTrack` callback prop to `ProteusDocumentShell` for analytics tracking
- `ProteusQuestion` fires 5 events: `Ask User Question Option Selected`, `Ask User Question Skipped`, `Ask Question Card Dismissed`, `Ask User Question Back`, `Ask User Question Submitted`

## Test plan
- [ ] Render `ProteusQuestion` with an `onTrack` spy and verify events fire with correct properties