### PR TITLE
Add live previews to Proteus guide

### DIFF
--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -1,4 +1,4 @@
-import { Demo } from "@/components";
+import { Demo, ProteusElementRef } from "@/components";
 
 # Proteus
 
@@ -142,3 +142,160 @@ When `blocking` is set to `true` on the Document, the chat input is hidden and t
 
 The [Proteus Designer](/guides/proteus-designer) is a visual editor for building Proteus documents. You can build a component tree, edit properties in the inspector, see a live preview of how the document renders, and copy the final JSON into your resource handler. You can also provide sample data to test how dynamic values resolve.
 
+## Element reference
+
+The tables below list element-specific props for each `$type`. Every element also accepts the full set of [styling props](#styling-props), so those are omitted from the per-element tables.
+
+### Document
+
+The root element of every Proteus document.
+
+<ProteusElementRef type="Document" />
+
+### Layout
+
+#### Group
+
+<ProteusElementRef type="Group" />
+
+#### Card
+
+<ProteusElementRef type="Card" />
+
+#### CardHeader
+
+<ProteusElementRef type="CardHeader" />
+
+#### CardLink
+
+<ProteusElementRef type="CardLink" />
+
+#### Separator
+
+<ProteusElementRef type="Separator" />
+
+### Typography
+
+#### Heading
+
+<ProteusElementRef type="Heading" />
+
+#### Text
+
+<ProteusElementRef type="Text" />
+
+#### Link
+
+<ProteusElementRef type="Link" />
+
+### Data display
+
+#### DataTable
+
+<ProteusElementRef type="DataTable" />
+
+#### Chart
+
+<ProteusElementRef type="Chart" />
+
+#### Image
+
+<ProteusElementRef type="Image" />
+
+#### ImageCarousel
+
+<ProteusElementRef type="ImageCarousel" />
+
+#### Avatar
+
+<ProteusElementRef type="Avatar" />
+
+#### Badge
+
+<ProteusElementRef type="Badge" />
+
+#### Time
+
+<ProteusElementRef type="Time" />
+
+### Form controls
+
+#### Field
+
+<ProteusElementRef type="Field" />
+
+#### Input
+
+<ProteusElementRef type="Input" />
+
+#### Textarea
+
+<ProteusElementRef type="Textarea" />
+
+#### Select
+
+<ProteusElementRef type="Select" />
+
+#### SelectTrigger
+
+<ProteusElementRef type="SelectTrigger" />
+
+#### SelectContent
+
+<ProteusElementRef type="SelectContent" />
+
+#### Switch
+
+<ProteusElementRef type="Switch" />
+
+#### Range
+
+<ProteusElementRef type="Range" />
+
+#### Question
+
+<ProteusElementRef type="Question" />
+
+### Actions
+
+#### Action
+
+<ProteusElementRef type="Action" />
+
+#### Button
+
+<ProteusElementRef type="Button" />
+
+### Data binding
+
+#### Value
+
+<ProteusElementRef type="Value" />
+
+#### Map
+
+<ProteusElementRef type="Map" />
+
+#### MapIndex
+
+<ProteusElementRef type="MapIndex" />
+
+#### Concat
+
+<ProteusElementRef type="Concat" />
+
+#### Zip
+
+<ProteusElementRef type="Zip" />
+
+### Conditional
+
+#### Show
+
+<ProteusElementRef type="Show" />
+
+### Bridge
+
+#### Bridge
+
+<ProteusElementRef type="Bridge" />

--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -46,7 +46,7 @@ Wrap inputs with `Field` to add a label. Available inputs include `Input`, `Text
 
 ### Actions
 
-`Action` renders a button with an `onClick` handler (see [Interactions](#interactions) below). `CancelAction` renders a cancel button that abandons the current interaction.
+`Action` renders a button with an `onClick` handler (see [Interactions](#interactions) below). Use `appearance` (`primary`, `danger`, `subtle`, etc.) to style the button.
 
 <Demo component="proteus/actions" scrollable />
 
@@ -134,7 +134,7 @@ Triggers a file download:
 
 ### Blocking mode
 
-When `blocking` is set to `true` on the Document, the chat input is hidden and the user must click an `Action` or `CancelAction` to continue. Use this for forms that require explicit user input before proceeding.
+When `blocking` is set to `true` on the Document, the chat input is hidden and the user must click an `Action` to continue. Use this for forms that require explicit user input before proceeding.
 
 ## Proteus Designer
 

--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -1,3 +1,5 @@
+import { Demo } from "@/components";
+
 # Proteus
 
 Proteus is a JSON-based UI specification for building interactive tool interfaces. You define your UI as a JSON document, and the Proteus renderer (`@optiaxiom/proteus`) turns it into interactive Axiom components.
@@ -6,49 +8,15 @@ Proteus is a JSON-based UI specification for building interactive tool interface
 
 ### Minimal document
 
-A Proteus document is a JSON object with `$type: "Document"`. At minimum it needs a `body`:
+A Proteus document is a JSON object with `$type: "Document"`. At minimum it needs a `body`. Every element has a `$type` that identifies the component. The `children` property holds nested content: a string, number, another element, or an array of elements.
 
-```json
-{
-  "$type": "Document",
-  "body": [
-    { "$type": "Heading", "children": "Hello World" },
-    { "$type": "Text", "children": "Welcome to Proteus." }
-  ]
-}
-```
-
-Every element has a `$type` that identifies the component. The `children` property holds nested content: a string, number, another element, or an array of elements.
+<Demo component="proteus/minimal-document" scrollable />
 
 ### Document properties
 
 Documents also support `title`, `subtitle`, `appName`, `appIcon`, and `actions` (buttons rendered at the bottom). Set `blocking` to `true` to hide the chat input and force the user to interact with the UI before continuing.
 
-```json
-{
-  "$type": "Document",
-  "appName": "Task Manager",
-  "title": "Create Task",
-  "subtitle": "Fill out the form below",
-  "body": [
-    {
-      "$type": "Field",
-      "label": "Task Name",
-      "children": {
-        "$type": "Input",
-        "name": "task_name",
-        "placeholder": "Enter task name",
-        "required": true
-      }
-    }
-  ],
-  "actions": [
-    { "$type": "Action", "children": "Create", "appearance": "primary" },
-    { "$type": "CancelAction", "children": "Cancel" }
-  ],
-  "blocking": true
-}
-```
+<Demo component="proteus/document-properties" scrollable />
 
 ## Components
 
@@ -56,219 +24,79 @@ Documents also support `title`, `subtitle`, `appName`, `appIcon`, and `actions` 
 
 Use `Group` as a flexbox container to arrange child elements. It supports `flexDirection`, `gap`, `alignItems`, and `justifyContent`. `Card`, `CardHeader`, and `CardLink` provide card-based layouts. `Separator` adds a visual divider.
 
-```json
-{
-  "$type": "Group",
-  "flexDirection": "column",
-  "gap": "12",
-  "children": [
-    {
-      "$type": "Card",
-      "children": [
-        { "$type": "CardHeader", "children": "Settings" },
-        { "$type": "Text", "children": "Configure your preferences below." }
-      ]
-    },
-    { "$type": "Separator" },
-    { "$type": "Text", "children": "More content here." }
-  ]
-}
-```
+<Demo component="proteus/layout" scrollable />
 
 ### Typography
 
 `Heading` renders section headings, `Text` renders inline or block text, and `Link` renders a hyperlink with an `href` prop.
 
-```json
-[
-  { "$type": "Heading", "children": "Welcome" },
-  {
-    "$type": "Text",
-    "children": "Get started by filling out the form.",
-    "fontSize": "sm",
-    "color": "fg.secondary"
-  },
-  { "$type": "Link", "href": "https://example.com", "children": "Learn more" }
-]
-```
+<Demo component="proteus/typography" scrollable />
 
 ### Data display
 
 `DataTable` renders structured data with columns, sorting, and pagination. `Chart` renders bar or line charts. `Image` and `ImageCarousel` display images. `Avatar`, `Badge`, and `Time` handle user avatars, status tags, and formatted timestamps.
 
-```json
-{
-  "$type": "DataTable",
-  "columns": [
-    { "header": "Name", "accessorKey": "name" },
-    { "header": "Status", "accessorKey": "status" }
-  ],
-  "rows": { "$type": "Value", "path": "/items" }
-}
-```
+<Demo component="proteus/data-display" scrollable />
 
 ### Form controls
 
 Wrap inputs with `Field` to add a label. Available inputs include `Input`, `Textarea`, `Select` (composed from `SelectTrigger` and `SelectContent`), `Switch`, `Range`, and `Question` (a multi-question dynamic form).
 
-```json
-[
-  {
-    "$type": "Field",
-    "label": "Email",
-    "children": {
-      "$type": "Input",
-      "name": "email",
-      "placeholder": "you@example.com",
-      "required": true
-    }
-  },
-  {
-    "$type": "Field",
-    "label": "Category",
-    "children": {
-      "$type": "Select",
-      "name": "category",
-      "children": [
-        { "$type": "SelectTrigger", "children": "Choose a category" },
-        { "$type": "SelectContent" }
-      ]
-    }
-  },
-  {
-    "$type": "Field",
-    "label": "Notifications",
-    "children": { "$type": "Switch", "name": "notifications" }
-  }
-]
-```
+<Demo component="proteus/form-controls" scrollable />
 
 ### Actions
 
 `Action` renders a button with an `onClick` handler (see [Interactions](#interactions) below). `CancelAction` renders a cancel button that abandons the current interaction.
 
-```json
-[
-  {
-    "$type": "Action",
-    "children": "Submit",
-    "appearance": "primary",
-    "onClick": { "interaction": "submit_form" }
-  },
-  { "$type": "CancelAction", "children": "Cancel" }
-]
-```
+<Demo component="proteus/actions" scrollable />
 
 ### Styling props
 
 All components accept Axiom styling props for spacing, colors, layout, and typography:
 
-```json
-{
-  "$type": "Group",
-  "flexDirection": "column",
-  "gap": "8",
-  "p": "12",
-  "bg": "bg.error.subtle",
-  "rounded": "md",
-  "maxH": "sm",
-  "children": {
-    "$type": "Text",
-    "children": "Styled container",
-    "color": "fg.error",
-    "fontSize": "sm",
-    "fontWeight": "500"
-  }
-}
-```
+<Demo component="proteus/styling-props" scrollable />
 
-Available props include `p`, `px`, `py`, `m`, `mb`, `mt`, `bg`, `color`, `fontSize`, `fontWeight`, `rounded`, `display`, `gap`, `flexDirection`, `alignItems`, `justifyContent`, `maxH`, `maxW`, `overflow`, and `objectFit`.
+Available props are grouped by category:
+
+| Category   | Props                                                                                                     |
+| ---------- | --------------------------------------------------------------------------------------------------------- |
+| Spacing    | `p`, `px`, `py`, `pt`, `pr`, `pb`, `pl`, `m`, `mx`, `my`, `mt`, `mr`, `mb`, `ml`, `gap`                   |
+| Sizing     | `w`, `h`, `maxW`, `maxH`, `size`                                                                          |
+| Layout     | `display`, `flexDirection`, `flexWrap`, `flex`, `alignItems`, `alignSelf`, `justifyContent`, `placeItems` |
+| Color      | `bg`, `color`, `borderColor`                                                                              |
+| Border     | `border`, `borderT`, `borderR`, `borderB`, `borderL`, `rounded`, `shadow`                                 |
+| Typography | `fontSize`, `fontWeight`, `fontFamily`, `textAlign`, `textTransform`, `whiteSpace`                        |
+| Other      | `overflow`, `overflowX`, `overflowY`, `objectFit`, `cursor`, `pointerEvents`, `transition`, `z`           |
+
+These accept either a token (e.g. `"sm"`, `"fg.error"`) or a responsive array (`["sm", "md"]`). Every element type accepts the full set.
 
 ## Data binding
 
 ### Value
 
-Reads a field from the tool response using a JSON Pointer path:
+Reads a field from the tool response using a JSON Pointer path. Paths starting with `/` are absolute (from the root of the tool response). Paths without a leading `/` are relative (resolved from the current context, like inside a `Map`).
 
-```json
-{ "$type": "Value", "path": "/title" }
-```
-
-Paths starting with `/` are absolute (from the root of the tool response). Paths without a leading `/` are relative (resolved from the current context, like inside a `Map`).
+<Demo component="proteus/value" scrollable />
 
 ### Map
 
 Iterates over an array, rendering `children` once per item. Inside a `Map`, relative paths resolve against the current item:
 
-```json
-{
-  "$type": "Map",
-  "path": "/results",
-  "children": {
-    "$type": "Text",
-    "children": { "$type": "Value", "path": "name" }
-  }
-}
-```
+<Demo component="proteus/map" scrollable />
 
 ### Other expressions
 
 `MapIndex` gives you the current iteration index inside a `Map`. `Concat` joins multiple values into a single string. `Zip` combines parallel arrays into an array of objects.
 
-```json
-{
-  "$type": "Concat",
-  "children": [
-    "Item #",
-    { "$type": "MapIndex" },
-    ": ",
-    { "$type": "Value", "path": "name" }
-  ]
-}
-```
+<Demo component="proteus/concat" scrollable />
+
+`Concat` and `Zip` follow the same shape — they take a `children`/`sources` array and produce a value you can use anywhere a `Value` would work.
 
 ### Putting it together
 
-Given this tool response:
+This template renders a list of search results dynamically from a tool response:
 
-```json
-{
-  "title": "Search Results",
-  "results": [
-    { "name": "Widget A", "price": 9.99 },
-    { "name": "Widget B", "price": 14.99 }
-  ]
-}
-```
-
-This template renders the results dynamically:
-
-```json
-{
-  "$type": "Document",
-  "title": { "$type": "Value", "path": "/title" },
-  "body": {
-    "$type": "Map",
-    "path": "/results",
-    "children": {
-      "$type": "Card",
-      "children": [
-        {
-          "$type": "Heading",
-          "children": { "$type": "Value", "path": "name" }
-        },
-        {
-          "$type": "Text",
-          "children": {
-            "$type": "Concat",
-            "children": ["$", { "$type": "Value", "path": "price" }]
-          }
-        }
-      ]
-    }
-  }
-}
-```
+<Demo component="proteus/data-binding" scrollable />
 
 ## Conditional rendering
 
@@ -276,76 +104,33 @@ This template renders the results dynamically:
 
 Use `Show` to render content only when a condition is met:
 
-```json
-{
-  "$type": "Show",
-  "when": { "!!": { "$type": "Value", "path": "/error" } },
-  "children": {
-    "$type": "Text",
-    "children": "An error occurred",
-    "color": "fg.error"
-  }
-}
-```
+<Demo component="proteus/show" scrollable />
 
 ### Operators
 
 Supported operators: `==`, `!=`, `<`, `<=`, `>`, `>=`, `!!` (truthy), `!` (falsy). Combine conditions with `and` and `or`:
 
-```json
-{
-  "$type": "Show",
-  "when": {
-    "and": [
-      { "!!": { "$type": "Value", "path": "/items" } },
-      { "!=": [{ "$type": "Value", "path": "/status" }, "loading"] }
-    ]
-  },
-  "children": { "$type": "Text", "children": "Items loaded" }
-}
-```
+<Demo component="proteus/show-operators" scrollable />
 
 ## Interactions
 
 ### Interaction handler
 
-Calls a server-side interaction handler registered with the SDK:
+Sends the named interaction back to your server, where it can be handled and responded to:
 
-```json
-{
-  "$type": "Action",
-  "children": "Submit",
-  "appearance": "primary",
-  "onClick": { "interaction": "submit_form" }
-}
-```
+<Demo component="proteus/action-interaction" scrollable />
 
 ### Message handler
 
 Sends a text message back to the LLM:
 
-```json
-{
-  "$type": "Action",
-  "children": "Continue",
-  "onClick": { "message": "User confirmed the selection" }
-}
-```
+<Demo component="proteus/action-message" scrollable />
 
 ### Download handler
 
 Triggers a file download:
 
-```json
-{
-  "$type": "Action",
-  "children": "Download Report",
-  "onClick": {
-    "action": "download",
-    "url": { "$type": "Value", "path": "/download_url" }
-  }
-}
-```
+<Demo component="proteus/action-download" scrollable />
 
 ### Blocking mode
 
@@ -356,3 +141,4 @@ When `blocking` is set to `true` on the Document, the chat input is hidden and t
 ### Visual editor
 
 The [Proteus Designer](/guides/proteus-designer) is a visual editor for building Proteus documents. You can build a component tree, edit properties in the inspector, see a live preview of how the document renders, and copy the final JSON into your resource handler. You can also provide sample data to test how dynamic values resolve.
+

--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -56,20 +56,6 @@ All components accept Axiom styling props for spacing, colors, layout, and typog
 
 <Demo component="proteus/styling-props" />
 
-Available props are grouped by category:
-
-| Category   | Props                                                                                                     |
-| ---------- | --------------------------------------------------------------------------------------------------------- |
-| Spacing    | `p`, `px`, `py`, `pt`, `pr`, `pb`, `pl`, `m`, `mx`, `my`, `mt`, `mr`, `mb`, `ml`, `gap`                   |
-| Sizing     | `w`, `h`, `maxW`, `maxH`, `size`                                                                          |
-| Layout     | `display`, `flexDirection`, `flexWrap`, `flex`, `alignItems`, `alignSelf`, `justifyContent`, `placeItems` |
-| Color      | `bg`, `color`, `borderColor`                                                                              |
-| Border     | `border`, `borderT`, `borderR`, `borderB`, `borderL`, `rounded`, `shadow`                                 |
-| Typography | `fontSize`, `fontWeight`, `fontFamily`, `textAlign`, `textTransform`, `whiteSpace`                        |
-| Other      | `overflow`, `overflowX`, `overflowY`, `objectFit`, `cursor`, `pointerEvents`, `transition`, `z`           |
-
-These accept either a token (e.g. `"sm"`, `"fg.error"`) or a responsive array (`["sm", "md"]`). Every rendering component accepts the full set; expression and control-flow elements (`Value`, `MapIndex`, `Concat`, `Zip`, `Show`, `Map`, `Bridge`, `Question`) do not, since they don't render their own DOM node.
-
 ## Data binding
 
 ### Value
@@ -138,11 +124,7 @@ The [Proteus Designer](/guides/proteus-designer) is a visual editor for building
 
 ## Element reference
 
-The sections below list element-specific props for each `$type`. Rendering elements also accept the full set of [styling props](#styling-props), so those are omitted here.
-
 ### Document
-
-The root element of every Proteus document.
 
 <ProteusElementRef type="Document" />
 

--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -14,7 +14,7 @@ A Proteus document is a JSON object with `$type: "Document"`. At minimum it need
 
 ### Document properties
 
-Documents also support `title`, `subtitle`, `appName`, `appIcon`, and `actions` (buttons rendered at the bottom). Set `blocking` to `true` to hide the chat input and force the user to interact with the UI before continuing.
+Documents also support `title`, `subtitle`, `appName`, `appIcon`, and `actions` (buttons rendered at the bottom).
 
 <Demo component="proteus/document-properties" scrollable />
 
@@ -129,10 +129,6 @@ Sends a text message back to the LLM:
 Triggers a file download:
 
 <Demo component="proteus/action-download" scrollable />
-
-### Blocking mode
-
-When `blocking` is set to `true` on the Document, the chat input is hidden and the user must click an `Action` to continue. Use this for forms that require explicit user input before proceeding.
 
 ## Proteus Designer
 

--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -10,13 +10,13 @@ Proteus is a JSON-based UI specification for building interactive tool interface
 
 A Proteus document is a JSON object with `$type: "Document"`. At minimum it needs a `body`. Every element has a `$type` that identifies the component. The `children` property holds nested content: a string, number, another element, or an array of elements.
 
-<Demo component="proteus/minimal-document" scrollable />
+<Demo component="proteus/minimal-document" />
 
 ### Document properties
 
 Documents also support `title`, `subtitle`, `appName`, `appIcon`, and `actions` (buttons rendered at the bottom).
 
-<Demo component="proteus/document-properties" scrollable />
+<Demo component="proteus/document-properties" />
 
 ## Components
 
@@ -24,37 +24,37 @@ Documents also support `title`, `subtitle`, `appName`, `appIcon`, and `actions` 
 
 Use `Group` as a flexbox container to arrange child elements. It supports `flexDirection`, `gap`, `alignItems`, and `justifyContent`. `Card`, `CardHeader`, and `CardLink` provide card-based layouts. `Separator` adds a visual divider.
 
-<Demo component="proteus/layout" scrollable />
+<Demo component="proteus/layout" />
 
 ### Typography
 
 `Heading` renders section headings, `Text` renders inline or block text, and `Link` renders a hyperlink with an `href` prop.
 
-<Demo component="proteus/typography" scrollable />
+<Demo component="proteus/typography" />
 
 ### Data display
 
 `DataTable` renders structured data with columns, sorting, and pagination. `Chart` renders bar or line charts. `Image` and `ImageCarousel` display images. `Avatar`, `Badge`, and `Time` handle user avatars, status tags, and formatted timestamps.
 
-<Demo component="proteus/data-display" scrollable />
+<Demo component="proteus/data-display" />
 
 ### Form controls
 
 Wrap inputs with `Field` to add a label. Available inputs include `Input`, `Textarea`, `Select` (composed from `SelectTrigger` and `SelectContent`), `Switch`, `Range`, and `Question` (a multi-question dynamic form).
 
-<Demo component="proteus/form-controls" scrollable />
+<Demo component="proteus/form-controls" />
 
 ### Actions
 
 `Action` renders a button with an `onClick` handler (see [Interactions](#interactions) below). Use `appearance` (`primary`, `danger`, `subtle`, etc.) to style the button.
 
-<Demo component="proteus/actions" scrollable />
+<Demo component="proteus/actions" />
 
 ### Styling props
 
 All components accept Axiom styling props for spacing, colors, layout, and typography:
 
-<Demo component="proteus/styling-props" scrollable />
+<Demo component="proteus/styling-props" />
 
 Available props are grouped by category:
 
@@ -76,25 +76,25 @@ These accept either a token (e.g. `"sm"`, `"fg.error"`) or a responsive array (`
 
 Reads a field from the tool response using a JSON Pointer path. Paths starting with `/` are absolute (from the root of the tool response). Paths without a leading `/` are relative (resolved from the current context, like inside a `Map`).
 
-<Demo component="proteus/value" scrollable />
+<Demo component="proteus/value" />
 
 ### Map
 
 Iterates over an array, rendering `children` once per item. Inside a `Map`, relative paths resolve against the current item:
 
-<Demo component="proteus/map" scrollable />
+<Demo component="proteus/map" />
 
 ### Other expressions
 
 `MapIndex` gives you the current iteration index inside a `Map`. `Concat` takes a `children` array and joins each resolved value into a single string. `Zip` takes a `sources` object — each key becomes a property name, and the values (arrays or expressions resolving to arrays) are zipped row-wise into an array of objects, useful as `Chart.data` or `DataTable.data`.
 
-<Demo component="proteus/concat" scrollable />
+<Demo component="proteus/concat" />
 
 ### Putting it together
 
 This template renders a list of search results dynamically from a tool response:
 
-<Demo component="proteus/data-binding" scrollable />
+<Demo component="proteus/data-binding" />
 
 ## Conditional rendering
 
@@ -102,13 +102,13 @@ This template renders a list of search results dynamically from a tool response:
 
 Use `Show` to render content only when a condition is met:
 
-<Demo component="proteus/show" scrollable />
+<Demo component="proteus/show" />
 
 ### Operators
 
 Supported operators: `==`, `!=`, `<`, `<=`, `>`, `>=`, `!!` (truthy), `!` (falsy). Combine conditions with `and` and `or`:
 
-<Demo component="proteus/show-operators" scrollable />
+<Demo component="proteus/show-operators" />
 
 ## Interactions
 
@@ -116,19 +116,19 @@ Supported operators: `==`, `!=`, `<`, `<=`, `>`, `>=`, `!!` (truthy), `!` (falsy
 
 Sends the named interaction back to your server, where it can be handled and responded to:
 
-<Demo component="proteus/action-interaction" scrollable />
+<Demo component="proteus/action-interaction" />
 
 ### Message handler
 
 Sends a text message back to the LLM:
 
-<Demo component="proteus/action-message" scrollable />
+<Demo component="proteus/action-message" />
 
 ### Download handler
 
 Triggers a file download:
 
-<Demo component="proteus/action-download" scrollable />
+<Demo component="proteus/action-download" />
 
 ## Proteus Designer
 

--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -68,7 +68,7 @@ Available props are grouped by category:
 | Typography | `fontSize`, `fontWeight`, `fontFamily`, `textAlign`, `textTransform`, `whiteSpace`                        |
 | Other      | `overflow`, `overflowX`, `overflowY`, `objectFit`, `cursor`, `pointerEvents`, `transition`, `z`           |
 
-These accept either a token (e.g. `"sm"`, `"fg.error"`) or a responsive array (`["sm", "md"]`). Every element type accepts the full set.
+These accept either a token (e.g. `"sm"`, `"fg.error"`) or a responsive array (`["sm", "md"]`). Every rendering component accepts the full set; expression and control-flow elements (`Value`, `MapIndex`, `Concat`, `Zip`, `Show`, `Map`, `Bridge`, `Question`) do not, since they don't render their own DOM node.
 
 ## Data binding
 
@@ -86,11 +86,9 @@ Iterates over an array, rendering `children` once per item. Inside a `Map`, rela
 
 ### Other expressions
 
-`MapIndex` gives you the current iteration index inside a `Map`. `Concat` joins multiple values into a single string. `Zip` combines parallel arrays into an array of objects.
+`MapIndex` gives you the current iteration index inside a `Map`. `Concat` takes a `children` array and joins each resolved value into a single string. `Zip` takes a `sources` object — each key becomes a property name, and the values (arrays or expressions resolving to arrays) are zipped row-wise into an array of objects, useful as `Chart.data` or `DataTable.data`.
 
 <Demo component="proteus/concat" scrollable />
-
-`Concat` and `Zip` follow the same shape — they take a `children`/`sources` array and produce a value you can use anywhere a `Value` would work.
 
 ### Putting it together
 
@@ -144,7 +142,7 @@ The [Proteus Designer](/guides/proteus-designer) is a visual editor for building
 
 ## Element reference
 
-The tables below list element-specific props for each `$type`. Every element also accepts the full set of [styling props](#styling-props), so those are omitted from the per-element tables.
+The sections below list element-specific props for each `$type`. Rendering elements also accept the full set of [styling props](#styling-props), so those are omitted here.
 
 ### Document
 
@@ -288,14 +286,14 @@ The root element of every Proteus document.
 
 <ProteusElementRef type="Zip" />
 
-### Conditional
-
-#### Show
+### Show
 
 <ProteusElementRef type="Show" />
 
-### Bridge
+### IconCalendar
 
-#### Bridge
+<ProteusElementRef type="IconCalendar" />
+
+### Bridge
 
 <ProteusElementRef type="Bridge" />

--- a/apps/docs/components/index.ts
+++ b/apps/docs/components/index.ts
@@ -4,4 +4,5 @@ export * from "./icon-gallery";
 export * from "./keyboard-table";
 export * from "./links";
 export * from "./props-table";
+export * from "./proteus-element-ref";
 export * from "./scale";

--- a/apps/docs/components/proteus-element-ref/ProteusElementRef.tsx
+++ b/apps/docs/components/proteus-element-ref/ProteusElementRef.tsx
@@ -1,8 +1,6 @@
+import { schema } from "@optiaxiom/proteus/spec";
 import { Box, Group, Text } from "@optiaxiom/react";
 import { Fragment, type ReactNode } from "react";
-
-import schema from "../../../../packages/proteus/src/schema/public-schema.json";
-import { Table, Td, Th, Thead, Tr } from "../table";
 
 type SchemaDefinition = {
   properties: Record<string, SchemaProperty>;
@@ -52,47 +50,44 @@ export function ProteusElementRef({ type }: { type: string }) {
   }
 
   return (
-    <Table>
-      <Thead>
-        <tr>
-          <Th>Prop</Th>
-        </tr>
-      </Thead>
-      <tbody>
-        {entries.map(([name, prop]) => (
-          <Tr key={name}>
-            <Td>
-              <Group
-                alignItems="start"
-                flexDirection={["column", "row"]}
-                gap="12"
-              >
-                <Box
-                  fontFamily="mono"
-                  style={{ color: "var(--shiki-token-function)" }}
-                  w="1/4"
-                  whiteSpace="nowrap"
-                >
-                  <code>{required.has(name) ? `${name}*` : name}</code>
-                </Box>
-                <Group flex="1" flexDirection="column" gap="8">
-                  {prop.description && (
-                    <Text>{renderDescription(prop.description)}</Text>
-                  )}
-                  <Text>
-                    <Box asChild fontFamily="mono">
-                      <code style={{ color: "var(--shiki-token-function)" }}>
-                        {renderType(prop)}
-                      </code>
-                    </Box>
-                  </Text>
-                </Group>
-              </Group>
-            </Td>
-          </Tr>
-        ))}
-      </tbody>
-    </Table>
+    <Box
+      bg="bg.default"
+      border="1"
+      borderColor="border.tertiary"
+      mt="24"
+      rounded="lg"
+    >
+      {entries.map(([name, prop], index) => (
+        <Group
+          alignItems="start"
+          borderColor="border.tertiary"
+          borderT={index === 0 ? undefined : "1"}
+          flexDirection={["column", "row"]}
+          gap="12"
+          key={name}
+          p="12"
+        >
+          <Box
+            fontFamily="mono"
+            style={{ color: "var(--shiki-token-function)" }}
+            w={["full", "1/4"]}
+            whiteSpace="nowrap"
+          >
+            <code>{required.has(name) ? `${name}*` : name}</code>
+          </Box>
+          <Group flex="1" flexDirection="column" gap="8">
+            {prop.description && (
+              <Text>{renderDescription(prop.description)}</Text>
+            )}
+            <Box asChild fontFamily="mono">
+              <code style={{ color: "var(--shiki-token-function)" }}>
+                {renderType(prop)}
+              </code>
+            </Box>
+          </Group>
+        </Group>
+      ))}
+    </Box>
   );
 }
 

--- a/apps/docs/components/proteus-element-ref/ProteusElementRef.tsx
+++ b/apps/docs/components/proteus-element-ref/ProteusElementRef.tsx
@@ -1,0 +1,121 @@
+import { Box, Group, Text } from "@optiaxiom/react";
+import { Fragment, type ReactNode } from "react";
+
+import schema from "../../../../packages/proteus/src/schema/public-schema.json";
+import { Table, Td, Th, Thead, Tr } from "../table";
+
+type SchemaDefinition = {
+  properties: Record<string, SchemaProperty>;
+  required?: string[];
+};
+
+type SchemaProperty = {
+  $ref?: string;
+  anyOf?: SchemaProperty[];
+  const?: string;
+  description?: string;
+  enum?: string[];
+  type?: string;
+};
+
+function renderDescription(text: string): ReactNode[] {
+  const parts = text.split(/(`[^`]+`)/g);
+  return parts.map((part, i) =>
+    part.startsWith("`") && part.endsWith("`") ? (
+      <code key={i}>{part.slice(1, -1)}</code>
+    ) : (
+      <Fragment key={i}>{part}</Fragment>
+    ),
+  );
+}
+
+const definitions = (
+  schema as unknown as { definitions: Record<string, SchemaDefinition> }
+).definitions;
+
+export function ProteusElementRef({ type }: { type: string }) {
+  const def = definitions[`Proteus${type}`];
+  if (!def) {
+    throw new Error(`Could not find schema definition: Proteus${type}`);
+  }
+  const required = new Set(def.required ?? []);
+  const entries = Object.entries(def.properties).filter(
+    ([name, prop]) => name !== "$type" && !isSprinkleRef(prop),
+  );
+
+  if (entries.length === 0) {
+    return (
+      <Text fontSize="lg" mt="16">
+        Accepts only <code>$type</code> plus the standard styling props.
+      </Text>
+    );
+  }
+
+  return (
+    <Table>
+      <Thead>
+        <tr>
+          <Th>Prop</Th>
+        </tr>
+      </Thead>
+      <tbody>
+        {entries.map(([name, prop]) => (
+          <Tr key={name}>
+            <Td>
+              <Group
+                alignItems="start"
+                flexDirection={["column", "row"]}
+                gap="12"
+              >
+                <Box
+                  fontFamily="mono"
+                  style={{ color: "var(--shiki-token-function)" }}
+                  w="1/4"
+                  whiteSpace="nowrap"
+                >
+                  <code>{required.has(name) ? `${name}*` : name}</code>
+                </Box>
+                <Group flex="1" flexDirection="column" gap="8">
+                  {prop.description && (
+                    <Text>{renderDescription(prop.description)}</Text>
+                  )}
+                  <Text>
+                    <Box asChild fontFamily="mono">
+                      <code style={{ color: "var(--shiki-token-function)" }}>
+                        {renderType(prop)}
+                      </code>
+                    </Box>
+                  </Text>
+                </Group>
+              </Group>
+            </Td>
+          </Tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+}
+
+function isSprinkleRef(prop: SchemaProperty): boolean {
+  return Boolean(prop.$ref?.startsWith("#/definitions/SprinkleProp_"));
+}
+
+function refName(ref: string): string {
+  const name = ref.replace("#/definitions/", "");
+  return name.startsWith("Proteus") ? name.slice("Proteus".length) : name;
+}
+
+function renderType(prop: SchemaProperty): string {
+  if (prop.const !== undefined) return JSON.stringify(prop.const);
+  if (prop.enum) return prop.enum.map((v) => JSON.stringify(v)).join(" | ");
+  if (prop.$ref) return refName(prop.$ref);
+  if (prop.anyOf) {
+    return prop.anyOf
+      .map((sub) => renderType(sub))
+      .filter((s, i, arr) => arr.indexOf(s) === i)
+      .join(" | ");
+  }
+  if (prop.type === "array") return "Array";
+  if (prop.type) return prop.type;
+  return "any";
+}

--- a/apps/docs/components/proteus-element-ref/index.ts
+++ b/apps/docs/components/proteus-element-ref/index.ts
@@ -1,0 +1,1 @@
+export * from "./ProteusElementRef";

--- a/apps/docs/demos/proteus/action-download/App.tsx
+++ b/apps/docs/demos/proteus/action-download/App.tsx
@@ -7,23 +7,32 @@ export function App() {
   return (
     <Box maxW="md" w="full">
       <ProteusDocumentRenderer
-        data={{ download_url: "https://example.com/reports/q1-2026.pdf" }}
+        data={{
+          download_url:
+            "https://example.com/files/strategic-pitch-presentation.pptx",
+        }}
         element={{
           $type: "Document",
           actions: [
             {
               $type: "Action",
               appearance: "primary",
-              children: "Download report",
+              children: "Download",
               onClick: {
                 action: "download",
                 url: { $type: "Value", path: "/download_url" },
               },
             },
           ],
-          body: [],
-          subtitle: "Q1 2026 metrics are compiled and ready to download.",
-          title: "Quarterly report ready",
+          body: [
+            {
+              $type: "Image",
+              alt: "Slide preview of Strategic Pitch Presentation",
+              src: "https://placehold.co/560x315",
+            },
+          ],
+          subtitle: "Google Slides",
+          title: "Strategic Pitch Presentation",
         }}
       />
     </Box>

--- a/apps/docs/demos/proteus/action-download/App.tsx
+++ b/apps/docs/demos/proteus/action-download/App.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        data={{ download_url: "https://example.com/reports/q1-2026.pdf" }}
+        element={{
+          $type: "Document",
+          actions: [
+            {
+              $type: "Action",
+              appearance: "primary",
+              children: "Download report",
+              onClick: {
+                action: "download",
+                url: { $type: "Value", path: "/download_url" },
+              },
+            },
+          ],
+          body: [],
+          subtitle: "Q1 2026 metrics are compiled and ready to download.",
+          title: "Quarterly report ready",
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/action-interaction/App.tsx
+++ b/apps/docs/demos/proteus/action-interaction/App.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        element={{
+          $type: "Document",
+          actions: [
+            {
+              $type: "Action",
+              appearance: "primary",
+              children: "Approve",
+              onClick: { interaction: "approve_deploy" },
+            },
+            { $type: "CancelAction", children: "Cancel" },
+          ],
+          body: [],
+          subtitle:
+            "Submitting will run the deploy pipeline against production.",
+          title: "Approve deploy?",
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/action-interaction/App.tsx
+++ b/apps/docs/demos/proteus/action-interaction/App.tsx
@@ -16,7 +16,7 @@ export function App() {
               children: "Approve",
               onClick: { interaction: "approve_deploy" },
             },
-            { $type: "CancelAction", children: "Cancel" },
+            { $type: "Action", children: "Cancel" },
           ],
           body: [],
           subtitle:

--- a/apps/docs/demos/proteus/action-interaction/App.tsx
+++ b/apps/docs/demos/proteus/action-interaction/App.tsx
@@ -12,16 +12,26 @@ export function App() {
           actions: [
             {
               $type: "Action",
-              appearance: "primary",
-              children: "Approve",
-              onClick: { interaction: "approve_deploy" },
+              children: "Comment",
+              onClick: { interaction: "comment_on_task" },
             },
-            { $type: "Action", children: "Cancel" },
+            {
+              $type: "Action",
+              appearance: "primary",
+              children: "View task",
+              onClick: { interaction: "view_task" },
+            },
           ],
-          body: [],
-          subtitle:
-            "Submitting will run the deploy pipeline against production.",
-          title: "Approve deploy?",
+          appName: "Content Marketing Platform",
+          body: [
+            {
+              $type: "Text",
+              children:
+                "Initial performance metrics reveal a 12% drop in user retention post-update.",
+            },
+          ],
+          subtitle: "Android Scrum Campaign / TSK-98",
+          title: "Version 2.2 Performance Optimization",
         }}
       />
     </Box>

--- a/apps/docs/demos/proteus/action-message/App.tsx
+++ b/apps/docs/demos/proteus/action-message/App.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        element={{
+          $type: "Document",
+          actions: [
+            {
+              $type: "Action",
+              children: "Yes, proceed",
+              onClick: { message: "Yes, proceed with the migration." },
+            },
+            {
+              $type: "Action",
+              children: "No, hold off",
+              onClick: { message: "Hold off on the migration for now." },
+            },
+          ],
+          body: [
+            {
+              $type: "Text",
+              children:
+                "Pick an option and we'll continue the conversation in chat.",
+            },
+          ],
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/action-message/App.tsx
+++ b/apps/docs/demos/proteus/action-message/App.tsx
@@ -12,22 +12,30 @@ export function App() {
           actions: [
             {
               $type: "Action",
-              children: "Yes, proceed",
-              onClick: { message: "Yes, proceed with the migration." },
+              children: "Comment",
+              onClick: {
+                message: "I'd like to leave a comment on this task.",
+              },
             },
             {
               $type: "Action",
-              children: "No, hold off",
-              onClick: { message: "Hold off on the migration for now." },
+              appearance: "primary",
+              children: "View task",
+              onClick: {
+                message: "Show me the full details for TSK-98.",
+              },
             },
           ],
+          appName: "Content Marketing Platform",
           body: [
             {
               $type: "Text",
               children:
-                "Pick an option and we'll continue the conversation in chat.",
+                "Initial performance metrics reveal a 12% drop in user retention post-update.",
             },
           ],
+          subtitle: "Android Scrum Campaign / TSK-98",
+          title: "Version 2.2 Performance Optimization",
         }}
       />
     </Box>

--- a/apps/docs/demos/proteus/actions/App.tsx
+++ b/apps/docs/demos/proteus/actions/App.tsx
@@ -10,18 +10,23 @@ export function App() {
         element={{
           $type: "Document",
           actions: [
+            { $type: "Action", children: "Comment" },
             {
               $type: "Action",
-              appearance: "danger",
-              children: "Delete project",
-              onClick: { interaction: "delete_project" },
+              appearance: "primary",
+              children: "View task",
             },
-            { $type: "Action", children: "Keep project" },
           ],
-          body: [],
-          subtitle:
-            "This permanently removes the project and all of its experiments. This cannot be undone.",
-          title: "Delete project?",
+          appName: "Content Marketing Platform",
+          body: [
+            {
+              $type: "Text",
+              children:
+                "Initial performance metrics reveal a 12% drop in user retention post-update.",
+            },
+          ],
+          subtitle: "Android Scrum Campaign / TSK-98",
+          title: "Version 2.2 Performance Optimization",
         }}
       />
     </Box>

--- a/apps/docs/demos/proteus/actions/App.tsx
+++ b/apps/docs/demos/proteus/actions/App.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        element={{
+          $type: "Document",
+          actions: [
+            {
+              $type: "Action",
+              appearance: "danger",
+              children: "Delete project",
+              onClick: { interaction: "delete_project" },
+            },
+            { $type: "CancelAction", children: "Keep project" },
+          ],
+          body: [],
+          subtitle:
+            "This permanently removes the project and all of its experiments. This cannot be undone.",
+          title: "Delete project?",
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/actions/App.tsx
+++ b/apps/docs/demos/proteus/actions/App.tsx
@@ -16,7 +16,7 @@ export function App() {
               children: "Delete project",
               onClick: { interaction: "delete_project" },
             },
-            { $type: "CancelAction", children: "Keep project" },
+            { $type: "Action", children: "Keep project" },
           ],
           body: [],
           subtitle:

--- a/apps/docs/demos/proteus/concat/App.tsx
+++ b/apps/docs/demos/proteus/concat/App.tsx
@@ -1,33 +1,63 @@
 "use client";
 
 import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
-import { Box } from "@optiaxiom/react";
+import { Box, toaster } from "@optiaxiom/react";
 
 export function App() {
   return (
     <Box maxW="md" w="full">
       <ProteusDocumentRenderer
         data={{
-          items: [{ name: "Apples" }, { name: "Oranges" }, { name: "Pears" }],
+          parameters: [
+            { name: "Campaign Name", value: "spring-sale-2024" },
+            { name: "Landing Page URL", value: "https://example.com/landing" },
+            { name: "Channel", value: null },
+          ],
         }}
         element={{
           $type: "Document",
-          body: {
-            $type: "Map",
-            children: {
-              $type: "Text",
-              children: {
-                $type: "Concat",
-                children: [
-                  "#",
-                  { $type: "MapIndex" },
-                  " — ",
-                  { $type: "Value", path: "name" },
-                ],
+          actions: [
+            {
+              $type: "Action",
+              appearance: "primary-opal",
+              children: "Run agent",
+              onClick: {
+                message: {
+                  $type: "Map",
+                  children: {
+                    $type: "Concat",
+                    children: [
+                      { $type: "Value", path: "name" },
+                      ": ",
+                      {
+                        $type: "Show",
+                        children: "[Not specified]",
+                        when: { "!": { $type: "Value", path: "value" } },
+                      },
+                      {
+                        $type: "Show",
+                        children: { $type: "Value", path: "value" },
+                        when: { "!!": { $type: "Value", path: "value" } },
+                      },
+                    ],
+                  },
+                  path: "/parameters",
+                  separator: "\n",
+                },
               },
             },
-            path: "/items",
-          },
+          ],
+          body: [
+            {
+              $type: "Text",
+              children:
+                "Click the button to see how Concat formats the parameter values into a single message.",
+            },
+          ],
+          title: "UTM Creation",
+        }}
+        onMessage={(msg) => {
+          toaster.create(typeof msg === "string" ? msg : JSON.stringify(msg));
         }}
       />
     </Box>

--- a/apps/docs/demos/proteus/concat/App.tsx
+++ b/apps/docs/demos/proteus/concat/App.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        data={{
+          items: [{ name: "Apples" }, { name: "Oranges" }, { name: "Pears" }],
+        }}
+        element={{
+          $type: "Document",
+          body: {
+            $type: "Map",
+            children: {
+              $type: "Group",
+              children: [
+                {
+                  $type: "Text",
+                  children: { $type: "MapIndex" },
+                  color: "fg.tertiary",
+                },
+                {
+                  $type: "Text",
+                  children: { $type: "Value", path: "name" },
+                  fontWeight: "600",
+                },
+              ],
+              flexDirection: "row",
+              gap: "8",
+            },
+            path: "/items",
+          },
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/concat/App.tsx
+++ b/apps/docs/demos/proteus/concat/App.tsx
@@ -15,21 +15,16 @@ export function App() {
           body: {
             $type: "Map",
             children: {
-              $type: "Group",
-              children: [
-                {
-                  $type: "Text",
-                  children: { $type: "MapIndex" },
-                  color: "fg.tertiary",
-                },
-                {
-                  $type: "Text",
-                  children: { $type: "Value", path: "name" },
-                  fontWeight: "600",
-                },
-              ],
-              flexDirection: "row",
-              gap: "8",
+              $type: "Text",
+              children: {
+                $type: "Concat",
+                children: [
+                  "#",
+                  { $type: "MapIndex" },
+                  " — ",
+                  { $type: "Value", path: "name" },
+                ],
+              },
             },
             path: "/items",
           },

--- a/apps/docs/demos/proteus/data-binding/App.tsx
+++ b/apps/docs/demos/proteus/data-binding/App.tsx
@@ -8,35 +8,44 @@ export function App() {
     <Box maxW="md" w="full">
       <ProteusDocumentRenderer
         data={{
-          results: [
-            { name: "Widget A", sku: "WA-001" },
-            { name: "Widget B", sku: "WB-002" },
-            { name: "Widget C", sku: "WC-003" },
+          table_data: [
+            {
+              cmp_url: "https://example.com/task/id-123",
+              owner: "John Doe",
+              reference: "TSK-8526",
+              status: "Overdue",
+              title: "Add quantity badges to product thumbnails",
+            },
+            {
+              cmp_url: "https://example.com/task/id-345",
+              owner: "Jane Doe",
+              reference: "TSK-9102",
+              status: "In Progress",
+              title: "D-Congress 2026 - Digital screen content",
+            },
           ],
-          title: "Search results",
+          total_results: 2,
         }}
         element={{
           $type: "Document",
+          appName: "Content Marketing Platform",
           body: {
             $type: "Map",
             children: {
               $type: "Card",
-              children: [
-                {
-                  $type: "CardHeader",
-                  children: { $type: "Value", path: "name" },
+              children: {
+                $type: "CardHeader",
+                children: {
+                  $type: "CardLink",
+                  children: { $type: "Value", path: "title" },
+                  href: { $type: "Value", path: "cmp_url" },
                 },
-                {
-                  $type: "Text",
-                  children: { $type: "Value", path: "sku" },
-                  color: "fg.secondary",
-                  fontSize: "sm",
-                },
-              ],
+                description: { $type: "Value", path: "reference" },
+              },
             },
-            path: "/results",
+            path: "/table_data",
           },
-          title: { $type: "Value", path: "/title" },
+          title: [{ $type: "Value", path: "/total_results" }, " results found"],
         }}
       />
     </Box>

--- a/apps/docs/demos/proteus/data-binding/App.tsx
+++ b/apps/docs/demos/proteus/data-binding/App.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        data={{
+          results: [
+            { name: "Widget A", sku: "WA-001" },
+            { name: "Widget B", sku: "WB-002" },
+            { name: "Widget C", sku: "WC-003" },
+          ],
+          title: "Search results",
+        }}
+        element={{
+          $type: "Document",
+          body: {
+            $type: "Map",
+            children: {
+              $type: "Card",
+              children: [
+                {
+                  $type: "CardHeader",
+                  children: { $type: "Value", path: "name" },
+                },
+                {
+                  $type: "Text",
+                  children: { $type: "Value", path: "sku" },
+                  color: "fg.secondary",
+                  fontSize: "sm",
+                },
+              ],
+            },
+            path: "/results",
+          },
+          title: { $type: "Value", path: "/title" },
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/data-display/App.tsx
+++ b/apps/docs/demos/proteus/data-display/App.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        element={{
+          $type: "Document",
+          body: {
+            $type: "DataTable",
+            columns: [
+              { accessorKey: "id", header: "Order" },
+              { accessorKey: "customer", header: "Customer" },
+              { accessorKey: "status", header: "Status" },
+            ],
+            data: [
+              { customer: "Arthur Morgan", id: "#1024", status: "Shipped" },
+              { customer: "John Marston", id: "#1025", status: "Processing" },
+              { customer: "Sadie Adler", id: "#1026", status: "Delivered" },
+            ],
+          },
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/data-display/App.tsx
+++ b/apps/docs/demos/proteus/data-display/App.tsx
@@ -9,19 +9,50 @@ export function App() {
       <ProteusDocumentRenderer
         element={{
           $type: "Document",
+          appName: "Salesforce CRM",
           body: {
             $type: "DataTable",
             columns: [
-              { accessorKey: "id", header: "Order" },
-              { accessorKey: "customer", header: "Customer" },
-              { accessorKey: "status", header: "Status" },
+              { accessorKey: "rank", header: "Rank", size: 80 },
+              { accessorKey: "representative", header: "Representative" },
+              { accessorKey: "deals", header: "Deals Closed", size: 120 },
+              { accessorKey: "revenue", header: "Revenue", size: 120 },
             ],
             data: [
-              { customer: "Arthur Morgan", id: "#1024", status: "Shipped" },
-              { customer: "John Marston", id: "#1025", status: "Processing" },
-              { customer: "Sadie Adler", id: "#1026", status: "Delivered" },
+              {
+                deals: "47",
+                rank: "1",
+                representative: "Sarah Chen",
+                revenue: "$2.8M",
+              },
+              {
+                deals: "42",
+                rank: "2",
+                representative: "Michael Wong",
+                revenue: "$2.5M",
+              },
+              {
+                deals: "39",
+                rank: "3",
+                representative: "Jenn Taylor",
+                revenue: "$2.3M",
+              },
+              {
+                deals: "35",
+                rank: "4",
+                representative: "David Smith",
+                revenue: "$2.1M",
+              },
+              {
+                deals: "33",
+                rank: "5",
+                representative: "Emily Johnson",
+                revenue: "$2.0M",
+              },
             ],
           },
+          subtitle: "October 1 - December 31, 2025",
+          title: "Q4 2024 Sales Performance",
         }}
       />
     </Box>

--- a/apps/docs/demos/proteus/document-properties/App.tsx
+++ b/apps/docs/demos/proteus/document-properties/App.tsx
@@ -2,43 +2,50 @@
 
 import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
 import { Box } from "@optiaxiom/react";
+import { useState } from "react";
 
 export function App() {
+  const [data, setData] = useState<Record<string, unknown>>({});
   return (
     <Box maxW="md" w="full">
       <ProteusDocumentRenderer
+        data={data}
         element={{
           $type: "Document",
           actions: [
-            { $type: "Action", appearance: "primary", children: "Submit" },
-            { $type: "Action", children: "Cancel" },
+            {
+              $type: "Action",
+              appearance: "primary-opal",
+              children: "Create Test Plan",
+            },
           ],
-          appName: "Issue Tracker",
+          appName: "Opal",
           blocking: true,
           body: [
             {
               $type: "Field",
               children: {
                 $type: "Input",
-                name: "title",
-                placeholder: "Login button doesn't work on mobile",
-                required: true,
+                name: "url",
+                placeholder: "Add a URL",
               },
-              label: "Title",
+              label: "URL",
             },
             {
               $type: "Field",
               children: {
                 $type: "Textarea",
-                name: "steps",
-                placeholder: "1. Open the app on iOS\n2. Tap Sign in\n3. ...",
+                name: "test_idea",
+                placeholder:
+                  "e.g., Add quantity badges to product thumbnails to show how many of each item they're buying",
               },
-              label: "Steps to reproduce",
+              label: "Test Idea",
             },
           ],
-          subtitle: "Tell us what went wrong and we'll take a look.",
-          title: "Report an issue",
+          subtitle: "Select how you'd like to define the page or experience.",
+          title: "Create your test plan",
         }}
+        onDataChange={setData}
       />
     </Box>
   );

--- a/apps/docs/demos/proteus/document-properties/App.tsx
+++ b/apps/docs/demos/proteus/document-properties/App.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        element={{
+          $type: "Document",
+          actions: [
+            { $type: "Action", appearance: "primary", children: "Submit" },
+            { $type: "CancelAction", children: "Cancel" },
+          ],
+          appName: "Issue Tracker",
+          blocking: true,
+          body: [
+            {
+              $type: "Field",
+              children: {
+                $type: "Input",
+                name: "title",
+                placeholder: "Login button doesn't work on mobile",
+                required: true,
+              },
+              label: "Title",
+            },
+            {
+              $type: "Field",
+              children: {
+                $type: "Textarea",
+                name: "steps",
+                placeholder: "1. Open the app on iOS\n2. Tap Sign in\n3. ...",
+              },
+              label: "Steps to reproduce",
+            },
+          ],
+          subtitle: "Tell us what went wrong and we'll take a look.",
+          title: "Report an issue",
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/document-properties/App.tsx
+++ b/apps/docs/demos/proteus/document-properties/App.tsx
@@ -11,7 +11,7 @@ export function App() {
           $type: "Document",
           actions: [
             { $type: "Action", appearance: "primary", children: "Submit" },
-            { $type: "CancelAction", children: "Cancel" },
+            { $type: "Action", children: "Cancel" },
           ],
           appName: "Issue Tracker",
           blocking: true,

--- a/apps/docs/demos/proteus/form-controls/App.tsx
+++ b/apps/docs/demos/proteus/form-controls/App.tsx
@@ -2,24 +2,17 @@
 
 import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
 import { Box } from "@optiaxiom/react";
+import { useState } from "react";
 
 export function App() {
+  const [data, setData] = useState<Record<string, unknown>>({});
   return (
     <Box maxW="md" w="full">
       <ProteusDocumentRenderer
+        data={data}
         element={{
           $type: "Document",
           body: [
-            {
-              $type: "Field",
-              children: {
-                $type: "Input",
-                name: "email",
-                placeholder: "you@example.com",
-                required: true,
-              },
-              label: "Email",
-            },
             {
               $type: "Field",
               children: {
@@ -28,31 +21,41 @@ export function App() {
                   { $type: "SelectTrigger", w: "full" },
                   { $type: "SelectContent" },
                 ],
-                name: "plan",
+                name: "target_by",
                 options: [
-                  { label: "Starter", value: "starter" },
-                  { label: "Pro", value: "pro" },
-                  { label: "Enterprise", value: "enterprise" },
+                  { label: "URL", value: "url" },
+                  { label: "Saved Pages", value: "page" },
                 ],
               },
-              label: "Plan",
+              label: "Target by",
+            },
+            {
+              $type: "Field",
+              children: {
+                $type: "Input",
+                name: "url",
+                placeholder: "Add a URL",
+              },
+              label: "URL",
             },
             {
               $type: "Field",
               children: {
                 $type: "Textarea",
-                name: "notes",
-                placeholder: "Anything we should know?",
+                name: "test_idea",
+                placeholder:
+                  "e.g., Add quantity badges to product thumbnails to show how many of each item they're buying",
               },
-              label: "Notes",
+              label: "Test Idea",
             },
             {
               $type: "Field",
-              children: { $type: "Switch", name: "notifications" },
-              label: "Email me product updates",
+              children: { $type: "Switch", name: "include_metadata" },
+              label: "Include Metadata",
             },
           ],
         }}
+        onDataChange={setData}
       />
     </Box>
   );

--- a/apps/docs/demos/proteus/form-controls/App.tsx
+++ b/apps/docs/demos/proteus/form-controls/App.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        element={{
+          $type: "Document",
+          body: [
+            {
+              $type: "Field",
+              children: {
+                $type: "Input",
+                name: "email",
+                placeholder: "you@example.com",
+                required: true,
+              },
+              label: "Email",
+            },
+            {
+              $type: "Field",
+              children: {
+                $type: "Select",
+                children: [
+                  { $type: "SelectTrigger", w: "full" },
+                  { $type: "SelectContent" },
+                ],
+                name: "plan",
+                options: [
+                  { label: "Starter", value: "starter" },
+                  { label: "Pro", value: "pro" },
+                  { label: "Enterprise", value: "enterprise" },
+                ],
+              },
+              label: "Plan",
+            },
+            {
+              $type: "Field",
+              children: {
+                $type: "Textarea",
+                name: "notes",
+                placeholder: "Anything we should know?",
+              },
+              label: "Notes",
+            },
+            {
+              $type: "Field",
+              children: { $type: "Switch", name: "notifications" },
+              label: "Email me product updates",
+            },
+          ],
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/layout/App.tsx
+++ b/apps/docs/demos/proteus/layout/App.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        element={{
+          $type: "Document",
+          body: {
+            $type: "Group",
+            children: [
+              {
+                $type: "Card",
+                children: [
+                  { $type: "CardHeader", children: "Notifications" },
+                  {
+                    $type: "Text",
+                    children: "We'll email you when a deploy finishes.",
+                  },
+                ],
+              },
+              { $type: "Separator" },
+              {
+                $type: "Card",
+                children: [
+                  { $type: "CardHeader", children: "Workspace" },
+                  {
+                    $type: "Text",
+                    children: "Acme Inc. — 12 members",
+                  },
+                ],
+              },
+            ],
+            flexDirection: "column",
+            gap: "12",
+          },
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/layout/App.tsx
+++ b/apps/docs/demos/proteus/layout/App.tsx
@@ -11,31 +11,51 @@ export function App() {
           $type: "Document",
           body: {
             $type: "Group",
+            border: "1",
+            borderColor: "border.tertiary",
             children: [
               {
-                $type: "Card",
+                $type: "Group",
                 children: [
-                  { $type: "CardHeader", children: "Notifications" },
                   {
                     $type: "Text",
-                    children: "We'll email you when a deploy finishes.",
+                    children: "Add quantity badges to product thumbnails",
+                    fontWeight: "600",
+                  },
+                  {
+                    $type: "Text",
+                    children: "TSK-8526",
+                    color: "fg.tertiary",
+                    fontSize: "sm",
                   },
                 ],
+                flexDirection: "column",
+                gap: "4",
+                p: "12",
               },
-              { $type: "Separator" },
+              { $type: "Separator", borderColor: "border.tertiary" },
               {
-                $type: "Card",
+                $type: "Group",
                 children: [
-                  { $type: "CardHeader", children: "Workspace" },
                   {
                     $type: "Text",
-                    children: "Acme Inc. — 12 members",
+                    children: "D-Congress 2026 - Digital screen content",
+                    fontWeight: "600",
+                  },
+                  {
+                    $type: "Text",
+                    children: "TSK-9102",
+                    color: "fg.tertiary",
+                    fontSize: "sm",
                   },
                 ],
+                flexDirection: "column",
+                gap: "4",
+                p: "12",
               },
             ],
             flexDirection: "column",
-            gap: "12",
+            rounded: "md",
           },
         }}
       />

--- a/apps/docs/demos/proteus/map/App.tsx
+++ b/apps/docs/demos/proteus/map/App.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        data={{
+          results: [
+            { name: "Widget A" },
+            { name: "Widget B" },
+            { name: "Widget C" },
+          ],
+        }}
+        element={{
+          $type: "Document",
+          body: {
+            $type: "Map",
+            children: {
+              $type: "Text",
+              children: { $type: "Value", path: "name" },
+            },
+            path: "/results",
+          },
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/map/App.tsx
+++ b/apps/docs/demos/proteus/map/App.tsx
@@ -8,21 +8,67 @@ export function App() {
     <Box maxW="md" w="full">
       <ProteusDocumentRenderer
         data={{
-          results: [
-            { name: "Widget A" },
-            { name: "Widget B" },
-            { name: "Widget C" },
+          metrics: [
+            {
+              label: "TOTAL REVENUE",
+              trend: "+12% vs last quarter",
+              trendColor: "fg.success.strong",
+              value: "$204M",
+            },
+            {
+              label: "TOTAL CLOSE RATE",
+              trend: "-3% vs last quarter",
+              trendColor: "fg.error.strong",
+              value: "83%",
+            },
+            {
+              label: "TOTAL DEALS CLOSED",
+              trend: "+18 vs last quarter",
+              trendColor: "fg.success.strong",
+              value: "230",
+            },
           ],
         }}
         element={{
           $type: "Document",
           body: {
-            $type: "Map",
+            $type: "Group",
             children: {
-              $type: "Text",
-              children: { $type: "Value", path: "name" },
+              $type: "Map",
+              children: {
+                $type: "Group",
+                border: "1",
+                borderColor: "border.tertiary",
+                children: [
+                  {
+                    $type: "Text",
+                    children: { $type: "Value", path: "label" },
+                    color: "fg.tertiary",
+                    fontSize: "xs",
+                    textTransform: "uppercase",
+                  },
+                  {
+                    $type: "Text",
+                    children: { $type: "Value", path: "value" },
+                    fontSize: "2xl",
+                    fontWeight: "700",
+                  },
+                  {
+                    $type: "Text",
+                    children: { $type: "Value", path: "trend" },
+                    color: { $type: "Value", path: "trendColor" },
+                    fontSize: "sm",
+                  },
+                ],
+                flex: "1",
+                flexDirection: "column",
+                gap: "4",
+                p: "12",
+                rounded: "xl",
+              },
+              path: "/metrics",
             },
-            path: "/results",
+            gap: "16",
           },
         }}
       />

--- a/apps/docs/demos/proteus/minimal-document/App.tsx
+++ b/apps/docs/demos/proteus/minimal-document/App.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        element={{
+          $type: "Document",
+          body: [
+            { $type: "Heading", children: "Welcome to your dashboard" },
+            {
+              $type: "Text",
+              children:
+                "Proteus turns a JSON description into a fully interactive Axiom UI.",
+            },
+          ],
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/minimal-document/App.tsx
+++ b/apps/docs/demos/proteus/minimal-document/App.tsx
@@ -10,13 +10,13 @@ export function App() {
         element={{
           $type: "Document",
           body: [
-            { $type: "Heading", children: "Welcome to your dashboard" },
             {
               $type: "Text",
               children:
                 "Proteus turns a JSON description into a fully interactive Axiom UI.",
             },
           ],
+          title: "Welcome to your dashboard",
         }}
       />
     </Box>

--- a/apps/docs/demos/proteus/show-operators/App.tsx
+++ b/apps/docs/demos/proteus/show-operators/App.tsx
@@ -2,29 +2,72 @@
 
 import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
 import { Box } from "@optiaxiom/react";
+import { useState } from "react";
 
 export function App() {
+  const [data, setData] = useState<Record<string, unknown>>({
+    target_by: "url",
+    url: "https://example.com",
+  });
   return (
     <Box maxW="md" w="full">
       <ProteusDocumentRenderer
-        data={{ items: [1, 2, 3], status: "ready" }}
+        data={data}
         element={{
           $type: "Document",
-          body: {
-            $type: "Show",
-            children: {
-              $type: "Text",
-              children: "All items loaded.",
-              color: "fg.success",
+          body: [
+            {
+              $type: "Field",
+              children: {
+                $type: "Select",
+                children: [
+                  { $type: "SelectTrigger", w: "full" },
+                  { $type: "SelectContent" },
+                ],
+                name: "target_by",
+                options: [
+                  { label: "URL", value: "url" },
+                  { label: "Saved Pages", value: "page" },
+                ],
+              },
+              label: "Target by",
             },
-            when: {
-              and: [
-                { "!!": { $type: "Value", path: "/items" } },
-                { "!=": [{ $type: "Value", path: "/status" }, "loading"] },
-              ],
+            {
+              $type: "Show",
+              children: {
+                $type: "Field",
+                children: {
+                  $type: "Textarea",
+                  name: "test_idea",
+                  placeholder:
+                    "e.g., Add quantity badges to product thumbnails",
+                },
+                label: "Test Idea",
+              },
+              when: {
+                or: [
+                  {
+                    and: [
+                      {
+                        "==": [{ $type: "Value", path: "/target_by" }, "url"],
+                      },
+                      { "!!": { $type: "Value", path: "/url" } },
+                    ],
+                  },
+                  {
+                    and: [
+                      {
+                        "==": [{ $type: "Value", path: "/target_by" }, "page"],
+                      },
+                      { "!!": { $type: "Value", path: "/saved_page" } },
+                    ],
+                  },
+                ],
+              },
             },
-          },
+          ],
         }}
+        onDataChange={setData}
       />
     </Box>
   );

--- a/apps/docs/demos/proteus/show-operators/App.tsx
+++ b/apps/docs/demos/proteus/show-operators/App.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        data={{ items: [1, 2, 3], status: "ready" }}
+        element={{
+          $type: "Document",
+          body: {
+            $type: "Show",
+            children: {
+              $type: "Text",
+              children: "All items loaded.",
+              color: "fg.success",
+            },
+            when: {
+              and: [
+                { "!!": { $type: "Value", path: "/items" } },
+                { "!=": [{ $type: "Value", path: "/status" }, "loading"] },
+              ],
+            },
+          },
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/show/App.tsx
+++ b/apps/docs/demos/proteus/show/App.tsx
@@ -2,24 +2,76 @@
 
 import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
 import { Box } from "@optiaxiom/react";
+import { useState } from "react";
 
 export function App() {
+  const [data, setData] = useState<Record<string, unknown>>({
+    target_by: "url",
+  });
   return (
     <Box maxW="md" w="full">
       <ProteusDocumentRenderer
-        data={{ error: "Could not connect to the database." }}
+        data={data}
         element={{
           $type: "Document",
-          body: {
-            $type: "Show",
-            children: {
-              $type: "Text",
-              children: { $type: "Value", path: "/error" },
-              color: "fg.error",
+          body: [
+            {
+              $type: "Field",
+              children: {
+                $type: "Select",
+                children: [
+                  { $type: "SelectTrigger", w: "full" },
+                  { $type: "SelectContent" },
+                ],
+                name: "target_by",
+                options: [
+                  { label: "URL", value: "url" },
+                  { label: "Saved Pages", value: "page" },
+                ],
+              },
+              label: "Target by",
             },
-            when: { "!!": { $type: "Value", path: "/error" } },
-          },
+            {
+              $type: "Show",
+              children: {
+                $type: "Field",
+                children: {
+                  $type: "Input",
+                  name: "url",
+                  placeholder: "Add a URL",
+                },
+                label: "URL",
+              },
+              when: {
+                "==": [{ $type: "Value", path: "/target_by" }, "url"],
+              },
+            },
+            {
+              $type: "Show",
+              children: {
+                $type: "Field",
+                children: {
+                  $type: "Select",
+                  children: [
+                    { $type: "SelectTrigger", w: "full" },
+                    { $type: "SelectContent" },
+                  ],
+                  name: "saved_page",
+                  options: [
+                    { label: "Home page", value: "home" },
+                    { label: "Marketplace", value: "marketplace" },
+                    { label: "Product Details", value: "product_details" },
+                  ],
+                },
+                label: "Saved Page",
+              },
+              when: {
+                "==": [{ $type: "Value", path: "/target_by" }, "page"],
+              },
+            },
+          ],
         }}
+        onDataChange={setData}
       />
     </Box>
   );

--- a/apps/docs/demos/proteus/show/App.tsx
+++ b/apps/docs/demos/proteus/show/App.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        data={{ error: "Could not connect to the database." }}
+        element={{
+          $type: "Document",
+          body: {
+            $type: "Show",
+            children: {
+              $type: "Text",
+              children: { $type: "Value", path: "/error" },
+              color: "fg.error",
+            },
+            when: { "!!": { $type: "Value", path: "/error" } },
+          },
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/styling-props/App.tsx
+++ b/apps/docs/demos/proteus/styling-props/App.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        element={{
+          $type: "Document",
+          body: {
+            $type: "Group",
+            bg: "bg.error.subtle",
+            children: [
+              {
+                $type: "Text",
+                children: "Build failed",
+                color: "fg.error",
+                fontWeight: "600",
+              },
+              {
+                $type: "Text",
+                children:
+                  "TypeScript reported 3 errors in apps/web. See the run output for details.",
+                color: "fg.error",
+                fontSize: "sm",
+              },
+            ],
+            flexDirection: "column",
+            gap: "8",
+            p: "16",
+            rounded: "md",
+          },
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/styling-props/App.tsx
+++ b/apps/docs/demos/proteus/styling-props/App.tsx
@@ -11,26 +11,33 @@ export function App() {
           $type: "Document",
           body: {
             $type: "Group",
-            bg: "bg.error.subtle",
+            border: "1",
+            borderColor: "border.tertiary",
             children: [
               {
                 $type: "Text",
-                children: "Build failed",
-                color: "fg.error",
-                fontWeight: "600",
+                children: "TOTAL REVENUE",
+                color: "fg.tertiary",
+                fontSize: "xs",
+                textTransform: "uppercase",
               },
               {
                 $type: "Text",
-                children:
-                  "TypeScript reported 3 errors in apps/web. See the run output for details.",
-                color: "fg.error",
+                children: "$204M",
+                fontSize: "2xl",
+                fontWeight: "700",
+              },
+              {
+                $type: "Text",
+                children: "+12% vs last quarter",
+                color: "fg.success.strong",
                 fontSize: "sm",
               },
             ],
             flexDirection: "column",
-            gap: "8",
-            p: "16",
-            rounded: "md",
+            gap: "4",
+            p: "12",
+            rounded: "xl",
           },
         }}
       />

--- a/apps/docs/demos/proteus/typography/App.tsx
+++ b/apps/docs/demos/proteus/typography/App.tsx
@@ -10,18 +10,18 @@ export function App() {
         element={{
           $type: "Document",
           body: [
-            { $type: "Heading", children: "Deployment paused" },
+            { $type: "Heading", children: "Key Insight", level: "4" },
             {
               $type: "Text",
               children:
-                "Your last deploy was rolled back due to a failed health check. Review the logs for the full trace before retrying.",
+                "Initial performance metrics reveal a 12% drop in user retention post-update. Immediate deep-dive into Android Scrum Project's V2.2 onboarding flow is critical to reverse the trend and secure Q3 engagement goals.",
               color: "fg.secondary",
               fontSize: "sm",
             },
             {
               $type: "Link",
-              children: "Open run #482",
-              href: "https://example.com/runs/482",
+              children: "View task TSK-98",
+              href: "https://example.com/task/tsk-98",
             },
           ],
         }}

--- a/apps/docs/demos/proteus/typography/App.tsx
+++ b/apps/docs/demos/proteus/typography/App.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        element={{
+          $type: "Document",
+          body: [
+            { $type: "Heading", children: "Deployment paused" },
+            {
+              $type: "Text",
+              children:
+                "Your last deploy was rolled back due to a failed health check. Review the logs for the full trace before retrying.",
+              color: "fg.secondary",
+              fontSize: "sm",
+            },
+            {
+              $type: "Link",
+              children: "Open run #482",
+              href: "https://example.com/runs/482",
+            },
+          ],
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/value/App.tsx
+++ b/apps/docs/demos/proteus/value/App.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        data={{
+          count: 42,
+          query: "axiom buttons",
+        }}
+        element={{
+          $type: "Document",
+          body: [
+            {
+              $type: "Heading",
+              children: { $type: "Value", path: "/count" },
+              level: "2",
+            },
+            {
+              $type: "Text",
+              children: "results found",
+              color: "fg.secondary",
+            },
+          ],
+          title: { $type: "Value", path: "/query" },
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/value/App.tsx
+++ b/apps/docs/demos/proteus/value/App.tsx
@@ -8,24 +8,44 @@ export function App() {
     <Box maxW="md" w="full">
       <ProteusDocumentRenderer
         data={{
-          count: 42,
-          query: "axiom buttons",
+          label: "TOTAL REVENUE",
+          trend: "+12% vs last quarter",
+          trendColor: "fg.success.strong",
+          value: "$204M",
         }}
         element={{
           $type: "Document",
-          body: [
-            {
-              $type: "Heading",
-              children: { $type: "Value", path: "/count" },
-              level: "2",
-            },
-            {
-              $type: "Text",
-              children: "results found",
-              color: "fg.secondary",
-            },
-          ],
-          title: { $type: "Value", path: "/query" },
+          body: {
+            $type: "Group",
+            border: "1",
+            borderColor: "border.tertiary",
+            children: [
+              {
+                $type: "Text",
+                children: { $type: "Value", path: "label" },
+                color: "fg.tertiary",
+                fontSize: "xs",
+                textTransform: "uppercase",
+              },
+              {
+                $type: "Text",
+                children: { $type: "Value", path: "value" },
+                fontSize: "2xl",
+                fontWeight: "700",
+              },
+              {
+                $type: "Text",
+                children: { $type: "Value", path: "trend" },
+                color: { $type: "Value", path: "trendColor" },
+                fontSize: "sm",
+              },
+            ],
+            flex: "1",
+            flexDirection: "column",
+            gap: "4",
+            p: "12",
+            rounded: "xl",
+          },
         }}
       />
     </Box>


### PR DESCRIPTION
## Summary
Replaces the static JSON code blocks on `/guides/proteus` with live `<Demo>` previews and adds an element schema reference at the bottom of the page.

## Screenshots:
<img width="1019" height="740" alt="image" src="https://github.com/user-attachments/assets/9505ce99-cf89-4429-8166-594ca1edbfa9" />

## Test plan
- [ ] `pnpm dev:docs`, navigate to `/guides/proteus`, scroll top-to-bottom and confirm every section shows a Demo preview + code panel.
- [ ] Verify a known component page (e.g. `/components/button`) still renders.