### PR TITLE
Fix rich text editor scrollable height

### DIFF
--- a/.changeset/rich-text-editor-scrollable-height.md
+++ b/.changeset/rich-text-editor-scrollable-height.md
@@ -1,0 +1,8 @@
+---
+"@optiaxiom/react": patch
+---
+
+Fix `RichTextEditor` overflow when a constrained height is set. The outer
+container is now a flex column with `overflow: hidden`, and the inner
+content area scrolls on its own — so the toolbar stays pinned at the top
+while the editable region scrolls inside.

--- a/apps/storybook/src/components/RichTextEditor.stories.tsx
+++ b/apps/storybook/src/components/RichTextEditor.stories.tsx
@@ -44,3 +44,11 @@ export const Readonly: Story = {
     readOnly: true,
   },
 };
+
+export const FixedHeight: Story = {
+  args: {
+    defaultValue:
+      "<p>This editor has a constrained height. The toolbar stays pinned at the top while the editable content scrolls inside.</p><p>Paragraph 2 — keep typing or scrolling to see the behavior.</p><p>Paragraph 3.</p><p>Paragraph 4.</p><p>Paragraph 5.</p><p>Paragraph 6.</p><p>Paragraph 7.</p><p>Paragraph 8.</p><p>Paragraph 9 — the last line.</p>",
+    h: "224",
+  },
+};

--- a/packages/react/src/rich-text-editor/RichTextEditor.css.ts
+++ b/packages/react/src/rich-text-editor/RichTextEditor.css.ts
@@ -9,6 +9,8 @@ export const editor = recipe({
     {
       bg: "bg.default",
       border: "1",
+      display: "flex",
+      flexDirection: "column",
       rounded: "md",
     },
     style({
@@ -39,6 +41,12 @@ export const toolbar = recipe({
       flexWrap: "wrap",
     }),
   ],
+});
+
+globalStyle(`${editorClass} > div:has(> .ProseMirror)`, {
+  flex: 1,
+  minHeight: 0,
+  overflowY: "auto",
 });
 
 globalStyle(`${editorClass} .ProseMirror`, {


### PR DESCRIPTION
## Summary
<img width="1728" height="790" alt="Screenshot 2026-06-11 at 9 25 33 PM" src="https://github.com/user-attachments/assets/b04396fc-7c37-4fe3-8dcc-7b598d22f9de" />

When `RichTextEditor` is rendered with a constrained height (e.g. `<RichTextEditor h="224" />`), the editor content currently overflows the container — the toolbar scrolls along with the content, and the visual boundary is broken.

This patch makes the editor handle constrained heights correctly: the toolbar stays pinned at the top while the editable content scrolls inside its own area.

## Changes

**`packages/react/src/rich-text-editor/RichTextEditor.css.ts`** — the actual fix
- Outer editor container is now a flex column with `overflow: hidden`
- The ProseMirror wrapper (`> div:has(> .ProseMirror)`) gets `flex: 1`, `min-height: 0`, `overflow-y: auto` — so it claims the remaining vertical space and scrolls on its own

**`apps/storybook/src/components/RichTextEditor.stories.tsx`** — `FixedHeight` story that demonstrates the behavior with `h="224"` and enough paragraphs to overflow.

**Patch bump for `@optiaxiom/react`** via changeset.

## Before / after

| Before | After |
|---|---|
| Toolbar scrolls with content; content can overflow the rounded border | Toolbar stays pinned; content scrolls inside the bordered area |

## Test plan

- [ ] Run `pnpm --filter @optiaxiom/storybook dev`, navigate to **Components → RichTextEditor → Fixed Height** — verify toolbar is pinned and the inner content area has its own scrollbar
- [ ] Other RichTextEditor stories (Basic, Default Value, Controlled, Readonly) render unchanged — no height set, content sizes naturally
- [ ] Lint and existing tests still pass: `pnpm lint --no-fix && pnpm test`
