### PR TITLE
feat(proteus): add FileUpload element

### DIFF
--- a/.changeset/tired-doors-read.md
+++ b/.changeset/tired-doors-read.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": patch
+---
+
+adds ProteusFileUpload element

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -1565,51 +1565,25 @@ export const AskAgentInputWithFileParam: Story = {
                   content: {
                     $type: "Map",
                     children: {
-                      $type: "Concat",
-                      children: [
-                        { $type: "Value", path: "name" },
-                        ": ",
-                        {
-                          $type: "Show",
-                          children: "[Not specified]",
-                          when: {
-                            and: [
-                              { "==": [{ $type: "Value", path: "type" }, "string"] },
-                              { "!": { $type: "Value", path: "value" } },
-                            ],
+                      $type: "Show",
+                      children: {
+                        $type: "Concat",
+                        children: [
+                          { $type: "Value", path: "name" },
+                          ": ",
+                          {
+                            $type: "Show",
+                            children: "[Not specified]",
+                            when: { "!": { $type: "Value", path: "value" } },
                           },
-                        },
-                        {
-                          $type: "Show",
-                          children: "[No file uploaded]",
-                          when: {
-                            and: [
-                              { "==": [{ $type: "Value", path: "type" }, "file"] },
-                              { "!": { $type: "Value", path: "value" } },
-                            ],
+                          {
+                            $type: "Show",
+                            children: { $type: "Value", path: "value" },
+                            when: { "!!": { $type: "Value", path: "value" } },
                           },
-                        },
-                        {
-                          $type: "Show",
-                          children: "[file attached]",
-                          when: {
-                            and: [
-                              { "==": [{ $type: "Value", path: "type" }, "file"] },
-                              { "!!": { $type: "Value", path: "value" } },
-                            ],
-                          },
-                        },
-                        {
-                          $type: "Show",
-                          children: { $type: "Value", path: "value" },
-                          when: {
-                            and: [
-                              { "!=": [{ $type: "Value", path: "type" }, "file"] },
-                              { "!!": { $type: "Value", path: "value" } },
-                            ],
-                          },
-                        },
-                      ],
+                        ],
+                      },
+                      when: { "!=": [{ $type: "Value", path: "type" }, "file"] },
                     },
                     path: "/parameters",
                     separator: "\n",

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -591,6 +591,159 @@ export const AskAgentInput: Story = {
   },
 };
 
+export const AskAgentInputWithFileParam: Story = {
+  args: {
+    data: {
+      agent: {
+        description: "Summarizes uploaded source documents.",
+        name: "Doc Summarizer",
+      },
+      parameters: [
+        {
+          description: "What to call the run",
+          name: "Run Name",
+          required: true,
+          type: "string",
+        },
+        {
+          description: "PDF or text file to summarize",
+          name: "Source Document",
+          required: true,
+          type: "file",
+        },
+      ],
+    },
+    element: {
+      $type: "Document",
+      actions: [
+        {
+          $type: "Action",
+          appearance: "subtle",
+          children: "Cancel",
+          onClick: { message: "[User declined to run the agent]" },
+        },
+        {
+          $type: "Action",
+          appearance: "primary-opal",
+          children: "Run agent",
+          onClick: {
+            message: {
+              files: {
+                $type: "Map",
+                children: {
+                  $type: "Show",
+                  children: { $type: "Value", path: "value" },
+                  when: {
+                    and: [
+                      { "==": [{ $type: "Value", path: "type" }, "file"] },
+                      { "!!": { $type: "Value", path: "value" } },
+                    ],
+                  },
+                },
+                path: "/parameters",
+              },
+              parts: [
+                {
+                  content: {
+                    $type: "Map",
+                    children: {
+                      $type: "Show",
+                      children: {
+                        $type: "Concat",
+                        children: [
+                          { $type: "Value", path: "name" },
+                          ": ",
+                          {
+                            $type: "Show",
+                            children: "[Not specified]",
+                            when: { "!": { $type: "Value", path: "value" } },
+                          },
+                          {
+                            $type: "Show",
+                            children: { $type: "Value", path: "value" },
+                            when: { "!!": { $type: "Value", path: "value" } },
+                          },
+                        ],
+                      },
+                      when: {
+                        "!=": [{ $type: "Value", path: "type" }, "file"],
+                      },
+                    },
+                    path: "/parameters",
+                    separator: "\n",
+                  },
+                  type: "text",
+                },
+              ],
+            },
+          },
+          type: "submit",
+        },
+      ],
+      appName: "Opal",
+      body: {
+        $type: "Group",
+        children: {
+          $type: "Map",
+          children: [
+            {
+              $type: "Show",
+              children: {
+                $type: "Field",
+                children: {
+                  $type: "Input",
+                  name: "value",
+                  placeholder: { $type: "Value", path: "placeholder" },
+                  required: { $type: "Value", path: "required" },
+                },
+                description: { $type: "Value", path: "description" },
+                label: { $type: "Value", path: "name" },
+                required: { $type: "Value", path: "required" },
+              },
+              when: { "==": [{ $type: "Value", path: "type" }, "string"] },
+            },
+            {
+              $type: "Show",
+              children: {
+                $type: "Field",
+                children: {
+                  $type: "FileUpload",
+                  accept: ["application/pdf", "text/*"],
+                  name: "value",
+                  required: { $type: "Value", path: "required" },
+                },
+                description: { $type: "Value", path: "description" },
+                label: { $type: "Value", path: "name" },
+                required: { $type: "Value", path: "required" },
+              },
+              when: { "==": [{ $type: "Value", path: "type" }, "file"] },
+            },
+          ],
+          path: "/parameters",
+        },
+        flexDirection: "column",
+        gap: "24",
+      },
+      subtitle: { $type: "Value", path: "/agent/description" },
+      title: { $type: "Value", path: "/agent/name" },
+    },
+    onUpload: async (file) => {
+      action("onUpload (mocked)")(file);
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      const fileId = Math.random().toString(36).slice(2, 10);
+      return `https://opal-localdev.optimizely.com/file-server/files/${fileId}/${encodeURIComponent(
+        file.name,
+      )}?signed=mock`;
+    },
+  },
+  render: function AskAgentInputWithFileParamRender(args) {
+    const [data, setData] = useState(args.data);
+    return (
+      <ProteusDocumentRenderer {...args} data={data} onDataChange={setData} />
+    );
+  },
+};
+
 export const AskAgentInputTruncate: Story = {
   args: {
     ...AskAgentInput.args,
@@ -1489,167 +1642,5 @@ export const PartialRendering: Story = {
       title: "Invalid Document Example",
     },
     strict: false,
-  },
-};
-
-/**
- * Reproduces Opal's `ask_agent_input` action card with a `file` parameter.
- * The host's `onUpload` callback is mocked: it accepts any File, simulates a
- * 1.5s upload, and returns a fake signed URL. The form data carries a single
- * URL string per file param. On submit, the `onMessage` action log shows the
- * structured payload `{ parts, files }`.
- */
-export const AskAgentInputWithFileParam: Story = {
-  render: function AskAgentInputWithFileParamRender(args) {
-    const [data, setData] = useState(args.data);
-    return (
-      <ProteusDocumentRenderer
-        {...args}
-        data={data}
-        onDataChange={setData}
-      />
-    );
-  },
-  args: {
-    data: {
-      agent: {
-        description: "Summarizes uploaded source documents.",
-        name: "Doc Summarizer",
-      },
-      parameters: [
-        {
-          description: "What to call the run",
-          name: "Run Name",
-          required: true,
-          type: "string",
-        },
-        {
-          description: "PDF or text file to summarize",
-          name: "Source Document",
-          required: true,
-          type: "file",
-        },
-      ],
-    },
-    element: {
-      $type: "Document",
-      actions: [
-        {
-          $type: "Action",
-          appearance: "subtle",
-          children: "Cancel",
-          onClick: { message: "[User declined to run the agent]" },
-        },
-        {
-          $type: "Action",
-          appearance: "primary-opal",
-          children: "Run agent",
-          onClick: {
-            message: {
-              files: {
-                $type: "Map",
-                children: {
-                  $type: "Show",
-                  children: { $type: "Value", path: "value" },
-                  when: {
-                    and: [
-                      { "==": [{ $type: "Value", path: "type" }, "file"] },
-                      { "!!": { $type: "Value", path: "value" } },
-                    ],
-                  },
-                },
-                path: "/parameters",
-              },
-              parts: [
-                {
-                  content: {
-                    $type: "Map",
-                    children: {
-                      $type: "Show",
-                      children: {
-                        $type: "Concat",
-                        children: [
-                          { $type: "Value", path: "name" },
-                          ": ",
-                          {
-                            $type: "Show",
-                            children: "[Not specified]",
-                            when: { "!": { $type: "Value", path: "value" } },
-                          },
-                          {
-                            $type: "Show",
-                            children: { $type: "Value", path: "value" },
-                            when: { "!!": { $type: "Value", path: "value" } },
-                          },
-                        ],
-                      },
-                      when: { "!=": [{ $type: "Value", path: "type" }, "file"] },
-                    },
-                    path: "/parameters",
-                    separator: "\n",
-                  },
-                  type: "text",
-                },
-              ],
-            },
-          },
-          type: "submit",
-        },
-      ],
-      appName: "Opal",
-      body: {
-        $type: "Group",
-        children: {
-          $type: "Map",
-          children: [
-            {
-              $type: "Show",
-              children: {
-                $type: "Field",
-                children: {
-                  $type: "Input",
-                  name: "value",
-                  placeholder: { $type: "Value", path: "placeholder" },
-                  required: { $type: "Value", path: "required" },
-                },
-                description: { $type: "Value", path: "description" },
-                label: { $type: "Value", path: "name" },
-                required: { $type: "Value", path: "required" },
-              },
-              when: { "==": [{ $type: "Value", path: "type" }, "string"] },
-            },
-            {
-              $type: "Show",
-              children: {
-                $type: "Field",
-                children: {
-                  $type: "FileUpload",
-                  accept: ["application/pdf", "text/*"],
-                  name: "value",
-                  required: { $type: "Value", path: "required" },
-                },
-                description: { $type: "Value", path: "description" },
-                label: { $type: "Value", path: "name" },
-                required: { $type: "Value", path: "required" },
-              },
-              when: { "==": [{ $type: "Value", path: "type" }, "file"] },
-            },
-          ],
-          path: "/parameters",
-        },
-        flexDirection: "column",
-        gap: "24",
-      },
-      subtitle: { $type: "Value", path: "/agent/description" },
-      title: { $type: "Value", path: "/agent/name" },
-    },
-    onUpload: async (file) => {
-      action("onUpload (mocked)")(file);
-      await new Promise((resolve) => setTimeout(resolve, 1500));
-      const fileId = Math.random().toString(36).slice(2, 10);
-      return `https://opal-localdev.optimizely.com/file-server/files/${fileId}/${encodeURIComponent(
-        file.name,
-      )}?signed=mock`;
-    },
   },
 };

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -1491,3 +1491,191 @@ export const PartialRendering: Story = {
     strict: false,
   },
 };
+
+/**
+ * Reproduces Opal's `ask_agent_input` action card with a `file` parameter.
+ * The host's `onUpload` callback is mocked: it accepts any File, simulates a
+ * 1.5s upload, and returns a fake signed URL. The form data carries a single
+ * URL string per file param. On submit, the `onMessage` action log shows the
+ * structured payload `{ parts, files }`.
+ */
+export const AskAgentInputWithFileParam: Story = {
+  render: function AskAgentInputWithFileParamRender(args) {
+    const [data, setData] = useState(args.data);
+    return (
+      <ProteusDocumentRenderer
+        {...args}
+        data={data}
+        onDataChange={setData}
+      />
+    );
+  },
+  args: {
+    data: {
+      agent: {
+        description: "Summarizes uploaded source documents.",
+        name: "Doc Summarizer",
+      },
+      parameters: [
+        {
+          description: "What to call the run",
+          name: "Run Name",
+          required: true,
+          type: "string",
+        },
+        {
+          description: "PDF or text file to summarize",
+          name: "Source Document",
+          required: true,
+          type: "file",
+        },
+      ],
+    },
+    element: {
+      $type: "Document",
+      actions: [
+        {
+          $type: "Action",
+          appearance: "subtle",
+          children: "Cancel",
+          onClick: { message: "[User declined to run the agent]" },
+        },
+        {
+          $type: "Action",
+          appearance: "primary-opal",
+          children: "Run agent",
+          onClick: {
+            message: {
+              files: {
+                $type: "Map",
+                children: {
+                  $type: "Show",
+                  children: { $type: "Value", path: "value" },
+                  when: {
+                    and: [
+                      { "==": [{ $type: "Value", path: "type" }, "file"] },
+                      { "!!": { $type: "Value", path: "value" } },
+                    ],
+                  },
+                },
+                path: "/parameters",
+              },
+              parts: [
+                {
+                  content: {
+                    $type: "Map",
+                    children: {
+                      $type: "Concat",
+                      children: [
+                        { $type: "Value", path: "name" },
+                        ": ",
+                        {
+                          $type: "Show",
+                          children: "[Not specified]",
+                          when: {
+                            and: [
+                              { "==": [{ $type: "Value", path: "type" }, "string"] },
+                              { "!": { $type: "Value", path: "value" } },
+                            ],
+                          },
+                        },
+                        {
+                          $type: "Show",
+                          children: "[No file uploaded]",
+                          when: {
+                            and: [
+                              { "==": [{ $type: "Value", path: "type" }, "file"] },
+                              { "!": { $type: "Value", path: "value" } },
+                            ],
+                          },
+                        },
+                        {
+                          $type: "Show",
+                          children: "[file attached]",
+                          when: {
+                            and: [
+                              { "==": [{ $type: "Value", path: "type" }, "file"] },
+                              { "!!": { $type: "Value", path: "value" } },
+                            ],
+                          },
+                        },
+                        {
+                          $type: "Show",
+                          children: { $type: "Value", path: "value" },
+                          when: {
+                            and: [
+                              { "!=": [{ $type: "Value", path: "type" }, "file"] },
+                              { "!!": { $type: "Value", path: "value" } },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                    path: "/parameters",
+                    separator: "\n",
+                  },
+                  type: "text",
+                },
+              ],
+            },
+          },
+          type: "submit",
+        },
+      ],
+      appName: "Opal",
+      body: {
+        $type: "Group",
+        children: {
+          $type: "Map",
+          children: [
+            {
+              $type: "Show",
+              children: {
+                $type: "Field",
+                children: {
+                  $type: "Input",
+                  name: "value",
+                  placeholder: { $type: "Value", path: "placeholder" },
+                  required: { $type: "Value", path: "required" },
+                },
+                description: { $type: "Value", path: "description" },
+                label: { $type: "Value", path: "name" },
+                required: { $type: "Value", path: "required" },
+              },
+              when: { "==": [{ $type: "Value", path: "type" }, "string"] },
+            },
+            {
+              $type: "Show",
+              children: {
+                $type: "Field",
+                children: {
+                  $type: "FileUpload",
+                  accept: ["application/pdf", "text/*"],
+                  name: "value",
+                  required: { $type: "Value", path: "required" },
+                },
+                description: { $type: "Value", path: "description" },
+                label: { $type: "Value", path: "name" },
+                required: { $type: "Value", path: "required" },
+              },
+              when: { "==": [{ $type: "Value", path: "type" }, "file"] },
+            },
+          ],
+          path: "/parameters",
+        },
+        flexDirection: "column",
+        gap: "24",
+      },
+      subtitle: { $type: "Value", path: "/agent/description" },
+      title: { $type: "Value", path: "/agent/name" },
+    },
+    onUpload: async (file) => {
+      action("onUpload (mocked)")(file);
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      const fileId = Math.random().toString(36).slice(2, 10);
+      return `https://opal-localdev.optimizely.com/file-server/files/${fileId}/${encodeURIComponent(
+        file.name,
+      )}?signed=mock`;
+    },
+  },
+};

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -114,6 +114,11 @@ const PROTEUS_COMPONENT_CONFIG = {
       label: "Field Label",
     },
   },
+  FileUpload: {
+    allowedProps: ["accept", "name", "required"],
+    example: { name: "value" },
+    extends: "Fragment",
+  },
   Group: {
     allowedProps: ["alignItems", "children", "flexDirection"],
     example: { children: [], flexDirection: "column", gap: "16" },
@@ -709,9 +714,10 @@ function generateSpec(additionalProperties = false) {
                   anyOf: [
                     { $ref: "#/definitions/ProteusExpression" },
                     { type: "string" },
+                    { $ref: "#/definitions/ProteusStructuredMessage" },
                   ],
                   description:
-                    "Message to send to LLM via sendNewMessage(). Can be a string, a Value reference, or a Map expression.",
+                    "Message to send to LLM via sendNewMessage(). Can be a string, a Value reference, a Map expression, or a structured payload with parts and files.",
                 },
               },
               required: ["message"],
@@ -752,6 +758,40 @@ function generateSpec(additionalProperties = false) {
           ],
           description:
             "A dynamic Proteus expression that resolves to a value at render time.",
+        },
+        ProteusStructuredMessage: {
+          ...(additionalProperties ? {} : { additionalProperties: false }),
+          description:
+            "Structured message payload that lets file URLs travel as a typed list alongside the text parts, instead of being joined into the text.",
+          properties: {
+            files: {
+              anyOf: [
+                { items: { type: "string" }, type: "array" },
+                { $ref: "#/definitions/ProteusExpression" },
+              ],
+              description:
+                "List of file URLs (typically signed URLs from a host upload).",
+            },
+            parts: {
+              items: {
+                ...(additionalProperties ? {} : { additionalProperties: false }),
+                properties: {
+                  content: {
+                    anyOf: [
+                      { type: "string" },
+                      { $ref: "#/definitions/ProteusExpression" },
+                    ],
+                  },
+                  type: { const: "text" },
+                },
+                required: ["type", "content"],
+                type: "object",
+              },
+              type: "array",
+            },
+          },
+          required: ["parts"],
+          type: "object",
         },
         ProteusNode: {
           anyOf: [
@@ -907,6 +947,29 @@ function getPropTypeOverrides(additionalProperties = false) {
           anyOf: [{ $ref: "#/definitions/ProteusNode" }, { type: "string" }],
         },
         type: "array",
+      },
+    },
+    FileUpload: {
+      accept: {
+        description:
+          "File types to accept; array of MIME types or extensions.",
+        items: { type: "string" },
+        type: "array",
+      },
+      name: {
+        anyOf: [
+          { type: "string" },
+          { $ref: "#/definitions/ProteusExpression" },
+        ],
+        description:
+          "The name of the form control element. The resolved URL is written at parentPath/name in form data.",
+      },
+      required: {
+        anyOf: [
+          { type: "boolean" },
+          { $ref: "#/definitions/ProteusExpression" },
+        ],
+        description: "Whether a file is required.",
       },
     },
     DataTable: {

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -759,40 +759,6 @@ function generateSpec(additionalProperties = false) {
           description:
             "A dynamic Proteus expression that resolves to a value at render time.",
         },
-        ProteusStructuredMessage: {
-          ...(additionalProperties ? {} : { additionalProperties: false }),
-          description:
-            "Structured message payload that lets file URLs travel as a typed list alongside the text parts, instead of being joined into the text.",
-          properties: {
-            files: {
-              anyOf: [
-                { items: { type: "string" }, type: "array" },
-                { $ref: "#/definitions/ProteusExpression" },
-              ],
-              description:
-                "List of file URLs (typically signed URLs from a host upload).",
-            },
-            parts: {
-              items: {
-                ...(additionalProperties ? {} : { additionalProperties: false }),
-                properties: {
-                  content: {
-                    anyOf: [
-                      { type: "string" },
-                      { $ref: "#/definitions/ProteusExpression" },
-                    ],
-                  },
-                  type: { const: "text" },
-                },
-                required: ["type", "content"],
-                type: "object",
-              },
-              type: "array",
-            },
-          },
-          required: ["parts"],
-          type: "object",
-        },
         ProteusNode: {
           anyOf: [
             {
@@ -815,6 +781,42 @@ function generateSpec(additionalProperties = false) {
           ],
           description:
             "A Proteus node can be a string, number, boolean, null, a single element, or an array of these types (similar to ReactNode)",
+        },
+        ProteusStructuredMessage: {
+          ...(additionalProperties ? {} : { additionalProperties: false }),
+          description:
+            "Structured message payload that lets file URLs travel as a typed list alongside the text parts, instead of being joined into the text.",
+          properties: {
+            files: {
+              anyOf: [
+                { items: { type: "string" }, type: "array" },
+                { $ref: "#/definitions/ProteusExpression" },
+              ],
+              description:
+                "List of file URLs (typically signed URLs from a host upload).",
+            },
+            parts: {
+              items: {
+                ...(additionalProperties
+                  ? {}
+                  : { additionalProperties: false }),
+                properties: {
+                  content: {
+                    anyOf: [
+                      { type: "string" },
+                      { $ref: "#/definitions/ProteusExpression" },
+                    ],
+                  },
+                  type: { const: "text" },
+                },
+                required: ["type", "content"],
+                type: "object",
+              },
+              type: "array",
+            },
+          },
+          required: ["parts"],
+          type: "object",
         },
         ProteusZip: {
           ...(additionalProperties ? {} : { additionalProperties: false }),
@@ -949,29 +951,6 @@ function getPropTypeOverrides(additionalProperties = false) {
         type: "array",
       },
     },
-    FileUpload: {
-      accept: {
-        description:
-          "File types to accept; array of MIME types or extensions.",
-        items: { type: "string" },
-        type: "array",
-      },
-      name: {
-        anyOf: [
-          { type: "string" },
-          { $ref: "#/definitions/ProteusExpression" },
-        ],
-        description:
-          "The name of the form control element. The resolved URL is written at parentPath/name in form data.",
-      },
-      required: {
-        anyOf: [
-          { type: "boolean" },
-          { $ref: "#/definitions/ProteusExpression" },
-        ],
-        description: "Whether a file is required.",
-      },
-    },
     DataTable: {
       columns: {
         anyOf: [
@@ -1030,6 +1009,28 @@ function getPropTypeOverrides(additionalProperties = false) {
           { $ref: "#/definitions/ProteusExpression" },
           { $ref: "#/definitions/ProteusZip" },
         ],
+      },
+    },
+    FileUpload: {
+      accept: {
+        description: "File types to accept; array of MIME types or extensions.",
+        items: { type: "string" },
+        type: "array",
+      },
+      name: {
+        anyOf: [
+          { type: "string" },
+          { $ref: "#/definitions/ProteusExpression" },
+        ],
+        description:
+          "The name of the form control element. The resolved URL is written at parentPath/name in form data.",
+      },
+      required: {
+        anyOf: [
+          { type: "boolean" },
+          { $ref: "#/definitions/ProteusExpression" },
+        ],
+        description: "Whether a file is required.",
       },
     },
     Image: {

--- a/packages/proteus/src/index.ts
+++ b/packages/proteus/src/index.ts
@@ -3,6 +3,7 @@ export * from "./proteus-bridge";
 export * from "./proteus-chart";
 export * from "./proteus-data-table";
 export * from "./proteus-document";
+export * from "./proteus-file-upload";
 export * from "./proteus-image";
 export * from "./proteus-image-carousel";
 export * from "./proteus-input";

--- a/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
+++ b/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
@@ -9,12 +9,15 @@ export type UseResource = (resource: string) => {
   isError: boolean;
 };
 
+export type UploadFile = (file: File) => Promise<string>;
+
 export const [ProteusDocumentProvider, useProteusDocumentContext] =
   createContext<{
     data: Record<string, unknown>;
     onDataChange: (path: string, value: unknown) => void;
     onEvent: (event: ProteusEventHandler) => Promise<unknown>;
     onTrack?: (event: string, properties: Record<string, string>) => void;
+    onUpload?: UploadFile;
     readOnly: boolean | undefined;
     strict: boolean | undefined;
     useResource?: UseResource;

--- a/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
+++ b/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
@@ -4,12 +4,12 @@ import { createContext } from "@radix-ui/react-context";
 
 import type { ProteusEventHandler } from "./schemas";
 
+export type UploadFile = (file: File) => Promise<string>;
+
 export type UseResource = (resource: string) => {
   data: undefined | { mimeType: string; text: string };
   isError: boolean;
 };
-
-export type UploadFile = (file: File) => Promise<string>;
 
 export const [ProteusDocumentProvider, useProteusDocumentContext] =
   createContext<{

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -19,12 +19,13 @@ import {
   useState,
 } from "react";
 
-import type { ProteusEventHandler } from "./schemas";
+import type { ProteusEventHandler, StructuredMessage } from "./schemas";
 
 import { useEffectEvent } from "../hooks";
 import { downloadFile } from "../proteus-image/downloadFile";
 import {
   ProteusDocumentProvider,
+  type UploadFile,
   type UseResource,
 } from "./ProteusDocumentContext";
 import * as styles from "./ProteusDocumentShell.css";
@@ -63,13 +64,20 @@ export type ProteusDocumentShellProps = Pick<
     params?: Record<string, unknown>,
   ) => Promise<unknown> | unknown;
   /**
-   * Callback when user sends a message action
+   * Callback when user sends a message action. The payload may be a plain
+   * string or a structured object (parts + optional files), depending on
+   * what the document declares for `Action.onClick.message`.
    */
-  onMessage?: (message: string) => Promise<void> | void;
+  onMessage?: (message: string | StructuredMessage) => Promise<void> | void;
   /**
    * Callback when an analytics event is fired
    */
   onTrack?: (event: string, properties: Record<string, string>) => void;
+  /**
+   * Async upload callback used by FileUpload elements. Receives a File and
+   * resolves to a URL string the document writes into form data.
+   */
+  onUpload?: UploadFile;
   /**
    * Whether form is readonly
    */
@@ -107,6 +115,7 @@ export function ProteusDocumentShell({
   onMessage,
   onOpenChange,
   onTrack,
+  onUpload,
   open: openProp,
   readOnly = false,
   strict,
@@ -191,6 +200,7 @@ export function ProteusDocumentShell({
           onTrack?.(event, properties);
         },
       )}
+      onUpload={onUpload}
       readOnly={readOnly}
       strict={strict}
       useResource={useResource}

--- a/packages/proteus/src/proteus-document/index.ts
+++ b/packages/proteus/src/proteus-document/index.ts
@@ -1,5 +1,5 @@
+export type { UploadFile } from "./ProteusDocumentContext";
 export * from "./ProteusDocumentRenderer";
 export * from "./ProteusDocumentShell";
-export type { UploadFile } from "./ProteusDocumentContext";
 export { safeParseDocument } from "./schemas";
 export type { StructuredMessage } from "./schemas";

--- a/packages/proteus/src/proteus-document/index.ts
+++ b/packages/proteus/src/proteus-document/index.ts
@@ -1,3 +1,5 @@
 export * from "./ProteusDocumentRenderer";
 export * from "./ProteusDocumentShell";
+export type { UploadFile } from "./ProteusDocumentContext";
 export { safeParseDocument } from "./schemas";
+export type { StructuredMessage } from "./schemas";

--- a/packages/proteus/src/proteus-document/resolveProteusValue.tsx
+++ b/packages/proteus/src/proteus-document/resolveProteusValue.tsx
@@ -159,18 +159,16 @@ export function resolveProteusValue(
       const resolvedPath = (value.path as string).startsWith("/")
         ? (value.path as string)
         : `${parentPath}/${value.path as string}`;
-      const items: unknown[] = [];
-      for (let index = 0; index < array.length; index++) {
-        const r = resolveProteusValue(
-          value.children,
-          data,
-          `${resolvedPath}/${index}`,
-          [...mapIndices, index],
-        );
-        if (r !== undefined) {
-          items.push(r);
-        }
-      }
+      const items = array
+        .map((_, index) =>
+          resolveProteusValue(
+            value.children,
+            data,
+            `${resolvedPath}/${index}`,
+            [...mapIndices, index],
+          ),
+        )
+        .filter((v: unknown) => v !== undefined);
       if ("separator" in value) {
         const sep = resolveProteusValue(
           value.separator,
@@ -211,30 +209,15 @@ export function resolveProteusValue(
   }
 
   if (Array.isArray(value)) {
-    let changed = false;
-    const out: unknown[] = [];
-    for (const v of value) {
-      const r = resolveProteusValue(v, data, parentPath, mapIndices);
-      if (r === undefined) {
-        changed = true;
-        continue;
-      }
-      if (r !== v) changed = true;
-      out.push(r);
-    }
-    return changed ? out : value;
+    return value
+      .map((v) => resolveProteusValue(v, data, parentPath, mapIndices))
+      .filter((v) => v !== undefined);
   }
 
-  let changed = false;
   const resolved: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(value)) {
     const r = resolveProteusValue(v, data, parentPath, mapIndices);
-    if (r === undefined) {
-      changed = true;
-      continue;
-    }
-    if (r !== v) changed = true;
-    resolved[k] = r;
+    if (r !== undefined) resolved[k] = r;
   }
-  return changed ? resolved : value;
+  return resolved;
 }

--- a/packages/proteus/src/proteus-document/resolveProteusValue.tsx
+++ b/packages/proteus/src/proteus-document/resolveProteusValue.tsx
@@ -159,12 +159,16 @@ export function resolveProteusValue(
       const resolvedPath = (value.path as string).startsWith("/")
         ? (value.path as string)
         : `${parentPath}/${value.path as string}`;
-      const items = array.map((_, index) =>
-        resolveProteusValue(value.children, data, `${resolvedPath}/${index}`, [
-          ...mapIndices,
-          index,
-        ]),
-      );
+      const items = array
+        .map((_, index) =>
+          resolveProteusValue(
+            value.children,
+            data,
+            `${resolvedPath}/${index}`,
+            [...mapIndices, index],
+          ),
+        )
+        .filter((v: unknown) => v !== undefined);
       if ("separator" in value) {
         const sep = resolveProteusValue(
           value.separator,
@@ -200,7 +204,22 @@ export function resolveProteusValue(
         .filter((v: unknown) => v !== undefined)
         .join("");
     }
+
+    return value;
   }
 
-  return value;
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => resolveProteusValue(v, data, parentPath, mapIndices))
+      .filter((v) => v !== undefined);
+  }
+
+  const resolved: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value)) {
+    const r = resolveProteusValue(v, data, parentPath, mapIndices);
+    if (r !== undefined) {
+      resolved[k] = r;
+    }
+  }
+  return resolved;
 }

--- a/packages/proteus/src/proteus-document/resolveProteusValue.tsx
+++ b/packages/proteus/src/proteus-document/resolveProteusValue.tsx
@@ -159,16 +159,18 @@ export function resolveProteusValue(
       const resolvedPath = (value.path as string).startsWith("/")
         ? (value.path as string)
         : `${parentPath}/${value.path as string}`;
-      const items = array
-        .map((_, index) =>
-          resolveProteusValue(
-            value.children,
-            data,
-            `${resolvedPath}/${index}`,
-            [...mapIndices, index],
-          ),
-        )
-        .filter((v: unknown) => v !== undefined);
+      const items: unknown[] = [];
+      for (let index = 0; index < array.length; index++) {
+        const r = resolveProteusValue(
+          value.children,
+          data,
+          `${resolvedPath}/${index}`,
+          [...mapIndices, index],
+        );
+        if (r !== undefined) {
+          items.push(r);
+        }
+      }
       if ("separator" in value) {
         const sep = resolveProteusValue(
           value.separator,
@@ -209,17 +211,30 @@ export function resolveProteusValue(
   }
 
   if (Array.isArray(value)) {
-    return value
-      .map((v) => resolveProteusValue(v, data, parentPath, mapIndices))
-      .filter((v) => v !== undefined);
+    let changed = false;
+    const out: unknown[] = [];
+    for (const v of value) {
+      const r = resolveProteusValue(v, data, parentPath, mapIndices);
+      if (r === undefined) {
+        changed = true;
+        continue;
+      }
+      if (r !== v) changed = true;
+      out.push(r);
+    }
+    return changed ? out : value;
   }
 
+  let changed = false;
   const resolved: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(value)) {
     const r = resolveProteusValue(v, data, parentPath, mapIndices);
-    if (r !== undefined) {
-      resolved[k] = r;
+    if (r === undefined) {
+      changed = true;
+      continue;
     }
+    if (r !== v) changed = true;
+    resolved[k] = r;
   }
-  return resolved;
+  return changed ? resolved : value;
 }

--- a/packages/proteus/src/proteus-document/schemas.ts
+++ b/packages/proteus/src/proteus-document/schemas.ts
@@ -71,11 +71,6 @@ export type ProteusElement =
   | (TextProps & { $type: "Text" })
   | (TimeProps & { $type: "Time" });
 
-export type StructuredMessage = {
-  files?: string[];
-  parts: Array<{ content: string; type: "text" }>;
-};
-
 export type ProteusEventHandler =
   | {
       action: "download";
@@ -83,6 +78,11 @@ export type ProteusEventHandler =
     }
   | { interaction: string; params?: Record<string, unknown> }
   | { message: string | StructuredMessage };
+
+export type StructuredMessage = {
+  files?: string[];
+  parts: Array<{ content: string; type: "text" }>;
+};
 
 type ProteusDocument = ProteusDocumentShellProps["element"] & {
   $type: "Document";

--- a/packages/proteus/src/proteus-document/schemas.ts
+++ b/packages/proteus/src/proteus-document/schemas.ts
@@ -25,6 +25,7 @@ import type { ProteusActionProps } from "../proteus-action/ProteusAction";
 import type { ProteusBridgeProps } from "../proteus-bridge/ProteusBridge";
 import type { ProteusChartProps } from "../proteus-chart/ProteusChart";
 import type { ProteusDataTableProps } from "../proteus-data-table/ProteusDataTable";
+import type { ProteusFileUploadProps } from "../proteus-file-upload/ProteusFileUpload";
 import type { ProteusImageCarouselProps } from "../proteus-image-carousel/ProteusImageCarousel";
 import type { ProteusImageProps } from "../proteus-image/ProteusImage";
 import type { ProteusMapProps } from "../proteus-map/ProteusMap";
@@ -53,6 +54,7 @@ export type ProteusElement =
   | (ProteusBridgeProps & { $type: "Bridge" })
   | (ProteusChartProps & { $type: "Chart" })
   | (ProteusDataTableProps & { $type: "DataTable" })
+  | (ProteusFileUploadProps & { $type: "FileUpload" })
   | (ProteusImageCarouselProps & { $type: "ImageCarousel" })
   | (ProteusImageProps & { $type: "Image" })
   | (ProteusMapProps & { $type: "Map" })
@@ -69,13 +71,18 @@ export type ProteusElement =
   | (TextProps & { $type: "Text" })
   | (TimeProps & { $type: "Time" });
 
+export type StructuredMessage = {
+  files?: string[];
+  parts: Array<{ content: string; type: "text" }>;
+};
+
 export type ProteusEventHandler =
   | {
       action: "download";
       url: (ProteusValueProps & { $type: "Value" }) | string | string[];
     }
   | { interaction: string; params?: Record<string, unknown> }
-  | { message: string };
+  | { message: string | StructuredMessage };
 
 type ProteusDocument = ProteusDocumentShellProps["element"] & {
   $type: "Document";

--- a/packages/proteus/src/proteus-element/ProteusElement.tsx
+++ b/packages/proteus/src/proteus-element/ProteusElement.tsx
@@ -25,6 +25,7 @@ import { useProteusDocumentContext } from "../proteus-document/ProteusDocumentCo
 import { useProteusDocumentPathContext } from "../proteus-document/ProteusDocumentPathContext";
 import { resolveProteusProp } from "../proteus-document/resolveProteusProp";
 import { safeParseElement } from "../proteus-document/schemas";
+import { ProteusFileUpload } from "../proteus-file-upload/ProteusFileUpload";
 import { ProteusImageCarousel } from "../proteus-image-carousel/ProteusImageCarousel";
 import { ProteusImage } from "../proteus-image/ProteusImage";
 import { ProteusInput } from "../proteus-input/ProteusInput";
@@ -136,6 +137,8 @@ export const ProteusElement = ({
       );
     case "Field":
       return <Field {...resolve(element)} />;
+    case "FileUpload":
+      return <ProteusFileUpload {...resolve(element)} />;
     case "Group":
       return <Group {...resolve(element)} />;
     case "Heading":

--- a/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
+++ b/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
@@ -30,11 +30,6 @@ export type ProteusFileUploadProps = {
 };
 
 type Item = FileUploadListProps["items"][number];
-type Entry = {
-  id: string;
-  item: Item;
-  url?: string;
-};
 
 export function ProteusFileUpload({ accept, name }: ProteusFileUploadProps) {
   const { onDataChange, onUpload, readOnly } = useProteusDocumentContext(
@@ -44,7 +39,7 @@ export function ProteusFileUpload({ accept, name }: ProteusFileUploadProps) {
     "@optiaxiom/proteus/ProteusFileUpload",
   );
 
-  const [entry, setEntry] = useState<Entry | null>(null);
+  const [item, setItem] = useState<Item | null>(null);
 
   const writeUrl = useCallback(
     (url: null | string) => {
@@ -60,25 +55,17 @@ export function ProteusFileUpload({ accept, name }: ProteusFileUploadProps) {
         return;
       }
       const file = incoming[0];
-      const id =
-        typeof crypto !== "undefined" && "randomUUID" in crypto
-          ? crypto.randomUUID()
-          : `${Date.now()}-${Math.random()}`;
-      setEntry({ id, item: { file, status: "uploading" } });
+      setItem({ file, status: "uploading" });
       writeUrl(null);
       try {
         const url = await onUpload(file);
-        setEntry((curr) =>
-          curr?.id === id
-            ? { ...curr, item: { file, status: "complete" }, url }
-            : curr,
+        setItem((curr) =>
+          curr?.file === file ? { file, status: "complete" } : curr,
         );
         writeUrl(url);
       } catch {
-        setEntry((curr) =>
-          curr?.id === id
-            ? { ...curr, item: { file, status: "error" } }
-            : curr,
+        setItem((curr) =>
+          curr?.file === file ? { file, status: "error" } : curr,
         );
       }
     },
@@ -86,7 +73,7 @@ export function ProteusFileUpload({ accept, name }: ProteusFileUploadProps) {
   );
 
   const handleRemove = useCallback(() => {
-    setEntry(null);
+    setItem(null);
     writeUrl(null);
   }, [writeUrl]);
 
@@ -97,8 +84,8 @@ export function ProteusFileUpload({ accept, name }: ProteusFileUploadProps) {
       onFilesDrop={handleFilesDrop}
     >
       <Flex flexDirection="column" gap="8">
-        {entry ? (
-          <FileUploadList items={[entry.item]} onRemove={handleRemove} />
+        {item ? (
+          <FileUploadList items={[item]} onRemove={handleRemove} />
         ) : (
           <FileUploadTrigger alignSelf="start" />
         )}

--- a/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
+++ b/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
@@ -1,0 +1,111 @@
+import { Flex } from "@optiaxiom/react";
+import {
+  FileUpload,
+  FileUploadDropzone,
+  FileUploadList,
+  type FileUploadListProps,
+  FileUploadTrigger,
+} from "@optiaxiom/react/unstable";
+import { useCallback, useState } from "react";
+
+import { useProteusDocumentContext } from "../proteus-document/ProteusDocumentContext";
+import { useProteusDocumentPathContext } from "../proteus-document/ProteusDocumentPathContext";
+
+export type ProteusFileUploadProps = {
+  /**
+   * File types to accept; array of MIME types or extensions.
+   *
+   * @example ["image/*", ".pdf"]
+   */
+  accept?: string[];
+  /**
+   * The name of the form control element. The resolved URL is written at
+   * `parentPath/name` in form data once the host's `onUpload` resolves.
+   */
+  name?: string;
+  /**
+   * Whether a file is required.
+   */
+  required?: boolean;
+};
+
+type Item = FileUploadListProps["items"][number];
+type Entry = {
+  id: string;
+  item: Item;
+  url?: string;
+};
+
+export function ProteusFileUpload({ accept, name }: ProteusFileUploadProps) {
+  const { onDataChange, onUpload, readOnly } = useProteusDocumentContext(
+    "@optiaxiom/proteus/ProteusFileUpload",
+  );
+  const { path: parentPath } = useProteusDocumentPathContext(
+    "@optiaxiom/proteus/ProteusFileUpload",
+  );
+
+  const [entry, setEntry] = useState<Entry | null>(null);
+
+  const writeUrl = useCallback(
+    (url: null | string) => {
+      if (!name) return;
+      onDataChange?.(`${parentPath}/${name}`, url);
+    },
+    [name, onDataChange, parentPath],
+  );
+
+  const handleFilesDrop = useCallback(
+    async (incoming: File[]) => {
+      if (!onUpload || readOnly || incoming.length === 0) {
+        return;
+      }
+      const file = incoming[0];
+      const id =
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : `${Date.now()}-${Math.random()}`;
+      setEntry({ id, item: { file, status: "uploading" } });
+      writeUrl(null);
+      try {
+        const url = await onUpload(file);
+        setEntry((curr) =>
+          curr?.id === id
+            ? { ...curr, item: { file, status: "complete" }, url }
+            : curr,
+        );
+        writeUrl(url);
+      } catch {
+        setEntry((curr) =>
+          curr?.id === id
+            ? { ...curr, item: { file, status: "error" } }
+            : curr,
+        );
+      }
+    },
+    [onUpload, readOnly, writeUrl],
+  );
+
+  const handleRemove = useCallback(() => {
+    setEntry(null);
+    writeUrl(null);
+  }, [writeUrl]);
+
+  return (
+    <FileUpload
+      accept={accept}
+      disabled={!onUpload || readOnly}
+      onFilesDrop={handleFilesDrop}
+    >
+      <Flex flexDirection="column" gap="8">
+        {entry ? (
+          <FileUploadList items={[entry.item]} onRemove={handleRemove} />
+        ) : (
+          <FileUploadTrigger alignSelf="start" />
+        )}
+      </Flex>
+      <FileUploadDropzone overlay />
+    </FileUpload>
+  );
+}
+
+ProteusFileUpload.displayName = "@optiaxiom/proteus/ProteusFileUpload";

--- a/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
+++ b/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
@@ -83,14 +83,16 @@ export function ProteusFileUpload({ accept, name }: ProteusFileUploadProps) {
       disabled={!onUpload || readOnly}
       onFilesDrop={handleFilesDrop}
     >
-      <Flex flexDirection="column" gap="8">
-        {item ? (
+      {item ? (
+        <Flex flexDirection="column" gap="8">
           <FileUploadList items={[item]} onRemove={handleRemove} />
-        ) : (
-          <FileUploadTrigger alignSelf="start" />
-        )}
-      </Flex>
-      <FileUploadDropzone overlay />
+          <FileUploadDropzone overlay />
+        </Flex>
+      ) : (
+        <FileUploadDropzone>
+          <FileUploadTrigger />
+        </FileUploadDropzone>
+      )}
     </FileUpload>
   );
 }

--- a/packages/proteus/src/proteus-file-upload/index.ts
+++ b/packages/proteus/src/proteus-file-upload/index.ts
@@ -1,0 +1,1 @@
+export * from "./ProteusFileUpload";

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -1309,6 +1309,7 @@
         { "$ref": "#/definitions/ProteusConcat" },
         { "$ref": "#/definitions/ProteusDataTable" },
         { "$ref": "#/definitions/ProteusField" },
+        { "$ref": "#/definitions/ProteusFileUpload" },
         { "$ref": "#/definitions/ProteusGroup" },
         { "$ref": "#/definitions/ProteusHeading" },
         { "$ref": "#/definitions/ProteusIconCalendar" },
@@ -1359,9 +1360,10 @@
             "message": {
               "anyOf": [
                 { "$ref": "#/definitions/ProteusExpression" },
-                { "type": "string" }
+                { "type": "string" },
+                { "$ref": "#/definitions/ProteusStructuredMessage" }
               ],
-              "description": "Message to send to LLM via sendNewMessage(). Can be a string, a Value reference, or a Map expression."
+              "description": "Message to send to LLM via sendNewMessage(). Can be a string, a Value reference, a Map expression, or a structured payload with parts and files."
             }
           },
           "required": ["message"],
@@ -1398,6 +1400,38 @@
         { "$ref": "#/definitions/ProteusValue" }
       ],
       "description": "A dynamic Proteus expression that resolves to a value at render time."
+    },
+    "ProteusStructuredMessage": {
+      "additionalProperties": false,
+      "description": "Structured message payload that lets file URLs travel as a typed list alongside the text parts, instead of being joined into the text.",
+      "properties": {
+        "files": {
+          "anyOf": [
+            { "items": { "type": "string" }, "type": "array" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "List of file URLs (typically signed URLs from a host upload)."
+        },
+        "parts": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "content": {
+                "anyOf": [
+                  { "type": "string" },
+                  { "$ref": "#/definitions/ProteusExpression" }
+                ]
+              },
+              "type": { "const": "text" }
+            },
+            "required": ["type", "content"],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": ["parts"],
+      "type": "object"
     },
     "ProteusNode": {
       "anyOf": [
@@ -2404,6 +2438,34 @@
         "w": { "$ref": "#/definitions/SprinkleProp_w" },
         "whiteSpace": { "$ref": "#/definitions/SprinkleProp_whiteSpace" },
         "z": { "$ref": "#/definitions/SprinkleProp_z" }
+      },
+      "required": ["$type"],
+      "type": "object"
+    },
+    "ProteusFileUpload": {
+      "additionalProperties": false,
+      "examples": [{ "$type": "FileUpload", "name": "value" }],
+      "properties": {
+        "$type": { "const": "FileUpload" },
+        "accept": {
+          "description": "File types to accept; array of MIME types or extensions.",
+          "items": { "type": "string" },
+          "type": "array"
+        },
+        "name": {
+          "anyOf": [
+            { "type": "string" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "The name of the form control element. The resolved URL is written at parentPath/name in form data."
+        },
+        "required": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "Whether a file is required."
+        }
       },
       "required": ["$type"],
       "type": "object"

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -1401,6 +1401,28 @@
       ],
       "description": "A dynamic Proteus expression that resolves to a value at render time."
     },
+    "ProteusNode": {
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              { "type": "string" },
+              { "type": "number" },
+              { "type": "boolean" },
+              { "type": "null" },
+              { "$ref": "#/definitions/ProteusElement" }
+            ]
+          },
+          "type": "array"
+        },
+        { "type": "string" },
+        { "type": "number" },
+        { "type": "boolean" },
+        { "type": "null" },
+        { "$ref": "#/definitions/ProteusElement" }
+      ],
+      "description": "A Proteus node can be a string, number, boolean, null, a single element, or an array of these types (similar to ReactNode)"
+    },
     "ProteusStructuredMessage": {
       "additionalProperties": false,
       "description": "Structured message payload that lets file URLs travel as a typed list alongside the text parts, instead of being joined into the text.",
@@ -1432,28 +1454,6 @@
       },
       "required": ["parts"],
       "type": "object"
-    },
-    "ProteusNode": {
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              { "type": "string" },
-              { "type": "number" },
-              { "type": "boolean" },
-              { "type": "null" },
-              { "$ref": "#/definitions/ProteusElement" }
-            ]
-          },
-          "type": "array"
-        },
-        { "type": "string" },
-        { "type": "number" },
-        { "type": "boolean" },
-        { "type": "null" },
-        { "$ref": "#/definitions/ProteusElement" }
-      ],
-      "description": "A Proteus node can be a string, number, boolean, null, a single element, or an array of these types (similar to ReactNode)"
     },
     "ProteusZip": {
       "additionalProperties": false,

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -1298,6 +1298,7 @@
         { "$ref": "#/definitions/ProteusConcat" },
         { "$ref": "#/definitions/ProteusDataTable" },
         { "$ref": "#/definitions/ProteusField" },
+        { "$ref": "#/definitions/ProteusFileUpload" },
         { "$ref": "#/definitions/ProteusGroup" },
         { "$ref": "#/definitions/ProteusHeading" },
         { "$ref": "#/definitions/ProteusIconCalendar" },
@@ -1346,9 +1347,10 @@
             "message": {
               "anyOf": [
                 { "$ref": "#/definitions/ProteusExpression" },
-                { "type": "string" }
+                { "type": "string" },
+                { "$ref": "#/definitions/ProteusStructuredMessage" }
               ],
-              "description": "Message to send to LLM via sendNewMessage(). Can be a string, a Value reference, or a Map expression."
+              "description": "Message to send to LLM via sendNewMessage(). Can be a string, a Value reference, a Map expression, or a structured payload with parts and files."
             }
           },
           "required": ["message"],
@@ -1384,6 +1386,36 @@
         { "$ref": "#/definitions/ProteusValue" }
       ],
       "description": "A dynamic Proteus expression that resolves to a value at render time."
+    },
+    "ProteusStructuredMessage": {
+      "description": "Structured message payload that lets file URLs travel as a typed list alongside the text parts, instead of being joined into the text.",
+      "properties": {
+        "files": {
+          "anyOf": [
+            { "items": { "type": "string" }, "type": "array" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "List of file URLs (typically signed URLs from a host upload)."
+        },
+        "parts": {
+          "items": {
+            "properties": {
+              "content": {
+                "anyOf": [
+                  { "type": "string" },
+                  { "$ref": "#/definitions/ProteusExpression" }
+                ]
+              },
+              "type": { "const": "text" }
+            },
+            "required": ["type", "content"],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": ["parts"],
+      "type": "object"
     },
     "ProteusNode": {
       "anyOf": [
@@ -2374,6 +2406,33 @@
         "w": { "$ref": "#/definitions/SprinkleProp_w" },
         "whiteSpace": { "$ref": "#/definitions/SprinkleProp_whiteSpace" },
         "z": { "$ref": "#/definitions/SprinkleProp_z" }
+      },
+      "required": ["$type"],
+      "type": "object"
+    },
+    "ProteusFileUpload": {
+      "examples": [{ "$type": "FileUpload", "name": "value" }],
+      "properties": {
+        "$type": { "const": "FileUpload" },
+        "accept": {
+          "description": "File types to accept; array of MIME types or extensions.",
+          "items": { "type": "string" },
+          "type": "array"
+        },
+        "name": {
+          "anyOf": [
+            { "type": "string" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "The name of the form control element. The resolved URL is written at parentPath/name in form data."
+        },
+        "required": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "Whether a file is required."
+        }
       },
       "required": ["$type"],
       "type": "object"

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -1387,6 +1387,28 @@
       ],
       "description": "A dynamic Proteus expression that resolves to a value at render time."
     },
+    "ProteusNode": {
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              { "type": "string" },
+              { "type": "number" },
+              { "type": "boolean" },
+              { "type": "null" },
+              { "$ref": "#/definitions/ProteusElement" }
+            ]
+          },
+          "type": "array"
+        },
+        { "type": "string" },
+        { "type": "number" },
+        { "type": "boolean" },
+        { "type": "null" },
+        { "$ref": "#/definitions/ProteusElement" }
+      ],
+      "description": "A Proteus node can be a string, number, boolean, null, a single element, or an array of these types (similar to ReactNode)"
+    },
     "ProteusStructuredMessage": {
       "description": "Structured message payload that lets file URLs travel as a typed list alongside the text parts, instead of being joined into the text.",
       "properties": {
@@ -1416,28 +1438,6 @@
       },
       "required": ["parts"],
       "type": "object"
-    },
-    "ProteusNode": {
-      "anyOf": [
-        {
-          "items": {
-            "anyOf": [
-              { "type": "string" },
-              { "type": "number" },
-              { "type": "boolean" },
-              { "type": "null" },
-              { "$ref": "#/definitions/ProteusElement" }
-            ]
-          },
-          "type": "array"
-        },
-        { "type": "string" },
-        { "type": "number" },
-        { "type": "boolean" },
-        { "type": "null" },
-        { "$ref": "#/definitions/ProteusElement" }
-      ],
-      "description": "A Proteus node can be a string, number, boolean, null, a single element, or an array of these types (similar to ReactNode)"
     },
     "ProteusZip": {
       "description": "Zips multiple parallel arrays into an array of objects. Each key in 'sources' becomes a property in the resulting row objects.",

--- a/packages/react/src/file-upload/FileUploadList.tsx
+++ b/packages/react/src/file-upload/FileUploadList.tsx
@@ -20,9 +20,9 @@ export type FileUploadListProps = BoxProps<"div"> & {
 };
 
 export const FileUploadList = forwardRef<HTMLDivElement, FileUploadListProps>(
-  ({ items, onRemove, ...props }) => {
+  ({ items, onRemove, ...props }, ref) => {
     return (
-      <Flex gap="12" {...props}>
+      <Flex gap="12" ref={ref} {...props}>
         {items.map((item, idx) => (
           <FileUploadListItem
             item={item}

--- a/packages/react/src/file-upload/useFileUploadDrop.ts
+++ b/packages/react/src/file-upload/useFileUploadDrop.ts
@@ -1,3 +1,5 @@
+import { toaster } from "@optiaxiom/globals";
+
 import type { BoxProps } from "../box";
 
 import { useAuthContext } from "../auth-provider";
@@ -37,7 +39,13 @@ export const useFileUploadDrop = ({
                 Array.from(event.dataTransfer.items).map(async (item) => {
                   if (item.kind === "file") {
                     const file = item.getAsFile();
-                    return file && isValidFile(file, accept) ? file : null;
+                    const valid = file && isValidFile(file, accept);
+                    if (!valid) {
+                      toaster.create(invalidFileTypeMessage(file), {
+                        intent: "danger",
+                      });
+                    }
+                    return valid ? file : null;
                   } else if (
                     item.type === "opal-chat-dnd-data" ||
                     item.type === "opal-host-dnd-data"
@@ -73,9 +81,15 @@ export const useFileUploadDrop = ({
                 }),
               )
             ).filter((file) => !!file)
-          : Array.from(event.dataTransfer.files).filter((file) =>
-              isValidFile(file, accept),
-            ),
+          : Array.from(event.dataTransfer.files).filter((file) => {
+              const valid = isValidFile(file, accept);
+              if (!valid) {
+                toaster.create(invalidFileTypeMessage(file), {
+                  intent: "danger",
+                });
+              }
+              return valid;
+            }),
       );
     },
   };
@@ -127,6 +141,14 @@ async function getRemoteFile(
       type: response.headers.get("Content-Type") || "application/octet-stream",
     });
   }
+}
+
+function invalidFileTypeMessage(file: File | null): string {
+  const ext = file?.name.includes(".")
+    ? `.${file.name.split(".").pop()}`
+    : undefined;
+  const label = ext || file?.type || "Unknown";
+  return `${label} is not an accepted file type`;
 }
 
 /**


### PR DESCRIPTION
Adds a first-class `FileUpload` element to `@optiaxiom/proteus` so JSON documents can declare file inputs alongside `Input`, `Switch`, etc., with the host owning the actual upload.

## What's added

- **`ProteusFileUpload`** (`packages/proteus/src/proteus-file-upload/`) — wraps `FileUpload` / `FileUploadDropzone` / `FileUploadList` from `@optiaxiom/react/unstable`. Local `{file, status, url?}` state shows the file immediately and flips to `complete` / `error` once the host upload resolves. Single file per field; the resolved URL is written into form data at the field's path.
- **`onUpload` on `ProteusDocumentContext`** — `(file: File) => Promise<string>`. Plumbed through `ProteusDocumentShell` / `ProteusDocumentRenderer` props. The proteus package itself does no I/O.
- **Structured `message` payload** — `ProteusEventHandler.message` widens from `string` to `string | { parts: [{type:'text', content}], files?: string[] }`. Lets file URLs travel as a typed list on a submit event instead of being joined into the text.
- **JSON-mode resolver tweaks** in `resolveProteusValue` — `Map` filters out `Show`-falsy items; the resolver now recurses into plain objects/arrays so structured payloads resolve composably with the same DSL as the renderer.
- **Schema generator** updates for the new element + structured-message anyOf branch.
- **Storybook story** (`AskAgentInputWithFileParam`) demonstrating the full flow with a mocked `onUpload`.
- Changeset: `@optiaxiom/proteus` patch.

## Test plan

- [x] `pnpm tsc --noEmit` clean across `packages/proteus` and `apps/storybook`
- [x] `pnpm build` clean for `packages/react` and `packages/proteus`
- [x] In storybook: ProteusDocumentRenderer → "Ask Agent Input With File Param" — drop a file, watch the spinner flip to file row, click "Run agent", confirm `onMessage` action log shows `{files, parts}`