### PR TITLE
Add manual trigger

### DIFF
--- a/.changeset/manual-suggestion-trigger.md
+++ b/.changeset/manual-suggestion-trigger.md
@@ -3,4 +3,4 @@
 "@optiaxiom/react": patch
 ---
 
-Add `manualSuggestion` flag to `unstable_SurfaceProvider`. When set, `Input` and `Textarea` skip the keystroke-debounced `track({ changed })` and instead render an Opal trigger button (pulses while pending) that fires `track({ changed, value })` on click. The next value-suggestion that arrives is auto-accepted silently. After accept the button hides until the value diverges again.
+Add `manualSuggestion` flag to `unstable_SurfaceProvider`. When set, `Input` and `Textarea` skip the keystroke-debounced `track({ changed })` and instead render an Opal trigger button that fires `track({ requested, value })` on click and shows a loading spinner while pending. The next value-suggestion that arrives is auto-accepted silently.

--- a/.changeset/manual-suggestion-trigger.md
+++ b/.changeset/manual-suggestion-trigger.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/globals": patch
+"@optiaxiom/react": patch
+---
+
+Add `manualSuggestion` flag to `unstable_SurfaceProvider`. When set, `Input` and `Textarea` skip the keystroke-debounced `track({ changed })` and instead render an Opal trigger button (pulses while pending) that fires `track({ changed, value })` on click. The next value-suggestion that arrives is auto-accepted silently. After accept the button hides until the value diverges again.

--- a/apps/storybook/src/components/Input.stories.tsx
+++ b/apps/storybook/src/components/Input.stories.tsx
@@ -190,3 +190,88 @@ export const WithSuggestion: Story = {
     );
   },
 };
+
+export const WithManualSuggestion: Story = {
+  render: function WithManualSuggestion() {
+    const [value, setValue] = useState("");
+    const [suggestions, setSuggestions] = useState<
+      Array<{
+        createdAt: string;
+        id: string;
+        page: string;
+        reason: string;
+        surface: string;
+        type: "value";
+        value: string;
+      }>
+    >([]);
+
+    return (
+      <SurfaceProvider
+        accept={(suggestionId: string) => {
+          action("accept")(suggestionId);
+          setValue(
+            String(suggestions.find((s) => s.id === suggestionId)?.value),
+          );
+          setSuggestions((prev) => prev.filter((s) => s.id !== suggestionId));
+        }}
+        executeTool={action("execute")}
+        manualSuggestion
+        metadata={{}}
+        name="email"
+        pageViewId=""
+        path="product<storybook>/page<demo>/resource<form>/property<email>"
+        reject={(suggestionId: string) => {
+          action("reject")(suggestionId);
+          setSuggestions((prev) => prev.filter((s) => s.id !== suggestionId));
+        }}
+        suggestionAlert={{ register: () => () => {}, registered: true }}
+        suggestionPopover={{ register: () => () => {}, registered: false }}
+        suggestions={suggestions}
+        track={(interaction) => {
+          action("track")(interaction);
+          if (interaction.name === "changed") {
+            setTimeout(() => {
+              setSuggestions([
+                {
+                  createdAt: new Date().toISOString(),
+                  id: `sug-${Date.now()}`,
+                  page: "product<storybook>/page<demo>",
+                  reason: "Based on your previous entries",
+                  surface: "property<email>",
+                  type: "value",
+                  value: "john.doe@example.com",
+                },
+              ]);
+            }, 1200);
+          }
+        }}
+        type="property"
+        value={value}
+      >
+        <Group alignItems="start" flexDirection="column" gap="16">
+          <Input
+            onValueChange={setValue}
+            placeholder="Enter email, then click the Opal icon"
+            value={value}
+          />
+
+          <Group gap="8">
+            <Text fontSize="sm">Value: {value || "(empty)"}</Text>
+          </Group>
+
+          <Button
+            disabled={value === ""}
+            onClick={() => {
+              setValue("");
+              setSuggestions([]);
+            }}
+            size="sm"
+          >
+            Reset
+          </Button>
+        </Group>
+      </SurfaceProvider>
+    );
+  },
+};

--- a/apps/storybook/src/components/Input.stories.tsx
+++ b/apps/storybook/src/components/Input.stories.tsx
@@ -230,7 +230,7 @@ export const WithManualSuggestion: Story = {
         suggestions={suggestions}
         track={(interaction) => {
           action("track")(interaction);
-          if (interaction.name === "changed") {
+          if (interaction.name === "requested") {
             setTimeout(() => {
               setSuggestions([
                 {

--- a/apps/storybook/src/components/Textarea.stories.tsx
+++ b/apps/storybook/src/components/Textarea.stories.tsx
@@ -206,7 +206,7 @@ export const WithManualSuggestion: Story = {
         suggestions={suggestions}
         track={(interaction) => {
           action("track")(interaction);
-          if (interaction.name === "changed") {
+          if (interaction.name === "requested") {
             setTimeout(() => {
               setSuggestions([
                 {

--- a/apps/storybook/src/components/Textarea.stories.tsx
+++ b/apps/storybook/src/components/Textarea.stories.tsx
@@ -166,3 +166,89 @@ export const WithSuggestion: Story = {
     );
   },
 };
+
+export const WithManualSuggestion: Story = {
+  render: function WithManualSuggestion() {
+    const [value, setValue] = useState("");
+    const [suggestions, setSuggestions] = useState<
+      Array<{
+        createdAt: string;
+        id: string;
+        page: string;
+        reason: string;
+        surface: string;
+        type: "value";
+        value: string;
+      }>
+    >([]);
+
+    return (
+      <SurfaceProvider
+        accept={(suggestionId: string) => {
+          action("accept")(suggestionId);
+          setValue(
+            String(suggestions.find((s) => s.id === suggestionId)?.value),
+          );
+          setSuggestions((prev) => prev.filter((s) => s.id !== suggestionId));
+        }}
+        executeTool={action("execute")}
+        manualSuggestion
+        metadata={{}}
+        name="description"
+        pageViewId=""
+        path="product<storybook>/page<demo>/resource<form>/property<description>"
+        reject={(suggestionId: string) => {
+          action("reject")(suggestionId);
+          setSuggestions((prev) => prev.filter((s) => s.id !== suggestionId));
+        }}
+        suggestionAlert={{ register: () => () => {}, registered: true }}
+        suggestionPopover={{ register: () => () => {}, registered: false }}
+        suggestions={suggestions}
+        track={(interaction) => {
+          action("track")(interaction);
+          if (interaction.name === "changed") {
+            setTimeout(() => {
+              setSuggestions([
+                {
+                  createdAt: new Date().toISOString(),
+                  id: `sug-${Date.now()}`,
+                  page: "product<storybook>/page<demo>",
+                  reason: "Based on similar entries",
+                  surface: "property<description>",
+                  type: "value",
+                  value:
+                    "This feature will improve user experience by providing real-time feedback and reducing the number of steps required to complete the workflow.",
+                },
+              ]);
+            }, 1200);
+          }
+        }}
+        type="property"
+        value={value}
+      >
+        <Group alignItems="start" flexDirection="column" gap="16">
+          <Textarea
+            onValueChange={setValue}
+            placeholder="Enter description, then click the Opal icon"
+            value={value}
+          />
+
+          <Group gap="8">
+            <Text fontSize="sm">Value: {value || "(empty)"}</Text>
+          </Group>
+
+          <Button
+            disabled={value === ""}
+            onClick={() => {
+              setValue("");
+              setSuggestions([]);
+            }}
+            size="sm"
+          >
+            Reset
+          </Button>
+        </Group>
+      </SurfaceProvider>
+    );
+  },
+};

--- a/packages/globals/src/surface-context.ts
+++ b/packages/globals/src/surface-context.ts
@@ -66,6 +66,7 @@ type SurfaceInteraction = { id?: string } & (
   | { name: "focused" }
   | { name: "invoked" }
   | { name: "removed"; value: unknown }
+  | { name: "requested"; value: unknown }
   | { name: "viewed" }
 );
 

--- a/packages/globals/src/surface-context.ts
+++ b/packages/globals/src/surface-context.ts
@@ -37,6 +37,7 @@ type Surface = {
 type SurfaceContextValue<V = unknown> = {
   accept: (suggestionId: string) => void;
   executeTool: (name: string, parameters: unknown) => Promise<void> | void;
+  manualSuggestion?: boolean;
   metadata: Record<string, Omit<Surface, "name">>;
   name: string;
   pageViewId: string | undefined;

--- a/packages/react/src/input/InputControl.tsx
+++ b/packages/react/src/input/InputControl.tsx
@@ -133,7 +133,9 @@ export const InputControl = forwardRef<
               const newValue = event.target.value;
               onValueChange?.(newValue);
 
-              debouncedTrack?.(newValue);
+              if (!surface?.manualSuggestion) {
+                debouncedTrack?.(newValue);
+              }
             }
           }}
           onFocus={(event) => {

--- a/packages/react/src/suggestion/SuggestionAutoPopover.tsx
+++ b/packages/react/src/suggestion/SuggestionAutoPopover.tsx
@@ -1,0 +1,77 @@
+import { forwardRef, useEffect } from "react";
+
+import { Avatar } from "../avatar";
+import { Button, type ButtonProps } from "../button";
+import { Heading } from "../heading";
+import { useEffectEvent } from "../hooks";
+import { IconCheck } from "../icons/IconCheck";
+import { Popover, PopoverContent, PopoverTrigger } from "../popover";
+import { Separator } from "../separator";
+import { useSurface } from "../surface";
+import { useSuggestions } from "../surface/internals";
+import { Text } from "../text";
+
+export type SuggestionAutoPopoverProps = ButtonProps<typeof PopoverTrigger>;
+
+export const SuggestionAutoPopover = forwardRef<
+  HTMLButtonElement,
+  SuggestionAutoPopoverProps
+>((props, ref) => {
+  const surface = useSurface("property");
+
+  const register = useEffectEvent(
+    surface?.suggestionPopover.register ?? (() => {}),
+  );
+  useEffect(() => {
+    return register();
+  }, []);
+
+  const suggestions = useSuggestions("property", "value");
+  const suggestion = suggestions?.find((s) => s.value !== surface?.value);
+
+  if (!suggestion || !surface) {
+    return null;
+  }
+
+  const text = surface.renderSuggestionValue
+    ? surface.renderSuggestionValue(suggestion.value)
+    : String(suggestion.value);
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        appearance="subtle"
+        aria-label="Opal suggestion"
+        icon={<Avatar fallback="opal" size="2xs" />}
+        ref={ref}
+        size="sm"
+        {...props}
+      />
+      <PopoverContent aria-label="Suggestion" fontSize="sm" gap="4" p="12">
+        <Text>{text}</Text>
+        {suggestion.reason && (
+          <>
+            <Separator my="8" />
+            <Heading fontSize="sm" level="4">
+              Why this was suggested
+            </Heading>
+            <Text color="fg.secondary">{suggestion.reason}</Text>
+          </>
+        )}
+        <Separator my="8" />
+        <Button
+          icon={<IconCheck />}
+          justifyContent="center"
+          onClick={() => {
+            surface.accept(suggestion.id);
+          }}
+          size="sm"
+        >
+          Accept
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+});
+
+SuggestionAutoPopover.displayName = "@optiaxiom/react/SuggestionAutoPopover";

--- a/packages/react/src/suggestion/SuggestionManualTrigger.tsx
+++ b/packages/react/src/suggestion/SuggestionManualTrigger.tsx
@@ -24,7 +24,6 @@ export const SuggestionManualTrigger = forwardRef<
   }, []);
 
   const [pending, setPending] = useState(false);
-  const [acceptedValue, setAcceptedValue] = useState<unknown>(undefined);
   const suggestions = useSuggestions("property", "value");
   const suggestion = suggestions?.find((s) => s.value !== surface?.value);
 
@@ -32,7 +31,6 @@ export const SuggestionManualTrigger = forwardRef<
     if (!suggestion) {
       return;
     }
-    setAcceptedValue(suggestion.value);
     surface?.accept(suggestion.id);
     setPending(false);
   });
@@ -40,7 +38,7 @@ export const SuggestionManualTrigger = forwardRef<
     acceptSuggestion();
   }, [suggestion?.id]);
 
-  if (!surface || surface.value === acceptedValue) {
+  if (!surface) {
     return null;
   }
 
@@ -58,7 +56,7 @@ export const SuggestionManualTrigger = forwardRef<
       }
       onClick={() => {
         setPending(true);
-        surface.track({ name: "changed", value: surface.value });
+        surface.track({ name: "requested", value: surface.value });
       }}
       ref={ref}
       size="sm"

--- a/packages/react/src/suggestion/SuggestionManualTrigger.tsx
+++ b/packages/react/src/suggestion/SuggestionManualTrigger.tsx
@@ -25,7 +25,7 @@ export const SuggestionManualTrigger = forwardRef<
 
   const [pending, setPending] = useState(false);
   const suggestions = useSuggestions("property", "value");
-  const suggestion = suggestions?.find((s) => s.value !== surface?.value);
+  const suggestion = suggestions?.[0];
 
   const acceptSuggestion = useEffectEvent(() => {
     if (!suggestion) {
@@ -47,13 +47,8 @@ export const SuggestionManualTrigger = forwardRef<
       appearance="subtle"
       aria-label="Opal suggestion"
       disabled={pending}
-      icon={
-        <Avatar
-          animation={pending ? "pulse" : undefined}
-          fallback="opal"
-          size="2xs"
-        />
-      }
+      icon={<Avatar fallback="opal" size="2xs" />}
+      loading={pending}
       onClick={() => {
         setPending(true);
         surface.track({ name: "requested", value: surface.value });

--- a/packages/react/src/suggestion/SuggestionManualTrigger.tsx
+++ b/packages/react/src/suggestion/SuggestionManualTrigger.tsx
@@ -1,0 +1,71 @@
+import { forwardRef, useEffect, useState } from "react";
+
+import type { PopoverTrigger } from "../popover";
+
+import { Avatar } from "../avatar";
+import { Button, type ButtonProps } from "../button";
+import { useEffectEvent } from "../hooks";
+import { useSurface } from "../surface";
+import { useSuggestions } from "../surface/internals";
+
+export type SuggestionManualTriggerProps = ButtonProps<typeof PopoverTrigger>;
+
+export const SuggestionManualTrigger = forwardRef<
+  HTMLButtonElement,
+  SuggestionManualTriggerProps
+>((props, ref) => {
+  const surface = useSurface("property");
+
+  const register = useEffectEvent(
+    surface?.suggestionPopover.register ?? (() => {}),
+  );
+  useEffect(() => {
+    return register();
+  }, []);
+
+  const [pending, setPending] = useState(false);
+  const [acceptedValue, setAcceptedValue] = useState<unknown>(undefined);
+  const suggestions = useSuggestions("property", "value");
+  const suggestion = suggestions?.find((s) => s.value !== surface?.value);
+
+  const acceptSuggestion = useEffectEvent(() => {
+    if (!suggestion) {
+      return;
+    }
+    setAcceptedValue(suggestion.value);
+    surface?.accept(suggestion.id);
+    setPending(false);
+  });
+  useEffect(() => {
+    acceptSuggestion();
+  }, [suggestion?.id]);
+
+  if (!surface || surface.value === acceptedValue) {
+    return null;
+  }
+
+  return (
+    <Button
+      appearance="subtle"
+      aria-label="Opal suggestion"
+      disabled={pending}
+      icon={
+        <Avatar
+          animation={pending ? "pulse" : undefined}
+          fallback="opal"
+          size="2xs"
+        />
+      }
+      onClick={() => {
+        setPending(true);
+        surface.track({ name: "changed", value: surface.value });
+      }}
+      ref={ref}
+      size="sm"
+      {...props}
+    />
+  );
+});
+
+SuggestionManualTrigger.displayName =
+  "@optiaxiom/react/SuggestionManualTrigger";

--- a/packages/react/src/suggestion/SuggestionPopover.tsx
+++ b/packages/react/src/suggestion/SuggestionPopover.tsx
@@ -1,15 +1,10 @@
-import { forwardRef, useEffect } from "react";
+import { forwardRef } from "react";
 
-import { Avatar } from "../avatar";
-import { Button, type ButtonProps } from "../button";
-import { Heading } from "../heading";
-import { useEffectEvent } from "../hooks";
-import { IconCheck } from "../icons/IconCheck";
-import { Popover, PopoverContent, PopoverTrigger } from "../popover";
-import { Separator } from "../separator";
+import { type ButtonProps } from "../button";
+import { type PopoverTrigger } from "../popover";
 import { useSurface } from "../surface";
-import { useSuggestions } from "../surface/internals";
-import { Text } from "../text";
+import { SuggestionAutoPopover } from "./SuggestionAutoPopover";
+import { SuggestionManualTrigger } from "./SuggestionManualTrigger";
 
 export type SuggestionPopoverProps = ButtonProps<typeof PopoverTrigger>;
 
@@ -21,60 +16,10 @@ export const SuggestionPopover = forwardRef<
   SuggestionPopoverProps
 >((props, ref) => {
   const surface = useSurface("property");
-
-  const register = useEffectEvent(
-    surface?.suggestionPopover.register ?? (() => {}),
-  );
-  useEffect(() => {
-    return register();
-  }, []);
-
-  const suggestions = useSuggestions("property", "value");
-  const suggestion = suggestions?.find((s) => s.value !== surface?.value);
-
-  // Return null if no suggestions or current value matches suggestion
-  if (!suggestion || !surface) {
-    return null;
-  }
-
-  const text = surface.renderSuggestionValue
-    ? surface.renderSuggestionValue(suggestion.value)
-    : String(suggestion.value);
-
-  return (
-    <Popover>
-      <PopoverTrigger
-        appearance="subtle"
-        aria-label="Opal suggestion"
-        icon={<Avatar fallback="opal" size="2xs" />}
-        ref={ref}
-        size="sm"
-        {...props}
-      />
-      <PopoverContent aria-label="Suggestion" fontSize="sm" gap="4" p="12">
-        <Text>{text}</Text>
-        {suggestion.reason && (
-          <>
-            <Separator my="8" />
-            <Heading fontSize="sm" level="4">
-              Why this was suggested
-            </Heading>
-            <Text color="fg.secondary">{suggestion.reason}</Text>
-          </>
-        )}
-        <Separator my="8" />
-        <Button
-          icon={<IconCheck />}
-          justifyContent="center"
-          onClick={() => {
-            surface.accept(suggestion.id);
-          }}
-          size="sm"
-        >
-          Accept
-        </Button>
-      </PopoverContent>
-    </Popover>
+  return surface?.manualSuggestion ? (
+    <SuggestionManualTrigger ref={ref} {...props} />
+  ) : (
+    <SuggestionAutoPopover ref={ref} {...props} />
   );
 });
 


### PR DESCRIPTION
## Summary

Adds a `manualSuggestion` boolean to `unstable_SurfaceProvider`. When set, an Axiom `Input`/`Textarea` no longer auto-fetches a suggestion on every keystroke — the user clicks an Opal trigger button to ask, and the resulting value-suggestion is auto-accepted silently.

## Problem

Today, every keystroke in `Input`/`Textarea` fires a debounced `surface.track({ name: "changed", ... })`, which the host listens to and uses to fetch a suggestion. The suggestion arrives on the surface and `SuggestionPopover` shows the Opal avatar with a popover-Accept flow. For some flows, the host wants the user — not value-change debounce — to ask for a suggestion, and to accept it without an extra confirmation step.

## Public API

`SurfaceContextValue` (in `@optiaxiom/globals`) gains one optional flag:

```ts
manualSuggestion?: boolean;
```

Host wires it on `unstable_SurfaceProvider`:

```tsx
<unstable_SurfaceProvider
  ...existing props (accept, reject, executeTool, track, suggestions, ...)
  manualSuggestion
>
  <Input value={value} onChange={onChange} />
  <Textarea value={value} onChange={onChange} />
</unstable_SurfaceProvider>
```

No new props on `Input`, `Textarea`, or `SuggestionPopover`.

## Behavior

**\`manualSuggestion\` falsy (default).** Unchanged — keystrokes fire \`track({ changed })\` after 300ms debounce; host produces a suggestion; popover Opal avatar appears; user clicks it, then Accept.

**\`manualSuggestion === true\`.** \`InputControl\` skips the keystroke \`debouncedTrack(newValue)\` call. \`SuggestionPopover\` reads \`surface.manualSuggestion\` and renders the manual branch — a plain Button (Opal avatar, no Popover wrapper) with these states:

| State | Trigger | UI |
|---|---|---|
| idle | no request in flight | enabled Opal avatar button |
| pending | user clicked, awaiting suggestion | disabled, Button `loading` spinner overlays the Opal avatar |
| arriving | suggestion appears on surface while pending | auto-call `surface.accept(id)`; clear pending; button stays visible |

Click handler in idle state:
1. Set local \`pending = true\`.
2. Call \`surface.track({ name: "requested", value: surface.value })\` — a new track type distinct from the keystroke-debounced \`changed\`.

The host's \`track\` handler produces a suggestion and pushes it via the provider's \`suggestions\` prop. The component picks the first entry (\`suggestions[0]\`) and auto-accepts; the button remains rendered so the user can request another suggestion at any time.

## File-level changes

- **\`packages/globals/src/surface-context.ts\`** — add optional \`manualSuggestion\` to \`SurfaceContextValue\`. Provider already spreads remaining props onto context value.
- **\`packages/react/src/input/InputControl.tsx\`** — wrap the \`debouncedTrack(newValue)\` call in \`if (!surface?.manualSuggestion) { ... }\`.
- **\`packages/react/src/suggestion/SuggestionPopover.tsx\`** — small router that reads \`surface.manualSuggestion\` and dispatches.
- **\`packages/react/src/suggestion/SuggestionAutoPopover.tsx\`** (new) — existing popover-with-Accept behavior, extracted.
- **\`packages/react/src/suggestion/SuggestionManualTrigger.tsx\`** (new) — \`Button\` with Opal avatar icon and built-in \`loading\` spinner; auto-accepts the first arriving suggestion; emits \`track({ requested })\` on click.
- **Stories.** \`Input\` and \`Textarea\` \`WithManualSuggestion\` — \`SurfaceProvider\` with \`manualSuggestion\`, \`track\` handler that pushes a suggestion 1.2s after a \`requested\` event.

## Edge cases

- **No suggestion arrives.** \`pending\` stays true; button stays disabled. Out of scope for v1; host responsible for resolving (e.g., push a no-op suggestion).
- **Suggestion matches current value.** Picking \`suggestions[0]\` (rather than filtering by \`value !== surface.value\`) ensures we always accept and clear pending — avoids a perpetual pending state.
- **Value changes while pending.** Pending state preserved; arriving suggestion still auto-accepts and overwrites.
- **\`manualSuggestion\` toggled mid-session.** Component re-reads from context; \`SuggestionPopover\` swaps branches; pending state resets on remount.
- **Multiple rapid clicks.** Button is disabled while pending — duplicate requests blocked at the UI layer.
- **Suggestion arrives in manual mode without a preceding click.** Auto-accepted defensively.
- **Telemetry in manual mode.** Keystroke \`track({ changed })\` is suppressed; only the manual-button click fires \`track({ requested })\`. \`blurred\`, \`focused\`, etc. still fire as today.

## Out of scope

- Manual mode for \`Select\`. (\`Checkbox\` and \`Switch\` also render \`SuggestionPopover\` and would inherit manual rendering, but \`InputControl\`'s debounce-skip change is Input/Textarea-specific.)
- Timeout, retry, or error UI for stuck pending state.
- A separate \`requestSuggestion\` API. We reuse the existing \`track\`.

## Test plan

- [ ] Storybook → \`Input\` → \`WithManualSuggestion\`: type, click Opal, verify spinner → auto-accept → button stays visible; click again to request another suggestion.
- [ ] Storybook → \`Textarea\` → \`WithManualSuggestion\`: same flow.
- [ ] Storybook → \`Input\` → \`WithSuggestion\` (auto mode): unchanged behavior, popover still appears.
- [ ] Lint, typecheck, vitest pass (\`pnpm lint\`, \`pnpm test\`).