### PR TITLE
docs: add Bridge and Federated guide sections

### DIFF
--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -4,6 +4,12 @@ import { Demo, ProteusElementRef } from "@/components";
 
 Proteus is a JSON-based UI specification for building interactive tool interfaces. You define your UI as a JSON document, and the Proteus renderer (`@optiaxiom/proteus`) turns it into interactive Axiom components.
 
+## Proteus Designer
+
+### Visual editor
+
+The [Proteus Designer](/guides/proteus-designer) is a visual editor for building Proteus documents. You can build a component tree, edit properties in the inspector, see a live preview of how the document renders, and copy the final JSON into your resource handler. You can also provide sample data to test how dynamic values resolve.
+
 ## Document structure
 
 ### Minimal document
@@ -116,11 +122,19 @@ Triggers a file download:
 
 <Demo component="proteus/action-download" />
 
-## Proteus Designer
+## Embedding external content
 
-### Visual editor
+### Bridge
 
-The [Proteus Designer](/guides/proteus-designer) is a visual editor for building Proteus documents. You can build a component tree, edit properties in the inspector, see a live preview of how the document renders, and copy the final JSON into your resource handler. You can also provide sample data to test how dynamic values resolve.
+`Bridge` embeds an MCP app widget inside the Proteus document by rendering it in a sandboxed iframe. Provide a `resource` URI; the document's `useResource` callback resolves it to an HTML payload that the iframe loads. Bridge wires up the [MCP App Bridge](https://modelcontextprotocol.io) so the embedded widget can call tools, send messages, open links, and request resize — with each event flowing through the document's existing event handlers.
+
+<Demo component="proteus/bridge" />
+
+### Federated
+
+`Federated` loads a remote React component at runtime via [Module Federation](https://module-federation.io) and renders it inline. The `entry` prop points to a `remoteEntry.js` (or `mf-manifest.json`) URL, and the optional `exposeKey` selects which exposed module to mount (defaults to the root export `"."`). The remote component receives the document `data` and `onEvent` so it can read context and trigger interactions like a native Proteus element. Use `fallback` to render content when the remote fails to load:
+
+<Demo component="proteus/federated" />
 
 ## Element reference
 
@@ -275,3 +289,7 @@ The [Proteus Designer](/guides/proteus-designer) is a visual editor for building
 ### Bridge
 
 <ProteusElementRef type="Bridge" />
+
+### Federated
+
+<ProteusElementRef type="Federated" />

--- a/apps/docs/demos/proteus/bridge/App.tsx
+++ b/apps/docs/demos/proteus/bridge/App.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+import { useMemo } from "react";
+
+const widgetHtml = `<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 0; padding: 16px; color: #1a1a1a; }
+      h1 { font-size: 16px; margin: 0 0 8px; }
+      p { color: #555; margin: 0 0 12px; font-size: 14px; }
+      button { padding: 6px 12px; background: #0037ff; color: white; border: none; border-radius: 6px; cursor: pointer; font-size: 13px; }
+      button:hover { background: #0029cc; }
+    </style>
+  </head>
+  <body>
+    <h1>Embedded MCP App</h1>
+    <p>This widget is rendered in a sandboxed iframe. Click below to call a tool on the host.</p>
+    <button id="btn">Refresh data</button>
+    <script>
+      document.getElementById('btn').addEventListener('click', function() {
+        if (window.openai && window.openai.callTool) {
+          window.openai.callTool('refresh_data', { range: 'Q1' });
+        }
+      });
+    </script>
+  </body>
+</html>`;
+
+export function App() {
+  const useResource = useMemo(
+    () => () => ({
+      data: { mimeType: "text/html+skybridge", text: widgetHtml },
+      isError: false,
+    }),
+    [],
+  );
+
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        element={{
+          $type: "Document",
+          appName: "MCP App",
+          body: [
+            {
+              $type: "Text",
+              children: "Embedded widget loaded via the App Bridge:",
+            },
+            {
+              $type: "Bridge",
+              height: 220,
+              resource: "ui://my-widget",
+            },
+          ],
+          title: "Bridge Component",
+        }}
+        useResource={useResource}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/federated/App.tsx
+++ b/apps/docs/demos/proteus/federated/App.tsx
@@ -21,18 +21,9 @@ export function App() {
               entry: "https://invalid.example.com/remoteEntry.js",
               fallback: [
                 {
-                  $type: "Card",
-                  children: [
-                    {
-                      $type: "CardHeader",
-                      children: "Remote unavailable",
-                    },
-                    {
-                      $type: "Text",
-                      children:
-                        "The federated remote could not be loaded. This fallback content keeps the document usable.",
-                    },
-                  ],
+                  $type: "Text",
+                  children:
+                    "Remote widget unavailable — fallback content keeps the document usable.",
                 },
               ],
             },

--- a/apps/docs/demos/proteus/federated/App.tsx
+++ b/apps/docs/demos/proteus/federated/App.tsx
@@ -3,29 +3,25 @@
 import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
 import { Box } from "@optiaxiom/react";
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
 export function App() {
   return (
     <Box maxW="md" w="full">
       <ProteusDocumentRenderer
+        data={{ status: "running", widgetName: "Experiment Results" }}
         element={{
           $type: "Document",
           appName: "Federated Widget",
           body: [
             {
               $type: "Text",
-              children:
-                "The remote below is intentionally unreachable so the fallback renders:",
+              children: "Remote component loaded via Module Federation:",
             },
             {
               $type: "Federated",
-              entry: "https://invalid.example.com/remoteEntry.js",
-              fallback: [
-                {
-                  $type: "Text",
-                  children:
-                    "Remote widget unavailable — fallback content keeps the document usable.",
-                },
-              ],
+              entry: `${basePath}/federated-widget/remoteEntry.js`,
+              exposeKey: "./App",
             },
           ],
           title: "Federated Component",

--- a/apps/docs/demos/proteus/federated/App.tsx
+++ b/apps/docs/demos/proteus/federated/App.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        element={{
+          $type: "Document",
+          appName: "Federated Widget",
+          body: [
+            {
+              $type: "Text",
+              children:
+                "The remote below is intentionally unreachable so the fallback renders:",
+            },
+            {
+              $type: "Federated",
+              entry: "https://invalid.example.com/remoteEntry.js",
+              fallback: [
+                {
+                  $type: "Card",
+                  children: [
+                    {
+                      $type: "CardHeader",
+                      children: "Remote unavailable",
+                    },
+                    {
+                      $type: "Text",
+                      children:
+                        "The federated remote could not be loaded. This fallback content keeps the document usable.",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          title: "Federated Component",
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/public/federated-widget/remoteEntry.js
+++ b/apps/docs/public/federated-widget/remoteEntry.js
@@ -1,0 +1,74 @@
+let React;
+
+const widgetStyle = {
+  background: "#f5f3ff",
+  border: "2px dashed #4f46e5",
+  borderRadius: 8,
+  fontFamily: "sans-serif",
+  padding: 16,
+};
+const headerStyle = { fontWeight: 600, marginBottom: 8 };
+const dataWrapperStyle = { fontSize: 13, marginBottom: 12 };
+const preStyle = {
+  background: "#ede9fe",
+  borderRadius: 4,
+  maxHeight: 120,
+  overflow: "auto",
+  padding: 8,
+};
+const buttonStyle = {
+  background: "#4f46e5",
+  border: "none",
+  borderRadius: 4,
+  color: "white",
+  cursor: "pointer",
+  padding: "6px 12px",
+};
+
+function Widget({ data, onEvent }) {
+  const h = React.createElement;
+  return h("div", { style: widgetStyle }, [
+    h("div", { key: "title", style: headerStyle }, "Federated Widget (remote)"),
+    h("div", { key: "data", style: dataWrapperStyle }, [
+      h("strong", { key: "label" }, "Received data:"),
+      h("pre", { key: "json", style: preStyle }, JSON.stringify(data, null, 2)),
+    ]),
+    h(
+      "button",
+      {
+        key: "btn",
+        onClick: () =>
+          onEvent({
+            interaction: "widget-click",
+            params: { source: "federated-widget" },
+          }),
+        style: buttonStyle,
+      },
+      "Send Event",
+    ),
+  ]);
+}
+
+const modules = {
+  ".": () => ({ default: Widget }),
+  "./App": () => ({ default: Widget }),
+  "./Dashboard": () => ({ default: Widget }),
+};
+
+export function get(id) {
+  if (!(id in modules)) {
+    throw new Error(`Module ${id} not found in federated-widget`);
+  }
+  return modules[id];
+}
+
+export function init(shareScope) {
+  if (shareScope && shareScope.react) {
+    const versions = Object.keys(shareScope.react);
+    if (versions.length > 0) {
+      const entry = shareScope.react[versions[0]];
+      const lib = typeof entry.lib === "function" ? entry.lib() : entry.lib;
+      React = lib ?? entry;
+    }
+  }
+}

--- a/packages/proteus/src/proteus-federated/ProteusFederated.tsx
+++ b/packages/proteus/src/proteus-federated/ProteusFederated.tsx
@@ -4,7 +4,7 @@ import {
   loadRemote,
   registerRemotes,
 } from "@module-federation/enhanced/runtime";
-import {
+import React, {
   type ComponentType,
   type ReactNode,
   Suspense,
@@ -12,6 +12,7 @@ import {
   useId,
   useState,
 } from "react";
+import * as ReactJsxRuntime from "react/jsx-runtime";
 
 import { useProteusDocumentContext } from "../proteus-document/ProteusDocumentContext";
 
@@ -93,7 +94,22 @@ export function ProteusFederated({
 
 function ensureInstance() {
   if (!getInstance()) {
-    init({ name: "proteus-federated", remotes: [] });
+    init({
+      name: "proteus-federated",
+      remotes: [],
+      shared: {
+        react: {
+          lib: () => React,
+          shareConfig: { requiredVersion: false, singleton: true },
+          version: React.version,
+        },
+        "react/jsx-runtime": {
+          lib: () => ReactJsxRuntime,
+          shareConfig: { requiredVersion: false, singleton: true },
+          version: React.version,
+        },
+      },
+    });
   }
 }
 


### PR DESCRIPTION
Documents the Bridge and Federated Proteus components in the guide and moves the Designer section to the top.