### PR TITLE
feat(proteus): add interaction mode to ProteusQuestion

### DIFF
--- a/.changeset/proteus-question-interaction-mode.md
+++ b/.changeset/proteus-question-interaction-mode.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": patch
+---
+
+add an `interaction` prop to ProteusQuestion. When set, submit and cancel report a structured `{ questions, answers }` payload via the named interaction instead of a text message, so a calling tool can read the answers programmatically. On cancel the payload also flags that the user declined. When omitted, the existing `message` (text transcript) behaviour is used.

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -639,6 +639,7 @@ export const AskUserQuestion: Story = {
       blocking: true,
       body: {
         $type: "Question",
+        interaction: "ask_user_question",
         questions: {
           $type: "Value",
           path: "/questions",

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -251,7 +251,7 @@ const PROTEUS_COMPONENT_CONFIG = {
     extends: "Fragment",
   },
   Question: {
-    allowedProps: ["questions"],
+    allowedProps: ["interaction", "questions"],
     extends: "Fragment",
     requiredProps: ["questions"],
   },
@@ -1418,6 +1418,11 @@ function getPropTypeOverrides(additionalProperties = false) {
       },
     },
     Question: {
+      interaction: {
+        description:
+          "Name of the interaction to fire when the user finishes or cancels. When set, submit and cancel send a structured `{ questions, answers }` payload via the named interaction so a calling tool can read the answers programmatically. When omitted, a human-readable transcript is sent via the `message` event instead.",
+        type: "string",
+      },
       questions: {
         $ref: "#/definitions/ProteusExpression",
         description: "Array of questions data",

--- a/packages/proteus/src/proteus-question/ProteusQuestion.tsx
+++ b/packages/proteus/src/proteus-question/ProteusQuestion.tsx
@@ -12,6 +12,15 @@ import * as styles from "./ProteusQuestion.css";
 
 export type ProteusQuestionProps = {
   /**
+   * Name of the interaction to fire when the user finishes or cancels.
+   *
+   * When set, submit and cancel send a structured `{ questions, answers }`
+   * payload via the `interaction` event (under this name) so the host can hand
+   * it back to the calling tool. When omitted, a human-readable transcript is
+   * sent via the `message` event instead (the default behaviour).
+   */
+  interaction?: string;
+  /**
    * Array of the questions data.
    */
   questions: QuestionData[];
@@ -23,7 +32,10 @@ type QuestionData = {
   type: "multi_select" | "single_select";
 };
 
-export function ProteusQuestion({ questions }: ProteusQuestionProps) {
+export function ProteusQuestion({
+  interaction,
+  questions,
+}: ProteusQuestionProps) {
   const { onEvent, onTrack } = useProteusDocumentContext(
     "@optiaxiom/proteus/ProteusQuestion",
   );
@@ -45,10 +57,20 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
     onTrack?.("Ask User Question Dismissed", {
       questionIndex: String(currentIndex),
     });
-    void onEvent({
-      message: "[User declined to answer the question]",
-    });
-  }, [currentIndex, onEvent, onTrack]);
+    if (interaction) {
+      void onEvent({
+        interaction,
+        params: {
+          cancelled: "[User declined to answer the question]",
+          questions,
+        },
+      });
+    } else {
+      void onEvent({
+        message: "[User declined to answer the question]",
+      });
+    }
+  }, [currentIndex, interaction, onEvent, onTrack, questions]);
 
   const questionRef = useRef<HTMLDivElement>(null);
   const lastIndexRef = useRef(currentIndex);
@@ -99,6 +121,20 @@ export function ProteusQuestion({ questions }: ProteusQuestionProps) {
       skippedCount: String(questions.length - answeredCount),
       totalQuestions: String(questions.length),
     });
+    if (interaction) {
+      return onEvent({
+        interaction,
+        params: {
+          answers: Object.fromEntries(
+            questions.map(({ question }, index) => [
+              question,
+              (answers[index] ?? []).join(", "),
+            ]),
+          ),
+          questions,
+        },
+      });
+    }
     return onEvent({
       message: answers
         .map(

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -4018,6 +4018,10 @@
       "additionalProperties": false,
       "properties": {
         "$type": { "const": "Question" },
+        "interaction": {
+          "description": "Name of the interaction to fire when the user finishes or cancels. When set, submit and cancel send a structured `{ questions, answers }` payload via the named interaction so a calling tool can read the answers programmatically. When omitted, a human-readable transcript is sent via the `message` event instead.",
+          "type": "string"
+        },
         "questions": {
           "$ref": "#/definitions/ProteusExpression",
           "description": "Array of questions data"

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -3959,6 +3959,10 @@
     "ProteusQuestion": {
       "properties": {
         "$type": { "const": "Question" },
+        "interaction": {
+          "description": "Name of the interaction to fire when the user finishes or cancels. When set, submit and cancel send a structured `{ questions, answers }` payload via the named interaction so a calling tool can read the answers programmatically. When omitted, a human-readable transcript is sent via the `message` event instead.",
+          "type": "string"
+        },
         "questions": {
           "$ref": "#/definitions/ProteusExpression",
           "description": "Array of questions data"


### PR DESCRIPTION
Add an optional `interaction` prop to ProteusQuestion. When set, submit and cancel report a structured payload via the named `interaction` event instead of a text `message`, so a calling tool can read the answers programmatically:

- submit: { questions, answers } where answers is Record<question, string>
  (multi-selects comma-joined, skipped questions mapped to "")
- cancel: { questions, cancelled: "[User declined to answer the question]" }

When `interaction` is omitted, the existing message-transcript behaviour is preserved. Wires the prop through the schema generator and adds an AskUserQuestionInteraction storybook story.