### PR TITLE
chore: promote proteus to v3

### DIFF
--- a/.changeset/v1-major-alignment.md
+++ b/.changeset/v1-major-alignment.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": major
+---
+
+Promote packages to v3 to align major version numbers across the Axiom ecosystem. No code changes — this release exists solely to give every public package a stable `^3` install range alongside `@optiaxiom/react@^3`.

--- a/packages/proteus/package.json
+++ b/packages/proteus/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/optimizely-axiom/optiaxiom.git"
   },
   "type": "module",
-  "version": "0.3.0",
+  "version": "2.0.0",
   "files": [
     "dist/**",
     "LICENSE"


### PR DESCRIPTION
Align major version numbers across the Axiom ecosystem so every public package has a stable ^3 install range alongside @optiaxiom/react@^3. No code changes.