### PR TITLE
Rebrand fixes: disabled button icon, table header font, badge padding

### DIFF
--- a/.changeset/nine-bees-cry.md
+++ b/.changeset/nine-bees-cry.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+update table header font size

--- a/.changeset/slow-squids-work.md
+++ b/.changeset/slow-squids-work.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+update badge padding

--- a/.changeset/smooth-nails-hope.md
+++ b/.changeset/smooth-nails-hope.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+fix primary disabled button icon color

--- a/packages/react/src/badge/Badge.css.ts
+++ b/packages/react/src/badge/Badge.css.ts
@@ -21,7 +21,7 @@ export const badge = recipe({
       fontSize: "sm",
       fontWeight: "400",
       justifyContent: "center",
-      px: "6",
+      px: "8",
       py: "2",
       rounded: "full",
       textTransform: "uppercase",

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -92,6 +92,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           addonBefore = (
             <ButtonIcon
               addon
+              data-disabled={props.disabled ? "" : undefined}
               inverse={props.appearance === "primary"}
               size={size}
             >
@@ -102,6 +103,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           addonAfter = (
             <ButtonIcon
               addon
+              data-disabled={props.disabled ? "" : undefined}
               inverse={props.appearance === "primary"}
               size={size}
             >

--- a/packages/react/src/button/ButtonIcon.css.ts
+++ b/packages/react/src/button/ButtonIcon.css.ts
@@ -85,6 +85,10 @@ export const icon = recipe({
           width: "28px",
 
           selectors: {
+            "&[data-disabled]": {
+              backgroundColor: theme.colors["fg.disabled"],
+              color: theme.colors["bg.secondary"],
+            },
             "&[data-prefix]": {
               paddingBlock: "6px",
             },

--- a/packages/react/src/table/TableHeaderCell.css.ts
+++ b/packages/react/src/table/TableHeaderCell.css.ts
@@ -36,7 +36,7 @@ export const content = recipe({
       color: "fg.tertiary",
       display: "flex",
       fontFamily: "mono",
-      fontSize: "xs",
+      fontSize: "sm",
       fontWeight: "400",
       size: "full",
       textTransform: "uppercase",


### PR DESCRIPTION
## Summary

Three small rebrand-related visual fixes, each closing an issue and accompanied by a changeset.

- **fix primary disabled button icon color** (closes #1587) — the primary large *disabled* button's icon chip kept a solid dark background + bright accent icon, looking enabled. Propagated `data-disabled` onto the icon and added an inverted disabled treatment (`fg.disabled` chip fill, glyph reads as a cutout). Pixel-sampled the designer mock to confirm `fg.disabled` is the exact chip token.
- **update table header font size** (closes #1593)
- **update badge padding** (closes #1594)

## Test plan

- `pnpm lint` (typecheck + lint) passes.
- Verified the disabled primary large button with icon in Storybook — icon chip now matches the expected muted rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
