### PR TITLE
fix(proteus): toast skipped-file count when selection exceeds maxFiles

### DIFF
--- a/.changeset/sweet-dodos-float.md
+++ b/.changeset/sweet-dodos-float.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": patch
+---
+
+`ProteusFileUpload`: surface a warning toast naming the number of dropped files when the selection would exceed `maxFiles`, instead of silently discarding them. The allowed files still upload as before.

--- a/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
+++ b/packages/proteus/src/proteus-file-upload/ProteusFileUpload.tsx
@@ -1,5 +1,5 @@
 import { IconPlus } from "@optiaxiom/icons";
-import { Flex } from "@optiaxiom/react";
+import { Flex, toaster } from "@optiaxiom/react";
 import {
   FileUpload,
   FileUploadDropzone,
@@ -86,13 +86,24 @@ export function ProteusFileUpload({
 
   const handleFilesDrop = useCallback(
     async (incoming: File[]) => {
-      if (multiple) {
-        incoming =
-          maxFiles !== undefined
-            ? incoming.slice(0, Math.max(0, maxFiles - itemsRef.current.length))
-            : incoming;
-      } else {
-        incoming = incoming.slice(0, 1);
+      let skipped = 0;
+      if (maxFiles !== undefined) {
+        const existing = multiple ? itemsRef.current.length : 0;
+        const remaining = Math.max(0, maxFiles - existing);
+        if (incoming.length > remaining) {
+          skipped = incoming.length - remaining;
+          incoming = incoming.slice(0, remaining);
+        }
+      }
+      if (skipped > 0) {
+        const accepted = incoming.length;
+        const skippedWord = skipped === 1 ? "was" : "were";
+        toaster.create(
+          accepted > 0
+            ? `Added ${accepted} file${accepted === 1 ? "" : "s"}. ${skipped} ${skippedWord} skipped because the limit is ${maxFiles}.`
+            : `${skipped} file${skipped === 1 ? "" : "s"} ${skippedWord} skipped because the limit is ${maxFiles}.`,
+          { type: "warning" },
+        );
       }
       if (!onUpload || readOnly || incoming.length === 0) {
         return;


### PR DESCRIPTION
When the user selects (or drops) more files than `maxFiles` allows, the SDK now uploads the files that fit and surfaces a warning toast via `@optiaxiom/react`'s `toaster` naming how many were skipped (e.g. *"Added 5 files. 2 were skipped because the limit is 10."*), instead of silently discarding the overflow.

No API change — host apps already mount the toaster provider, so the message renders without any wiring.