### PR TITLE
[OPAL-3916] feat(proteus): support multi-file upload via minItems/maxItems

### DIFF
--- a/.changeset/bitter-eagles-build.md
+++ b/.changeset/bitter-eagles-build.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/proteus": patch
+"@optiaxiom/react": patch
+---
+
+Add multi-file upload support to the file upload component, replace the required flag with minimum and maximum file count, let map flatten nested results, and have the file list remove handler pass the file item instead of its index.

--- a/apps/storybook/src/components/FileUpload.stories.tsx
+++ b/apps/storybook/src/components/FileUpload.stories.tsx
@@ -217,8 +217,8 @@ export const FilePreview: Story = {
               </FileUploadTrigger>
               <FileUploadList
                 items={items}
-                onRemove={(index) =>
-                  setItems((prev) => prev.filter((_, i) => i !== index))
+                onRemove={(item) =>
+                  setItems((prev) => prev.filter((i) => i !== item))
                 }
               />
               <FileUploadDropzone overlay />

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -688,6 +688,7 @@ export const AskAgentInputWithFileParam: Story = {
                     ],
                   },
                 },
+                flat: true,
                 path: "/parameters",
               },
               parts: [
@@ -695,27 +696,97 @@ export const AskAgentInputWithFileParam: Story = {
                   content: {
                     $type: "Map",
                     children: {
-                      $type: "Show",
-                      children: {
-                        $type: "Concat",
-                        children: [
-                          { $type: "Value", path: "name" },
-                          ": ",
-                          {
-                            $type: "Show",
-                            children: "[Not specified]",
-                            when: { "!": { $type: "Value", path: "value" } },
+                      $type: "Concat",
+                      children: [
+                        { $type: "Value", path: "name" },
+                        ": ",
+                        {
+                          $type: "Show",
+                          children: "[Not specified]",
+                          when: {
+                            and: [
+                              {
+                                "!=": [
+                                  { $type: "Value", path: "type" },
+                                  "boolean",
+                                ],
+                              },
+                              {
+                                "!=": [
+                                  { $type: "Value", path: "type" },
+                                  "file",
+                                ],
+                              },
+                              { "!": { $type: "Value", path: "value" } },
+                            ],
                           },
-                          {
-                            $type: "Show",
-                            children: { $type: "Value", path: "value" },
-                            when: { "!!": { $type: "Value", path: "value" } },
+                        },
+                        {
+                          $type: "Show",
+                          children: { $type: "Value", path: "value" },
+                          when: {
+                            and: [
+                              {
+                                "!=": [
+                                  { $type: "Value", path: "type" },
+                                  "file",
+                                ],
+                              },
+                              { "!!": { $type: "Value", path: "value" } },
+                            ],
                           },
-                        ],
-                      },
-                      when: {
-                        "!=": [{ $type: "Value", path: "type" }, "file"],
-                      },
+                        },
+                        {
+                          $type: "Show",
+                          children: {
+                            $type: "Map",
+                            children: { $type: "Value", path: "name" },
+                            path: "value",
+                            separator: ", ",
+                          },
+                          when: {
+                            and: [
+                              {
+                                "==": [
+                                  { $type: "Value", path: "type" },
+                                  "file",
+                                ],
+                              },
+                              { "!!": { $type: "Value", path: "value" } },
+                            ],
+                          },
+                        },
+                        {
+                          $type: "Show",
+                          children: "[Not specified]",
+                          when: {
+                            and: [
+                              {
+                                "==": [
+                                  { $type: "Value", path: "type" },
+                                  "file",
+                                ],
+                              },
+                              { "!": { $type: "Value", path: "value" } },
+                            ],
+                          },
+                        },
+                        {
+                          $type: "Show",
+                          children: { $type: "Value", path: "value" },
+                          when: {
+                            and: [
+                              {
+                                "==": [
+                                  { $type: "Value", path: "type" },
+                                  "boolean",
+                                ],
+                              },
+                              { "!": { $type: "Value", path: "value" } },
+                            ],
+                          },
+                        },
+                      ],
                     },
                     path: "/parameters",
                     separator: "\n",
@@ -757,8 +828,9 @@ export const AskAgentInputWithFileParam: Story = {
                 children: {
                   $type: "FileUpload",
                   accept: ["application/pdf", "text/*"],
+                  maxFiles: 1,
+                  minFiles: 1,
                   name: "value",
-                  required: { $type: "Value", path: "required" },
                 },
                 description: { $type: "Value", path: "description" },
                 label: { $type: "Value", path: "name" },

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -121,7 +121,7 @@ const PROTEUS_COMPONENT_CONFIG = {
     },
   },
   FileUpload: {
-    allowedProps: ["accept", "name", "required"],
+    allowedProps: ["accept", "maxFiles", "minFiles", "name"],
     example: { name: "value" },
     extends: "Fragment",
   },
@@ -171,7 +171,7 @@ const PROTEUS_COMPONENT_CONFIG = {
     example: { children: "Link text", href: "https://example.com" },
   },
   Map: {
-    allowedProps: ["path", "children", "separator"],
+    allowedProps: ["path", "children", "flat", "separator"],
     example: {
       children: { $type: "Text", children: "Item" },
       path: "/items",
@@ -434,8 +434,8 @@ function generateSpec(additionalProperties = false) {
               [op]: {
                 description,
                 items: { anyOf: comparisonValueTypes },
-                maxItems: 2,
-                minItems: 2,
+                maxFiles: 2,
+                minFiles: 2,
                 type: "array",
               },
             },
@@ -480,7 +480,7 @@ function generateSpec(additionalProperties = false) {
                     items: {
                       $ref: "#/definitions/ProteusCondition",
                     },
-                    minItems: 1,
+                    minFiles: 1,
                     type: "array",
                   },
                 },
@@ -498,7 +498,7 @@ function generateSpec(additionalProperties = false) {
                     items: {
                       anyOf: [{ $ref: "#/definitions/ProteusCondition" }],
                     },
-                    minItems: 1,
+                    minFiles: 1,
                     type: "array",
                   },
                 },
@@ -1082,20 +1082,28 @@ function getPropTypeOverrides(additionalProperties = false) {
         items: { type: "string" },
         type: "array",
       },
+      maxFiles: {
+        anyOf: [
+          { type: "number" },
+          { $ref: "#/definitions/ProteusExpression" },
+        ],
+        description:
+          "Maximum number of files allowed. When set to 1 the field is in single-file mode; any other value (or omitted) allows multiple uploads.",
+      },
+      minFiles: {
+        anyOf: [
+          { type: "number" },
+          { $ref: "#/definitions/ProteusExpression" },
+        ],
+        description: "Minimum number of files required.",
+      },
       name: {
         anyOf: [
           { type: "string" },
           { $ref: "#/definitions/ProteusExpression" },
         ],
         description:
-          "The name of the form control element. The resolved URL is written at parentPath/name in form data.",
-      },
-      required: {
-        anyOf: [
-          { type: "boolean" },
-          { $ref: "#/definitions/ProteusExpression" },
-        ],
-        description: "Whether a file is required.",
+          "The name of the form control element. The resolved metadata array is written at parentPath/name in form data.",
       },
     },
     Image: {
@@ -1166,6 +1174,11 @@ function getPropTypeOverrides(additionalProperties = false) {
         $ref: "#/definitions/ProteusNode",
         description:
           "Template object to render for each item in the array. Value paths inside this template are relative to the current item (e.g., path='title' resolves to each item's 'title' field). Use a leading '/' to reference top-level data (e.g., path='/title' resolves to the root data's 'title').",
+      },
+      flat: {
+        description:
+          "When true, flattens the result array by one level. Useful when each mapped item resolves to an array and you want a single flat list.",
+        type: "boolean",
       },
       path: {
         description:

--- a/packages/proteus/src/proteus-document/resolveProteusValue.tsx
+++ b/packages/proteus/src/proteus-document/resolveProteusValue.tsx
@@ -169,6 +169,7 @@ export function resolveProteusValue(
           ),
         )
         .filter((v: unknown) => v !== undefined);
+      const result = "flat" in value && value.flat ? items.flat() : items;
       if ("separator" in value) {
         const sep = resolveProteusValue(
           value.separator,
@@ -176,9 +177,9 @@ export function resolveProteusValue(
           parentPath,
           mapIndices,
         );
-        return items.join(typeof sep === "string" ? sep : "");
+        return result.join(typeof sep === "string" ? sep : "");
       }
-      return items;
+      return result;
     }
 
     if (value.$type === "Show" && "when" in value && "children" in value) {

--- a/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
+++ b/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
@@ -1,3 +1,4 @@
+import { IconPlus } from "@optiaxiom/icons";
 import { Flex } from "@optiaxiom/react";
 import {
   FileUpload,
@@ -24,23 +25,31 @@ export type ProteusFileUploadProps = {
    */
   accept?: string[];
   /**
-   * The name of the form control element. The resolved metadata object is
+   * Maximum number of files allowed. When set to `1` the field is in
+   * single-file mode; any other value (or omitted) allows multiple uploads.
+   */
+  maxFiles?: number;
+  /**
+   * Minimum number of files required.
+   */
+  minFiles?: number;
+  /**
+   * The name of the form control element. The resolved metadata array is
    * written at `parentPath/name` in form data once the host's `onUpload`
    * resolves.
    */
   name?: string;
-  /**
-   * Whether a file is required.
-   */
-  required?: boolean;
 };
 
-type Item = FileUploadListProps["items"][number];
+type Item = FileUploadListProps["items"][number] & {
+  metadata?: FileUploadMetadata;
+};
 
 export function ProteusFileUpload({
   accept,
+  maxFiles,
+  minFiles = 0,
   name,
-  required,
 }: ProteusFileUploadProps) {
   const { onDataChange, onUpload, readOnly } = useProteusDocumentContext(
     "@optiaxiom/proteus/ProteusFileUpload",
@@ -50,73 +59,122 @@ export function ProteusFileUpload({
   );
 
   const inputRef = useRef<HTMLInputElement>(null);
-  const [item, setItem] = useState<Item | null>(null);
+  const itemsRef = useRef<Item[]>([]);
+  const [items, setItems] = useState<Item[]>([]);
   const forceValueChange = useObserveValue(inputRef);
 
-  const writeValue = useCallback(
-    (value: FileUploadMetadata | null) => {
-      if (!name) return;
+  const multiple = maxFiles !== 1;
+  const atMax = multiple && maxFiles !== undefined && items.length >= maxFiles;
+
+  const writeValue = useCallback(() => {
+    setItems(itemsRef.current);
+    if (inputRef.current) {
+      forceValueChange(
+        itemsRef.current
+          .filter((item) => item.status === "complete")
+          .length.toString(),
+      );
+    }
+    if (name) {
+      const value = itemsRef.current
+        .filter((item) => item.status === "complete")
+        .map((item) => item.metadata)
+        .filter((metadata) => !!metadata);
       onDataChange?.(`${parentPath}/${name}`, value);
-    },
-    [name, onDataChange, parentPath],
-  );
+    }
+  }, [forceValueChange, name, onDataChange, parentPath]);
 
   const handleFilesDrop = useCallback(
     async (incoming: File[]) => {
+      if (multiple) {
+        incoming =
+          maxFiles !== undefined
+            ? incoming.slice(0, Math.max(0, maxFiles - itemsRef.current.length))
+            : incoming;
+      } else {
+        incoming = incoming.slice(0, 1);
+      }
       if (!onUpload || readOnly || incoming.length === 0) {
         return;
       }
-      const file = incoming[0];
-      setItem({ file, status: "uploading" });
-      writeValue(null);
-      if (inputRef.current) {
-        forceValueChange("");
-      }
-      try {
-        const metadata = await onUpload(file);
-        setItem((curr) =>
-          curr?.file === file ? { file, status: "complete" } : curr,
-        );
-        writeValue(metadata);
-        if (inputRef.current) {
-          forceValueChange("1");
-        }
-      } catch {
-        setItem((curr) =>
-          curr?.file === file ? { file, status: "error" } : curr,
-        );
-      }
+
+      itemsRef.current = [
+        ...(multiple ? itemsRef.current : []),
+        ...incoming.map((file) => ({ file, status: "uploading" as const })),
+      ];
+      writeValue();
+
+      const result = new Map<File, Item>(
+        await Promise.all(
+          incoming.map((file) =>
+            onUpload(file)
+              .then(
+                (metadata) =>
+                  [
+                    file,
+                    {
+                      file,
+                      metadata,
+                      status: "complete",
+                    },
+                  ] as const,
+              )
+              .catch(
+                () =>
+                  [
+                    file,
+                    {
+                      file,
+                      status: "error",
+                    },
+                  ] as const,
+              ),
+          ),
+        ),
+      );
+      itemsRef.current = itemsRef.current.map(
+        (item) => result.get(item.file) ?? item,
+      );
+      writeValue();
     },
-    [forceValueChange, onUpload, readOnly, writeValue],
+    [maxFiles, multiple, onUpload, readOnly, writeValue],
   );
 
-  const handleRemove = useCallback(() => {
-    setItem(null);
-    writeValue(null);
-    if (inputRef.current) {
-      forceValueChange("");
-    }
-  }, [forceValueChange, writeValue]);
+  const handleRemove = useCallback(
+    (item: Item) => {
+      itemsRef.current = itemsRef.current.filter((i) => i !== item);
+      writeValue();
+    },
+    [writeValue],
+  );
 
   return (
     <FileUpload
       accept={accept}
-      disabled={!onUpload || readOnly}
+      disabled={!onUpload || readOnly || atMax}
       onFilesDrop={handleFilesDrop}
     >
       <VisuallyHidden asChild>
         <input
           aria-hidden
+          defaultValue={0}
+          max={maxFiles !== undefined ? String(maxFiles) : undefined}
+          min={String(minFiles)}
           name={name}
           ref={inputRef}
-          required={required}
           tabIndex={-1}
+          type="number"
         />
       </VisuallyHidden>
-      {item ? (
+      {items.length > 0 ? (
         <Flex flexDirection="column" gap="8">
-          <FileUploadList items={[item]} onRemove={handleRemove} />
-          <FileUploadDropzone overlay />
+          {multiple && !atMax && (
+            <FileUploadTrigger alignSelf="end" icon={<IconPlus />}>
+              Add File
+            </FileUploadTrigger>
+          )}
+          <FileUploadList items={items} onRemove={handleRemove} />
+          {!atMax && <FileUploadDropzone overlay />}
         </Flex>
       ) : (
         <FileUploadDropzone>

--- a/packages/proteus/src/proteus-map/ProteusMap.tsx
+++ b/packages/proteus/src/proteus-map/ProteusMap.tsx
@@ -10,6 +10,11 @@ import { useProteusValue } from "../use-proteus-value";
 export type ProteusMapProps = {
   children?: ReactNode;
   /**
+   * When true, flattens the result array by one level. Only used during
+   * value resolution (e.g., onClick message); ignored during rendering.
+   */
+  flat?: boolean;
+  /**
    * JSON pointer path to the source array in the data (e.g., '/results')
    */
   path: string;

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -933,8 +933,8 @@
                   { "$ref": "#/definitions/ProteusValue" }
                 ]
               },
-              "maxItems": 2,
-              "minItems": 2,
+              "maxFiles": 2,
+              "minFiles": 2,
               "type": "array"
             }
           },
@@ -956,8 +956,8 @@
                   { "$ref": "#/definitions/ProteusValue" }
                 ]
               },
-              "maxItems": 2,
-              "minItems": 2,
+              "maxFiles": 2,
+              "minFiles": 2,
               "type": "array"
             }
           },
@@ -979,8 +979,8 @@
                   { "$ref": "#/definitions/ProteusValue" }
                 ]
               },
-              "maxItems": 2,
-              "minItems": 2,
+              "maxFiles": 2,
+              "minFiles": 2,
               "type": "array"
             }
           },
@@ -1002,8 +1002,8 @@
                   { "$ref": "#/definitions/ProteusValue" }
                 ]
               },
-              "maxItems": 2,
-              "minItems": 2,
+              "maxFiles": 2,
+              "minFiles": 2,
               "type": "array"
             }
           },
@@ -1025,8 +1025,8 @@
                   { "$ref": "#/definitions/ProteusValue" }
                 ]
               },
-              "maxItems": 2,
-              "minItems": 2,
+              "maxFiles": 2,
+              "minFiles": 2,
               "type": "array"
             }
           },
@@ -1048,8 +1048,8 @@
                   { "$ref": "#/definitions/ProteusValue" }
                 ]
               },
-              "maxItems": 2,
-              "minItems": 2,
+              "maxFiles": 2,
+              "minFiles": 2,
               "type": "array"
             }
           },
@@ -1098,7 +1098,7 @@
             "and": {
               "description": "Logical AND - returns true if all conditions are true",
               "items": { "$ref": "#/definitions/ProteusCondition" },
-              "minItems": 1,
+              "minFiles": 1,
               "type": "array"
             }
           },
@@ -1113,7 +1113,7 @@
               "items": {
                 "anyOf": [{ "$ref": "#/definitions/ProteusCondition" }]
               },
-              "minItems": 1,
+              "minFiles": 1,
               "type": "array"
             }
           },
@@ -2518,19 +2518,26 @@
           "items": { "type": "string" },
           "type": "array"
         },
+        "maxFiles": {
+          "anyOf": [
+            { "type": "number" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "Maximum number of files allowed. When set to 1 the field is in single-file mode; any other value (or omitted) allows multiple uploads."
+        },
+        "minFiles": {
+          "anyOf": [
+            { "type": "number" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "Minimum number of files required."
+        },
         "name": {
           "anyOf": [
             { "type": "string" },
             { "$ref": "#/definitions/ProteusExpression" }
           ],
-          "description": "The name of the form control element. The resolved URL is written at parentPath/name in form data."
-        },
-        "required": {
-          "anyOf": [
-            { "type": "boolean" },
-            { "$ref": "#/definitions/ProteusExpression" }
-          ],
-          "description": "Whether a file is required."
+          "description": "The name of the form control element. The resolved metadata array is written at parentPath/name in form data."
         }
       },
       "required": ["$type"],
@@ -3188,6 +3195,10 @@
         "children": {
           "$ref": "#/definitions/ProteusNode",
           "description": "Template object to render for each item in the array. Value paths inside this template are relative to the current item (e.g., path='title' resolves to each item's 'title' field). Use a leading '/' to reference top-level data (e.g., path='/title' resolves to the root data's 'title')."
+        },
+        "flat": {
+          "description": "When true, flattens the result array by one level. Useful when each mapped item resolves to an array and you want a single flat list.",
+          "type": "boolean"
         },
         "path": {
           "description": "JSON pointer path to the source array in the data (e.g., '/results')",

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -932,8 +932,8 @@
                   { "$ref": "#/definitions/ProteusValue" }
                 ]
               },
-              "maxItems": 2,
-              "minItems": 2,
+              "maxFiles": 2,
+              "minFiles": 2,
               "type": "array"
             }
           },
@@ -954,8 +954,8 @@
                   { "$ref": "#/definitions/ProteusValue" }
                 ]
               },
-              "maxItems": 2,
-              "minItems": 2,
+              "maxFiles": 2,
+              "minFiles": 2,
               "type": "array"
             }
           },
@@ -976,8 +976,8 @@
                   { "$ref": "#/definitions/ProteusValue" }
                 ]
               },
-              "maxItems": 2,
-              "minItems": 2,
+              "maxFiles": 2,
+              "minFiles": 2,
               "type": "array"
             }
           },
@@ -998,8 +998,8 @@
                   { "$ref": "#/definitions/ProteusValue" }
                 ]
               },
-              "maxItems": 2,
-              "minItems": 2,
+              "maxFiles": 2,
+              "minFiles": 2,
               "type": "array"
             }
           },
@@ -1020,8 +1020,8 @@
                   { "$ref": "#/definitions/ProteusValue" }
                 ]
               },
-              "maxItems": 2,
-              "minItems": 2,
+              "maxFiles": 2,
+              "minFiles": 2,
               "type": "array"
             }
           },
@@ -1042,8 +1042,8 @@
                   { "$ref": "#/definitions/ProteusValue" }
                 ]
               },
-              "maxItems": 2,
-              "minItems": 2,
+              "maxFiles": 2,
+              "minFiles": 2,
               "type": "array"
             }
           },
@@ -1089,7 +1089,7 @@
             "and": {
               "description": "Logical AND - returns true if all conditions are true",
               "items": { "$ref": "#/definitions/ProteusCondition" },
-              "minItems": 1,
+              "minFiles": 1,
               "type": "array"
             }
           },
@@ -1103,7 +1103,7 @@
               "items": {
                 "anyOf": [{ "$ref": "#/definitions/ProteusCondition" }]
               },
-              "minItems": 1,
+              "minFiles": 1,
               "type": "array"
             }
           },
@@ -2483,19 +2483,26 @@
           "items": { "type": "string" },
           "type": "array"
         },
+        "maxFiles": {
+          "anyOf": [
+            { "type": "number" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "Maximum number of files allowed. When set to 1 the field is in single-file mode; any other value (or omitted) allows multiple uploads."
+        },
+        "minFiles": {
+          "anyOf": [
+            { "type": "number" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "Minimum number of files required."
+        },
         "name": {
           "anyOf": [
             { "type": "string" },
             { "$ref": "#/definitions/ProteusExpression" }
           ],
-          "description": "The name of the form control element. The resolved URL is written at parentPath/name in form data."
-        },
-        "required": {
-          "anyOf": [
-            { "type": "boolean" },
-            { "$ref": "#/definitions/ProteusExpression" }
-          ],
-          "description": "Whether a file is required."
+          "description": "The name of the form control element. The resolved metadata array is written at parentPath/name in form data."
         }
       },
       "required": ["$type"],
@@ -3144,6 +3151,10 @@
         "children": {
           "$ref": "#/definitions/ProteusNode",
           "description": "Template object to render for each item in the array. Value paths inside this template are relative to the current item (e.g., path='title' resolves to each item's 'title' field). Use a leading '/' to reference top-level data (e.g., path='/title' resolves to the root data's 'title')."
+        },
+        "flat": {
+          "description": "When true, flattens the result array by one level. Useful when each mapped item resolves to an array and you want a single flat list.",
+          "type": "boolean"
         },
         "path": {
           "description": "JSON pointer path to the source array in the data (e.g., '/results')",

--- a/packages/react/src/file-upload/FileUploadList.tsx
+++ b/packages/react/src/file-upload/FileUploadList.tsx
@@ -16,7 +16,7 @@ export type FileUploadListProps = BoxProps<"div"> & {
   /**
    * Callback function called when a file is removed
    */
-  onRemove?: (index: number) => void;
+  onRemove?: (index: FileUploadListItemProps["item"]) => void;
 };
 
 export const FileUploadList = forwardRef<HTMLDivElement, FileUploadListProps>(
@@ -27,7 +27,7 @@ export const FileUploadList = forwardRef<HTMLDivElement, FileUploadListProps>(
           <FileUploadListItem
             item={item}
             key={idx}
-            onRemove={onRemove ? () => onRemove(idx) : undefined}
+            onRemove={onRemove ? () => onRemove(item) : undefined}
           />
         ))}
       </Flex>

--- a/packages/react/src/file-upload/FileUploadList.tsx
+++ b/packages/react/src/file-upload/FileUploadList.tsx
@@ -16,7 +16,7 @@ export type FileUploadListProps = BoxProps<"div"> & {
   /**
    * Callback function called when a file is removed
    */
-  onRemove?: (index: FileUploadListItemProps["item"]) => void;
+  onRemove?: (item: FileUploadListItemProps["item"]) => void;
 };
 
 export const FileUploadList = forwardRef<HTMLDivElement, FileUploadListProps>(


### PR DESCRIPTION
Ticket Link: [OPAL-3916](https://optimizely-ext.atlassian.net/browse/OPAL-3916)

## Summary

Adds `minFiles` / `maxFiles` props on `ProteusFileUpload`. Default is multi-file; pass `maxFiles=1` for single-file. Drops the `required` prop — use `minFiles=1` instead. Drops `minItems`/`maxItems` naming (was unreleased).

The host form gates submit via a hidden `<input type="number" min={minFiles} max={maxFiles}>` whose value tracks the completed-upload count, so HTML form validity enforces the range with no extra JS.

Drag-and-drop in multi mode uploads all incoming files in parallel; the list shows every upload with its own remove button and a `+ Add File` trigger. `FileUploadList.onRemove` now passes the `Item` instead of an index so callers don't have to look it up. `UI.Map` gets a `flat` flag so nested maps can flatten server-side at resolve time (used by callers collecting list-of-file values into a flat `files` array).

Version bump and changeset will be added separately.

## Stacked on

- #1556

## Test plan

- [ ] Single-file: `<UI.FileUpload name="value" maxFiles={1} minFiles={1} />` — drop one → submit enabled; trash → disabled. Resolved value is `FileUploadMetadata`.
- [ ] Multi-file: `<UI.FileUpload name="value" minFiles={3} maxFiles={10} />` — drop 1 → submit disabled; drop 2 more → enabled; trash one → disabled; uploading past max is silently capped. Resolved value is `FileUploadMetadata[]`.
- [ ] `+ Add File` trigger appears in multi mode and disappears at `maxFiles`.
- [ ] `UI.Map(... flat=true)` over an array of arrays returns a flat array at resolve time.