### PR TITLE
Debounce PillMenu input value change handler

### DIFF
--- a/.changeset/pill-menu-debounce-input.md
+++ b/.changeset/pill-menu-debounce-input.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+Debounce `onInputValueChange` on `PillMenu` by 300ms.

--- a/packages/react/src/pill-menu/PillMenu.tsx
+++ b/packages/react/src/pill-menu/PillMenu.tsx
@@ -1,3 +1,4 @@
+import { useDebouncedCallback } from "@mantine/hooks";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import {
   type ComponentPropsWithoutRef,
@@ -72,6 +73,10 @@ export const PillMenu = forwardRef<HTMLDivElement, PillMenuProps>(
       onChange: onOpenChange,
       prop: openProp,
     });
+    const debouncedOnInputValueChange = useDebouncedCallback(
+      (value: string) => onInputValueChange?.(value),
+      300,
+    );
     const options = optionsProp ?? valueProp ?? EMPTY_LIST;
     const value =
       valueProp ??
@@ -93,7 +98,7 @@ export const PillMenu = forwardRef<HTMLDivElement, PillMenuProps>(
           inputValue={inputValue}
           inputVisible={inputVisible}
           loading={loading}
-          onInputValueChange={onInputValueChange}
+          onInputValueChange={debouncedOnInputValueChange}
           onOpenChange={(open) => {
             setOpen(open);
             if (open) {


### PR DESCRIPTION
## Summary

Wrap the consumer's `onInputValueChange` handler in `PillMenu` with a 300ms debounce (via `useDebouncedCallback` from `@mantine/hooks`, matching the existing `useDebouncedTrack` convention) so async filtering or other side-effects driven by input changes aren't fired on every keystroke.

```diff
+    const debouncedOnInputValueChange = useDebouncedCallback(
+      (value: string) => onInputValueChange?.(value),
+      300,
+    );
     ...
-    onInputValueChange={onInputValueChange}
+    onInputValueChange={debouncedOnInputValueChange}
