### PR TITLE
chore: promote web-components, mcp, and proteus to v1

### DIFF
--- a/.changeset/v1-major-alignment.md
+++ b/.changeset/v1-major-alignment.md
@@ -1,0 +1,7 @@
+---
+"@optiaxiom/web-components": major
+"@optiaxiom/mcp": major
+"@optiaxiom/proteus": major
+---
+
+Promote packages to v1 to align major version numbers across the Axiom ecosystem. No code changes — this release exists solely to give every public package a stable `^1` install range alongside `@optiaxiom/react@^1`.


### PR DESCRIPTION
Align major version numbers across the Axiom ecosystem so every public package has a stable ^1 install range alongside @optiaxiom/react@^1. No code changes.