### PR TITLE
fix(proteus): fix required on ProteusFileUpload

### DIFF
--- a/.changeset/seven-kings-obey.md
+++ b/.changeset/seven-kings-obey.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": patch
+---
+
+fixes ProteusFileUploads required tag

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -537,7 +537,7 @@ export const AskAgentInput: Story = {
                     children: true,
                     when: { "==": [{ $type: "MapIndex" }, 0] },
                   },
-                  name: "value",
+                  name: { $type: "Value", path: "name" },
                   placeholder: { $type: "Value", path: "placeholder" },
                   required: { $type: "Value", path: "required" },
                 },
@@ -558,7 +558,7 @@ export const AskAgentInput: Story = {
                   path: "name",
                 },
                 description: { $type: "Value", path: "description" },
-                name: "value",
+                name: { $type: "Value", path: "name" },
                 value: "Yes",
               },
               when: {
@@ -692,7 +692,7 @@ export const AskAgentInputWithFileParam: Story = {
                 $type: "Field",
                 children: {
                   $type: "Input",
-                  name: "value",
+                  name: { $type: "Value", path: "name" },
                   placeholder: { $type: "Value", path: "placeholder" },
                   required: { $type: "Value", path: "required" },
                 },
@@ -709,7 +709,7 @@ export const AskAgentInputWithFileParam: Story = {
                 children: {
                   $type: "FileUpload",
                   accept: ["application/pdf", "text/*"],
-                  name: "value",
+                  name: { $type: "Value", path: "name" },
                   required: { $type: "Value", path: "required" },
                 },
                 description: { $type: "Value", path: "description" },

--- a/packages/proteus/src/hooks/index.ts
+++ b/packages/proteus/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./useEffectEvent";
+export * from "./useObserveValue";

--- a/packages/proteus/src/hooks/useObserveValue.ts
+++ b/packages/proteus/src/hooks/useObserveValue.ts
@@ -1,0 +1,38 @@
+import { type RefObject, useEffect } from "react";
+
+export const useObserveValue = (
+  inputRef: RefObject<HTMLInputElement | HTMLSelectElement>,
+  setValue?: (value: string) => void,
+) => {
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) {
+      return;
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(
+      input.constructor.prototype,
+      "value",
+    );
+    Object.defineProperty(input, "value", {
+      configurable: true,
+      enumerable: true,
+      get: function () {
+        return descriptor?.get?.call(input);
+      },
+      set: function (value) {
+        descriptor?.set?.call(input, value);
+        setValue?.(value);
+      },
+    });
+  }, [inputRef, setValue]);
+
+  return (value: string) => {
+    if (!inputRef.current) {
+      return;
+    }
+
+    inputRef.current.value = value;
+    inputRef.current.dispatchEvent(new Event("change", { bubbles: true }));
+  };
+};

--- a/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
+++ b/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
@@ -5,9 +5,11 @@ import {
   FileUploadList,
   type FileUploadListProps,
   FileUploadTrigger,
+  VisuallyHidden,
 } from "@optiaxiom/react/unstable";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
+import { useObserveValue } from "../hooks";
 import { useProteusDocumentContext } from "../proteus-document/ProteusDocumentContext";
 import { useProteusDocumentPathContext } from "../proteus-document/ProteusDocumentPathContext";
 
@@ -31,7 +33,11 @@ export type ProteusFileUploadProps = {
 
 type Item = FileUploadListProps["items"][number];
 
-export function ProteusFileUpload({ accept, name }: ProteusFileUploadProps) {
+export function ProteusFileUpload({
+  accept,
+  name,
+  required,
+}: ProteusFileUploadProps) {
   const { onDataChange, onUpload, readOnly } = useProteusDocumentContext(
     "@optiaxiom/proteus/ProteusFileUpload",
   );
@@ -39,7 +45,9 @@ export function ProteusFileUpload({ accept, name }: ProteusFileUploadProps) {
     "@optiaxiom/proteus/ProteusFileUpload",
   );
 
+  const inputRef = useRef<HTMLInputElement>(null);
   const [item, setItem] = useState<Item | null>(null);
+  const forceValueChange = useObserveValue(inputRef);
 
   const writeUrl = useCallback(
     (url: null | string) => {
@@ -57,25 +65,34 @@ export function ProteusFileUpload({ accept, name }: ProteusFileUploadProps) {
       const file = incoming[0];
       setItem({ file, status: "uploading" });
       writeUrl(null);
+      if (inputRef.current) {
+        forceValueChange("");
+      }
       try {
         const url = await onUpload(file);
         setItem((curr) =>
           curr?.file === file ? { file, status: "complete" } : curr,
         );
         writeUrl(url);
+        if (inputRef.current) {
+          forceValueChange("1");
+        }
       } catch {
         setItem((curr) =>
           curr?.file === file ? { file, status: "error" } : curr,
         );
       }
     },
-    [onUpload, readOnly, writeUrl],
+    [forceValueChange, onUpload, readOnly, writeUrl],
   );
 
   const handleRemove = useCallback(() => {
     setItem(null);
     writeUrl(null);
-  }, [writeUrl]);
+    if (inputRef.current) {
+      forceValueChange("");
+    }
+  }, [forceValueChange, writeUrl]);
 
   return (
     <FileUpload
@@ -83,6 +100,15 @@ export function ProteusFileUpload({ accept, name }: ProteusFileUploadProps) {
       disabled={!onUpload || readOnly}
       onFilesDrop={handleFilesDrop}
     >
+      <VisuallyHidden asChild>
+        <input
+          aria-hidden
+          name={name}
+          ref={inputRef}
+          required={required}
+          tabIndex={-1}
+        />
+      </VisuallyHidden>
       {item ? (
         <Flex flexDirection="column" gap="8">
           <FileUploadList items={[item]} onRemove={handleRemove} />


### PR DESCRIPTION
## Problem

`ProteusFileUpload` declared a `required` prop but never read it. The surrounding form's submit button stayed enabled even when a required file param was unfilled, and the structured-message resolver dropped the empty file from `files`, leaving the host with no signal a required input was missing.

## Fix

- `ProteusFileUpload` renders a `VisuallyHidden` controlled `<input>` whose value reflects upload completion and carries the `required` attribute, so native `checkValidity()` has something to gate on.
- `ProteusDocumentShell` re-runs `checkValidity()` whenever `data` changes, so submit re-enables once the uploaded URL is written into form data.