### PR TITLE
feat(proteus): return file upload metadata object instead of URL string

### DIFF
--- a/.changeset/dark-crabs-repeat.md
+++ b/.changeset/dark-crabs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": patch
+---
+
+retuns file upload metadata object instead of string

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -780,10 +780,10 @@ export const AskAgentInputWithFileParam: Story = {
       await new Promise((resolve) => setTimeout(resolve, 1500));
       const fileId = Math.random().toString(36).slice(2, 10);
       return {
-        name: file.name,
-        url: `https://opal-localdev.optimizely.com/file-server/files/${fileId}/${encodeURIComponent(
+        link: `https://opal-localdev.optimizely.com/file-server/files/${fileId}/${encodeURIComponent(
           file.name,
         )}?signed=mock`,
+        name: file.name,
       };
     },
   },

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -779,9 +779,12 @@ export const AskAgentInputWithFileParam: Story = {
       action("onUpload (mocked)")(file);
       await new Promise((resolve) => setTimeout(resolve, 1500));
       const fileId = Math.random().toString(36).slice(2, 10);
-      return `https://opal-localdev.optimizely.com/file-server/files/${fileId}/${encodeURIComponent(
-        file.name,
-      )}?signed=mock`;
+      return {
+        name: file.name,
+        url: `https://opal-localdev.optimizely.com/file-server/files/${fileId}/${encodeURIComponent(
+          file.name,
+        )}?signed=mock`,
+      };
     },
   },
   render: function AskAgentInputWithFileParamRender(args) {

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -740,7 +740,7 @@ export const AskAgentInputWithFileParam: Story = {
                 $type: "Field",
                 children: {
                   $type: "Input",
-                  name: { $type: "Value", path: "name" },
+                  name: "value",
                   placeholder: { $type: "Value", path: "placeholder" },
                   required: { $type: "Value", path: "required" },
                 },
@@ -757,7 +757,7 @@ export const AskAgentInputWithFileParam: Story = {
                 children: {
                   $type: "FileUpload",
                   accept: ["application/pdf", "text/*"],
-                  name: { $type: "Value", path: "name" },
+                  name: "value",
                   required: { $type: "Value", path: "required" },
                 },
                 description: { $type: "Value", path: "description" },

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -812,15 +812,28 @@ function generateSpec(additionalProperties = false) {
         ProteusStructuredMessage: {
           ...(additionalProperties ? {} : { additionalProperties: false }),
           description:
-            "Structured message payload that lets file URLs travel as a typed list alongside the text parts, instead of being joined into the text.",
+            "Structured message payload that lets file metadata travel as a typed list alongside the text parts, instead of being joined into the text.",
           properties: {
             files: {
               anyOf: [
-                { items: { type: "string" }, type: "array" },
+                {
+                  items: {
+                    ...(additionalProperties
+                      ? {}
+                      : { additionalProperties: false }),
+                    properties: {
+                      name: { type: "string" },
+                      url: { type: "string" },
+                    },
+                    required: ["name", "url"],
+                    type: "object",
+                  },
+                  type: "array",
+                },
                 { $ref: "#/definitions/ProteusExpression" },
               ],
               description:
-                "List of file URLs (typically signed URLs from a host upload).",
+                "List of uploaded file metadata objects (typically the host's onUpload return value).",
             },
             parts: {
               items: {

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -818,14 +818,11 @@ function generateSpec(additionalProperties = false) {
               anyOf: [
                 {
                   items: {
-                    ...(additionalProperties
-                      ? {}
-                      : { additionalProperties: false }),
                     properties: {
+                      link: { type: "string" },
                       name: { type: "string" },
-                      url: { type: "string" },
                     },
-                    required: ["name", "url"],
+                    required: ["name", "link"],
                     type: "object",
                   },
                   type: "array",
@@ -833,7 +830,7 @@ function generateSpec(additionalProperties = false) {
                 { $ref: "#/definitions/ProteusExpression" },
               ],
               description:
-                "List of uploaded file metadata objects (typically the host's onUpload return value).",
+                "List of uploaded file metadata objects (typically the host's onUpload return value). Hosts may attach additional fields beyond `name` and `link`.",
             },
             parts: {
               items: {

--- a/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
+++ b/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
@@ -5,8 +5,9 @@ import { createContext } from "@radix-ui/react-context";
 import type { ProteusEventHandler } from "./schemas";
 
 export type FileUploadMetadata = {
+  [key: string]: unknown;
+  link: string;
   name: string;
-  url: string;
 };
 
 export type UploadFile = (file: File) => Promise<FileUploadMetadata>;

--- a/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
+++ b/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
@@ -5,12 +5,13 @@ import { createContext } from "@radix-ui/react-context";
 import type { ProteusEventHandler } from "./schemas";
 
 export type FileUploadMetadata = {
-  [key: string]: unknown;
   link: string;
   name: string;
 };
 
-export type UploadFile = (file: File) => Promise<FileUploadMetadata>;
+export type UploadFile<F extends FileUploadMetadata = FileUploadMetadata> = (
+  file: File,
+) => Promise<F>;
 
 export type UseResource = (resource: string) => {
   data: undefined | { mimeType: string; text: string };

--- a/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
+++ b/packages/proteus/src/proteus-document/ProteusDocumentContext.ts
@@ -4,7 +4,12 @@ import { createContext } from "@radix-ui/react-context";
 
 import type { ProteusEventHandler } from "./schemas";
 
-export type UploadFile = (file: File) => Promise<string>;
+export type FileUploadMetadata = {
+  name: string;
+  url: string;
+};
+
+export type UploadFile = (file: File) => Promise<FileUploadMetadata>;
 
 export type UseResource = (resource: string) => {
   data: undefined | { mimeType: string; text: string };

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -75,7 +75,7 @@ export type ProteusDocumentShellProps = Pick<
   onTrack?: (event: string, properties: Record<string, string>) => void;
   /**
    * Async upload callback used by FileUpload elements. Receives a File and
-   * resolves to a URL string the document writes into form data.
+   * resolves to a metadata object the document writes into form data.
    */
   onUpload?: UploadFile;
   /**

--- a/packages/proteus/src/proteus-document/index.ts
+++ b/packages/proteus/src/proteus-document/index.ts
@@ -1,7 +1,4 @@
-export type {
-  FileUploadMetadata,
-  UploadFile,
-} from "./ProteusDocumentContext";
+export type { FileUploadMetadata, UploadFile } from "./ProteusDocumentContext";
 export * from "./ProteusDocumentRenderer";
 export * from "./ProteusDocumentShell";
 export { safeParseDocument } from "./schemas";

--- a/packages/proteus/src/proteus-document/index.ts
+++ b/packages/proteus/src/proteus-document/index.ts
@@ -1,4 +1,7 @@
-export type { UploadFile } from "./ProteusDocumentContext";
+export type {
+  FileUploadMetadata,
+  UploadFile,
+} from "./ProteusDocumentContext";
 export * from "./ProteusDocumentRenderer";
 export * from "./ProteusDocumentShell";
 export { safeParseDocument } from "./schemas";

--- a/packages/proteus/src/proteus-document/schemas.ts
+++ b/packages/proteus/src/proteus-document/schemas.ts
@@ -34,6 +34,7 @@ import type { ProteusQuestionProps } from "../proteus-question/ProteusQuestion";
 import type { ProteusSelectProps } from "../proteus-select/ProteusSelect";
 import type { ProteusShowProps } from "../proteus-show/ProteusShow";
 import type { ProteusValueProps } from "../proteus-value/ProteusValue";
+import type { FileUploadMetadata } from "./ProteusDocumentContext";
 import type { ProteusDocumentShellProps } from "./ProteusDocumentShell";
 
 import proteusDocumentSpec from "../schema/runtime-schema.json";
@@ -86,7 +87,7 @@ export type ProteusEventHandler =
   | { message: string | StructuredMessage };
 
 export type StructuredMessage = {
-  files?: string[];
+  files?: FileUploadMetadata[];
   parts: Array<{ content: string; type: "text" }>;
 };
 

--- a/packages/proteus/src/proteus-document/schemas.ts
+++ b/packages/proteus/src/proteus-document/schemas.ts
@@ -86,8 +86,10 @@ export type ProteusEventHandler =
   | { interaction: string; params?: Record<string, unknown> }
   | { message: string | StructuredMessage };
 
-export type StructuredMessage = {
-  files?: FileUploadMetadata[];
+export type StructuredMessage<
+  F extends FileUploadMetadata = FileUploadMetadata,
+> = {
+  files?: F[];
   parts: Array<{ content: string; type: "text" }>;
 };
 

--- a/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
+++ b/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
@@ -10,7 +10,10 @@ import {
 import { useCallback, useRef, useState } from "react";
 
 import { useObserveValue } from "../hooks";
-import { useProteusDocumentContext } from "../proteus-document/ProteusDocumentContext";
+import {
+  type FileUploadMetadata,
+  useProteusDocumentContext,
+} from "../proteus-document/ProteusDocumentContext";
 import { useProteusDocumentPathContext } from "../proteus-document/ProteusDocumentPathContext";
 
 export type ProteusFileUploadProps = {
@@ -21,8 +24,9 @@ export type ProteusFileUploadProps = {
    */
   accept?: string[];
   /**
-   * The name of the form control element. The resolved URL is written at
-   * `parentPath/name` in form data once the host's `onUpload` resolves.
+   * The name of the form control element. The resolved metadata object is
+   * written at `parentPath/name` in form data once the host's `onUpload`
+   * resolves.
    */
   name?: string;
   /**
@@ -49,10 +53,10 @@ export function ProteusFileUpload({
   const [item, setItem] = useState<Item | null>(null);
   const forceValueChange = useObserveValue(inputRef);
 
-  const writeUrl = useCallback(
-    (url: null | string) => {
+  const writeValue = useCallback(
+    (value: FileUploadMetadata | null) => {
       if (!name) return;
-      onDataChange?.(`${parentPath}/${name}`, url);
+      onDataChange?.(`${parentPath}/${name}`, value);
     },
     [name, onDataChange, parentPath],
   );
@@ -64,16 +68,16 @@ export function ProteusFileUpload({
       }
       const file = incoming[0];
       setItem({ file, status: "uploading" });
-      writeUrl(null);
+      writeValue(null);
       if (inputRef.current) {
         forceValueChange("");
       }
       try {
-        const url = await onUpload(file);
+        const metadata = await onUpload(file);
         setItem((curr) =>
           curr?.file === file ? { file, status: "complete" } : curr,
         );
-        writeUrl(url);
+        writeValue(metadata);
         if (inputRef.current) {
           forceValueChange("1");
         }
@@ -83,16 +87,16 @@ export function ProteusFileUpload({
         );
       }
     },
-    [forceValueChange, onUpload, readOnly, writeUrl],
+    [forceValueChange, onUpload, readOnly, writeValue],
   );
 
   const handleRemove = useCallback(() => {
     setItem(null);
-    writeUrl(null);
+    writeValue(null);
     if (inputRef.current) {
       forceValueChange("");
     }
-  }, [forceValueChange, writeUrl]);
+  }, [forceValueChange, writeValue]);
 
   return (
     <FileUpload

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -1446,14 +1446,25 @@
     },
     "ProteusStructuredMessage": {
       "additionalProperties": false,
-      "description": "Structured message payload that lets file URLs travel as a typed list alongside the text parts, instead of being joined into the text.",
+      "description": "Structured message payload that lets file metadata travel as a typed list alongside the text parts, instead of being joined into the text.",
       "properties": {
         "files": {
           "anyOf": [
-            { "items": { "type": "string" }, "type": "array" },
+            {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "name": { "type": "string" },
+                  "url": { "type": "string" }
+                },
+                "required": ["name", "url"],
+                "type": "object"
+              },
+              "type": "array"
+            },
             { "$ref": "#/definitions/ProteusExpression" }
           ],
-          "description": "List of file URLs (typically signed URLs from a host upload)."
+          "description": "List of uploaded file metadata objects (typically the host's onUpload return value)."
         },
         "parts": {
           "items": {

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -1452,19 +1452,18 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": false,
                 "properties": {
-                  "name": { "type": "string" },
-                  "url": { "type": "string" }
+                  "link": { "type": "string" },
+                  "name": { "type": "string" }
                 },
-                "required": ["name", "url"],
+                "required": ["name", "link"],
                 "type": "object"
               },
               "type": "array"
             },
             { "$ref": "#/definitions/ProteusExpression" }
           ],
-          "description": "List of uploaded file metadata objects (typically the host's onUpload return value)."
+          "description": "List of uploaded file metadata objects (typically the host's onUpload return value). Hosts may attach additional fields beyond `name` and `link`."
         },
         "parts": {
           "items": {

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -1437,17 +1437,17 @@
             {
               "items": {
                 "properties": {
-                  "name": { "type": "string" },
-                  "url": { "type": "string" }
+                  "link": { "type": "string" },
+                  "name": { "type": "string" }
                 },
-                "required": ["name", "url"],
+                "required": ["name", "link"],
                 "type": "object"
               },
               "type": "array"
             },
             { "$ref": "#/definitions/ProteusExpression" }
           ],
-          "description": "List of uploaded file metadata objects (typically the host's onUpload return value)."
+          "description": "List of uploaded file metadata objects (typically the host's onUpload return value). Hosts may attach additional fields beyond `name` and `link`."
         },
         "parts": {
           "items": {

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -1430,14 +1430,24 @@
       "description": "A Proteus node can be a string, number, boolean, null, a single element, or an array of these types (similar to ReactNode)"
     },
     "ProteusStructuredMessage": {
-      "description": "Structured message payload that lets file URLs travel as a typed list alongside the text parts, instead of being joined into the text.",
+      "description": "Structured message payload that lets file metadata travel as a typed list alongside the text parts, instead of being joined into the text.",
       "properties": {
         "files": {
           "anyOf": [
-            { "items": { "type": "string" }, "type": "array" },
+            {
+              "items": {
+                "properties": {
+                  "name": { "type": "string" },
+                  "url": { "type": "string" }
+                },
+                "required": ["name", "url"],
+                "type": "object"
+              },
+              "type": "array"
+            },
             { "$ref": "#/definitions/ProteusExpression" }
           ],
-          "description": "List of file URLs (typically signed URLs from a host upload)."
+          "description": "List of uploaded file metadata objects (typically the host's onUpload return value)."
         },
         "parts": {
           "items": {


### PR DESCRIPTION
Change `UploadFile` to return `Promise<FileUploadMetadata>` (`{ name, link }`) instead of a URL string, and make both `UploadFile<F>` and `StructuredMessage<F>` generic with that base as the default. Hosts can narrow the metadata to their own richer type (e.g. `<UploadFile<FileMetaData>>`) and `message.files` will be typed accordingly without proteus needing to know the consumer's schema.

**Breaking** for hosts implementing `onUpload`.