### PR TITLE
Guard ProteusQuestion against non-array questions

### DIFF
--- a/.changeset/proteus-question-guard.md
+++ b/.changeset/proteus-question-guard.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/proteus": patch
+---
+
+Guard `ProteusQuestion` against a missing or non-array `questions` prop
+to prevent "cannot read length of undefined" runtime errors.

--- a/packages/proteus/src/proteus-question/ProteusQuestion.tsx
+++ b/packages/proteus/src/proteus-question/ProteusQuestion.tsx
@@ -102,7 +102,7 @@ export function ProteusQuestion({
   const otherInputRef = useRef<HTMLInputElement>(null);
   const otherItemRef = useRef<HTMLDivElement>(null);
 
-  if (currentIndex >= questions.length) {
+  if (!Array.isArray(questions) || currentIndex >= questions.length) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Guards `ProteusQuestion` against a missing or non-array `questions` prop so the component no longer crashes when host data is malformed or still loading.

## Why

`ProteusQuestion` accessed `questions.length` unconditionally, throwing `TypeError: Cannot read properties of undefined (reading 'length')` whenever the host passed `undefined`, `null`, or a non-array value (e.g. while data is streaming in, or when the upstream `Value` expression resolves to nothing). The crash bubbled up and broke the entire `ProteusDocumentRenderer` tree.

## Changes

- `packages/proteus/src/proteus-question/ProteusQuestion.tsx` — added an `Array.isArray(questions)` check to the early-return guard:
  ```diff
  - if (currentIndex >= questions.length) {
  + if (!Array.isArray(questions) || currentIndex >= questions.length) {
      return null;
    }
