### PR TITLE
feat(react): auto-inherit color in subtle Kbd nested in Button

### DIFF
--- a/.changeset/ninety-trains-grow.md
+++ b/.changeset/ninety-trains-grow.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+`Kbd`: allow inheriting text color so keys can stay readable on colored button backgrounds.

--- a/apps/storybook/src/components/Kbd.stories.tsx
+++ b/apps/storybook/src/components/Kbd.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button, Group, Kbd, Text } from "@optiaxiom/react";
+
+export default {
+  args: {
+    children: "K",
+    modifiers: "mod",
+  },
+  component: Kbd,
+} as Meta<typeof Kbd>;
+
+type Story = StoryObj<typeof Kbd>;
+
+const appearances = [
+  "default",
+  "primary",
+  "subtle",
+  "danger",
+  "danger-outline",
+  "default-opal",
+  "primary-opal",
+] as const;
+
+export const Basic: Story = {};
+
+export const Variants: Story = {
+  render: (args) => (
+    <Group flexDirection="column" gap="16">
+      <Kbd {...args} variant="outline" />
+      <Kbd {...args} variant="subtle" />
+    </Group>
+  ),
+};
+
+export const Inline: Story = {
+  render: (args) => (
+    <Group flexDirection="column" gap="16">
+      <Text fontSize="md">
+        Press <Kbd {...args} variant="outline" /> to open the command palette.
+      </Text>
+      <Text fontSize="md">
+        Press <Kbd {...args} variant="subtle" /> to open the command palette.
+      </Text>
+    </Group>
+  ),
+};
+
+export const WithButton: Story = {
+  args: {
+    children: "↵",
+  },
+  render: (args) => (
+    <Group gap="16">
+      <Group flexDirection="column" gap="16">
+        {appearances.map((appearance) => (
+          <Button
+            addonAfter={<Kbd {...args} variant="outline" />}
+            appearance={appearance}
+            key={appearance}
+          >
+            Submit
+          </Button>
+        ))}
+      </Group>
+      <Group flexDirection="column" gap="16">
+        {appearances.map((appearance) => (
+          <Button
+            addonAfter={<Kbd {...args} variant="subtle" />}
+            appearance={appearance}
+            key={appearance}
+          >
+            Submit
+          </Button>
+        ))}
+      </Group>
+    </Group>
+  ),
+};

--- a/apps/storybook/src/components/Kbd.stories.tsx
+++ b/apps/storybook/src/components/Kbd.stories.tsx
@@ -66,7 +66,7 @@ export const WithButton: Story = {
       <Group flexDirection="column" gap="16">
         {appearances.map((appearance) => (
           <Button
-            addonAfter={<Kbd {...args} variant="subtle" />}
+            addonAfter={<Kbd {...args} color="current" variant="subtle" />}
             appearance={appearance}
             key={appearance}
           >

--- a/packages/react/src/kbd/Kbd.css.ts
+++ b/packages/react/src/kbd/Kbd.css.ts
@@ -2,6 +2,7 @@ import { recipe, type RecipeVariants, style } from "../vanilla-extract";
 
 export const kbd = recipe({
   base: {
+    color: "fg.secondary",
     display: "inline-flex",
     gap: "2",
     whiteSpace: "nowrap",
@@ -11,7 +12,6 @@ export const kbd = recipe({
 export const key = recipe({
   base: {
     alignItems: "center",
-    color: "fg.secondary",
     display: "inline-flex",
     fontFamily: "sans",
     gap: "2",


### PR DESCRIPTION
## Summary

Forward `className` and props to the inner `Box` elements rendered by `Kbd` so consumers can override the appearance of each individual rendered key — e.g. setting `color` on `<Kbd>` so the glyphs are readable on a colored button background.

Closes #1624.
