### PR TITLE
docs: pin install commands to v1 ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A React implementation of Optimizely's Axiom Design System.
 ### Installation
 
 ```sh
-npm install @optiaxiom/react
+npm install @optiaxiom/react@^1
 ```
 
 - [Documentation](https://optimizely-axiom.github.io/optiaxiom/)
@@ -18,7 +18,7 @@ npm install @optiaxiom/react
 We provide an [MCP server](./packages/mcp) that enables AI assistants like Claude Code and Cursor to access accurate Axiom component metadata, design tokens, and usage examples. This helps AI assistants generate better code using the Axiom design system.
 
 ```sh
-npm install -g @optiaxiom/mcp
+npm install -g @optiaxiom/mcp@^1
 ```
 
 See the [MCP guide](https://optimizely-axiom.github.io/optiaxiom/guides/mcp) for setup instructions.

--- a/apps/docs/app/(docs)/guides/mcp/page.mdx
+++ b/apps/docs/app/(docs)/guides/mcp/page.mdx
@@ -18,7 +18,7 @@ Add the MCP server to your workspace configuration file at `.vscode/mcp.json`:
   "servers": {
     "axiom": {
       "command": "npx",
-      "args": ["-y", "@optiaxiom/mcp"]
+      "args": ["-y", "@optiaxiom/mcp@^1"]
     }
   }
 }
@@ -33,7 +33,7 @@ Add to your Cursor MCP configuration:
   "mcpServers": {
     "axiom": {
       "command": "npx",
-      "args": ["-y", "@optiaxiom/mcp"]
+      "args": ["-y", "@optiaxiom/mcp@^1"]
     }
   }
 }
@@ -44,7 +44,7 @@ Add to your Cursor MCP configuration:
 For faster startup times, you can install the package globally:
 
 ```sh npm2yarn
-npm install -g @optiaxiom/mcp
+npm install -g @optiaxiom/mcp@^1
 ```
 
 Then update your configuration to use the global installation:

--- a/apps/docs/app/(docs)/guides/page.mdx
+++ b/apps/docs/app/(docs)/guides/page.mdx
@@ -16,7 +16,7 @@ import { Alert, Link, Text } from "@optiaxiom/react";
 Install the `@optiaxiom/react` package using your package manager of choice:
 
 ```sh npm2yarn
-npm install @optiaxiom/react
+npm install @optiaxiom/react@^1
 ```
 
 ### Setup CSS imports

--- a/apps/docs/demos/code/usage/App.tsx
+++ b/apps/docs/demos/code/usage/App.tsx
@@ -3,7 +3,7 @@ import { Code, Text } from "@optiaxiom/react";
 export function App() {
   return (
     <Text>
-      <Code>npm install @optiaxiom/react</Code>
+      <Code>npm install @optiaxiom/react@^1</Code>
     </Text>
   );
 }

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -24,17 +24,17 @@ MCP (Model Context Protocol) server for Axiom Design System. This server enables
 ### Global Installation
 
 ```bash
-npm install -g @optiaxiom/mcp
+npm install -g @optiaxiom/mcp@^1
 # or
-pnpm add -g @optiaxiom/mcp
+pnpm add -g @optiaxiom/mcp@^1
 ```
 
 ### Project Installation
 
 ```bash
-npm install --save-dev @optiaxiom/mcp
+npm install --save-dev @optiaxiom/mcp@^1
 # or
-pnpm add -D @optiaxiom/mcp
+pnpm add -D @optiaxiom/mcp@^1
 ```
 
 ## Usage
@@ -48,7 +48,7 @@ Add the MCP server to your workspace configuration file at `.vscode/mcp.json`:
   "servers": {
     "axiom": {
       "command": "npx",
-      "args": ["-y", "@optiaxiom/mcp"]
+      "args": ["-y", "@optiaxiom/mcp@^1"]
     }
   }
 }
@@ -63,7 +63,7 @@ Add to your Cursor MCP configuration:
   "mcpServers": {
     "axiom": {
       "command": "npx",
-      "args": ["-y", "@optiaxiom/mcp"]
+      "args": ["-y", "@optiaxiom/mcp@^1"]
     }
   }
 }
@@ -74,7 +74,7 @@ Add to your Cursor MCP configuration:
 You can also run the server directly:
 
 ```bash
-npx @optiaxiom/mcp
+npx @optiaxiom/mcp@^1
 ```
 
 ## Available Tools

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -7,7 +7,7 @@ A React implementation of Optimizely's Axiom Design System.
 Install the package using your package manager of choice:
 
 ```sh
-npm install @optiaxiom/react
+npm install @optiaxiom/react@^1
 ```
 
 ## AI Assistant Integration
@@ -15,7 +15,7 @@ npm install @optiaxiom/react
 We provide an MCP server that enables AI assistants like Claude Code and Cursor to access accurate Axiom component metadata, design tokens, and usage examples:
 
 ```sh
-npm install -g @optiaxiom/mcp
+npm install -g @optiaxiom/mcp@^1
 ```
 
 See the [MCP guide](https://optimizely-axiom.github.io/optiaxiom/guides/mcp) for setup instructions.

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -11,7 +11,7 @@ Please read the full [documentation](https://optimizely-axiom.github.io/optiaxio
 Use your favorite package manager to install the package:
 
 ```sh
-npm install @optiaxiom/web-components
+npm install @optiaxiom/web-components@^1
 ```
 
 Wrap your application with `AxiomProvider` and simply import and use the components:
@@ -35,7 +35,7 @@ Use your favorite CDN to import the package:
 ```html
 <script
   <!-- Make sure to replace `latest` with a fixed version number. -->
-  src="https://cdn.jsdelivr.net/npm/@optiaxiom/web-components@latest/dist/index.js"
+  src="https://cdn.jsdelivr.net/npm/@optiaxiom/web-components@1/dist/index.js"
   type="module"
 ></script>
 ```
@@ -54,7 +54,7 @@ By default the index entry of the library lazy loads components to avoid loading
 
 ```html
 <script
-  src="https://cdn.jsdelivr.net/npm/@optiaxiom/web-components@latest/dist/index.js" <!-- `index.js` entry -->
+  src="https://cdn.jsdelivr.net/npm/@optiaxiom/web-components@1/dist/index.js" <!-- `index.js` entry -->
   type="module"
 ></script>
 
@@ -85,7 +85,7 @@ function App() {
 
 ```html
 <script
-  src="https://cdn.jsdelivr.net/npm/@optiaxiom/web-components@latest/dist/components/Button.js" <!-- `Button.js` entry -->
+  src="https://cdn.jsdelivr.net/npm/@optiaxiom/web-components@1/dist/components/Button.js" <!-- `Button.js` entry -->
   type="module"
 ></script>
 


### PR DESCRIPTION
Pin install commands in v1 docs and READMEs so users copying snippets stay on the v1 release line now that v3 of @optiaxiom/react is published.

- @optiaxiom/react -> @^1
- @optiaxiom/web-components -> @^1
- @optiaxiom/mcp -> @^1