### PR TITLE
fix: truncate toast title text to prevent overflow

### DIFF
--- a/.changeset/long-toast-title-truncate.md
+++ b/.changeset/long-toast-title-truncate.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+truncate long toast title text to 2 lines

--- a/packages/react/src/toast/ToastTitle.css.ts
+++ b/packages/react/src/toast/ToastTitle.css.ts
@@ -1,0 +1,12 @@
+import { recipe, style } from "../vanilla-extract";
+
+export const title = recipe({
+  base: [
+    {
+      flex: "1",
+    },
+    style({
+      overflowWrap: "break-word",
+    }),
+  ],
+});

--- a/packages/react/src/toast/ToastTitle.tsx
+++ b/packages/react/src/toast/ToastTitle.tsx
@@ -2,6 +2,7 @@ import * as RadixToast from "@radix-ui/react-toast";
 import { forwardRef } from "react";
 
 import { Text, type TextProps } from "../text";
+import * as styles from "./ToastTitle.css";
 
 export type ToastTitleProps = TextProps<typeof RadixToast.Title>;
 
@@ -10,9 +11,9 @@ export type ToastTitleProps = TextProps<typeof RadixToast.Title>;
  * @extends Text
  */
 export const ToastTitle = forwardRef<HTMLDivElement, ToastTitleProps>(
-  ({ children, ...props }, ref) => {
+  ({ children, className, ...props }, ref) => {
     return (
-      <Text asChild flex="1" {...props}>
+      <Text asChild lineClamp="2" {...styles.title({}, className)} {...props}>
         <RadixToast.Title ref={ref}>{children}</RadixToast.Title>
       </Text>
     );


### PR DESCRIPTION
## Summary

When a toast notification displays very long text (e.g., a 300+ character string with no word breaks), the toast grows unbounded vertically, creating an oversized notification.

This adds `lineClamp="2"` and `overflow-wrap: break-word` to `ToastTitle` so that long text is clamped to 2 lines with an ellipsis. Normal-length messages that naturally span 2 lines (like the existing `LongContent` story) are unaffected.

### Before
<img width="374" height="167" alt="image" src="https://github.com/user-attachments/assets/6da56467-d3d3-4c03-8acf-54dfd2d384a4" />

### After
<img width="377" height="175" alt="image" src="https://github.com/user-attachments/assets/0e64ff53-cf80-4f53-84b2-3f1daaf77a30" />


## Changes

- **`ToastTitle.tsx`**: Added `lineClamp="2"` as a default prop and applied CSS recipe for word-breaking
- **`ToastTitle.css.ts`** (new): CSS recipe with `overflowWrap: "break-word"` for long unbreakable strings

## Context

Reported via CMP internal ticket CCP-16762 — a field with a very long name caused the toast to display an oversized notification when the field was removed.