### PR TITLE
fix(react): respect disabled prop for AI suggestion trigger

### DIFF
--- a/.changeset/suggestion-respect-disabled.md
+++ b/.changeset/suggestion-respect-disabled.md
@@ -1,0 +1,7 @@
+---
+"@optiaxiom/react": patch
+---
+
+Respect the `disabled` prop on `Input` and `Textarea` for the AI suggestion
+manual trigger. When the field is disabled, the Opal suggestion button is now
+disabled too instead of remaining clickable.

--- a/packages/react/src/input/Input.tsx
+++ b/packages/react/src/input/Input.tsx
@@ -93,7 +93,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         </InputControl>
 
         <InputAddon {...styles.addon()}>
-          <SuggestionPopover />
+          <SuggestionPopover disabled={restProps.disabled} />
           {addonAfter}
         </InputAddon>
       </InputRoot>

--- a/packages/react/src/suggestion/SuggestionManualTrigger.tsx
+++ b/packages/react/src/suggestion/SuggestionManualTrigger.tsx
@@ -46,7 +46,6 @@ export const SuggestionManualTrigger = forwardRef<
     <Button
       appearance="subtle"
       aria-label="Opal suggestion"
-      disabled={pending}
       icon={<Avatar fallback="opal" size="2xs" />}
       loading={pending}
       onClick={() => {
@@ -56,6 +55,7 @@ export const SuggestionManualTrigger = forwardRef<
       ref={ref}
       size="sm"
       {...props}
+      disabled={pending || props.disabled}
     />
   );
 });

--- a/packages/react/src/textarea/Textarea.tsx
+++ b/packages/react/src/textarea/Textarea.tsx
@@ -90,7 +90,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         <InputAddon {...styles.addon()}>
           {props.value !== undefined && (
             <Group justifyContent="end">
-              <SuggestionPopover />
+              <SuggestionPopover disabled={props.disabled} />
             </Group>
           )}
           {addonAfter}


### PR DESCRIPTION
When an `Input` or `Textarea` is disabled, the Opal AI suggestion manual trigger now receives the `disabled` prop too instead of remaining clickable.

Jira: [OPAL-4105](https://optimizely-ext.atlassian.net/browse/OPAL-4105)
