### PR TITLE
docs: add fonts guide

### DIFF
--- a/apps/docs/app/(docs)/guides/fonts/page.mdx
+++ b/apps/docs/app/(docs)/guides/fonts/page.mdx
@@ -1,0 +1,41 @@
+import { Alert } from "@optiaxiom/react";
+
+# Fonts (Optimizely staff only)
+
+We ship our licensed brand fonts as a private package for use with our Optimizely Design System.
+
+<Alert intent="warning" mt="16">
+<p style={{ margin: 0 }}>**Optimizely staff** should always use the fonts from our **`@optimizely/axiom-fonts`** package.</p>
+
+<p style={{ margin: 0 }}>**Third party developers** can skip this package - we automatically fall back to free web fonts.</p>
+</Alert>
+
+## Installation
+
+### Install package
+
+Make sure you have access to our private package repository and install the `@optimizely/axiom-fonts` package.
+
+```sh npm2yarn
+npm install @optimizely/axiom-fonts
+```
+
+### Basic usage
+
+Add a bare import statement at the top of your application's entry point (such as your root layout or main entry file) so the fonts CSS gets loaded.
+
+```tsx
+import "@optimizely/axiom-fonts";
+```
+
+Make sure the import stays static and synchronous - keep it as a top-level `import` rather than a dynamic `import()` or lazy-loaded module - so the fonts are available from first paint and you avoid a flash of fallback fonts.
+
+## How it works
+
+### Font fallbacks
+
+Our font stacks already list our **licensed brand fonts** first, followed by free web fonts. The free fonts are loaded automatically by the design system, so text always renders.
+
+### Loading the brand fonts
+
+The `@optimizely/axiom-fonts` package adds the `@font-face` declarations for the brand fonts. Once it's imported, the browser uses them at the front of the stack; without it, text gracefully falls back to the free web fonts.

--- a/apps/docs/app/(docs)/guides/page.mdx
+++ b/apps/docs/app/(docs)/guides/page.mdx
@@ -53,4 +53,4 @@ export function MyComponent() {
 
 ### What to read next
 
-<Cards items={["Components", "Styling", "Icons", "MCP"]} />
+<Cards items={["Components", "Styling", "Icons", "Fonts", "MCP"]} />

--- a/apps/docs/app/_meta.global.tsx
+++ b/apps/docs/app/_meta.global.tsx
@@ -42,6 +42,7 @@ export default {
       },
       "css-imports": "CSS Imports",
       "css-layers": "CSS Layers",
+      fonts: "Fonts",
       icons: "Icons",
       "module-federation": "Module Federation",
       "nested-overlays": "Nested Overlays",

--- a/apps/docs/components/cards/Cards.tsx
+++ b/apps/docs/components/cards/Cards.tsx
@@ -14,6 +14,7 @@ import { DialogIcon } from "./icons/DialogIcon";
 import { DropdownMenuIcon } from "./icons/DropdownMenuIcon";
 import { FileUploadIcon } from "./icons/FileUploadIcon";
 import { FlexIcon } from "./icons/FlexIcon";
+import { FontsIcon } from "./icons/FontsIcon";
 import { GridIcon } from "./icons/GridIcon";
 import { HeadingIcon } from "./icons/HeadingIcon";
 import { IconsIcon } from "./icons/IconsIcon";
@@ -116,6 +117,12 @@ const COMPONENTS = {
     href: "/components/flex/",
     icon: <FlexIcon />,
     title: "Flex",
+  },
+  Fonts: {
+    description: "Brand fonts for use with the Optimizely Design System.",
+    href: "/guides/fonts/",
+    icon: <FontsIcon />,
+    title: "Fonts",
   },
   Grid: {
     description:

--- a/apps/docs/components/cards/icons/FontsIcon.tsx
+++ b/apps/docs/components/cards/icons/FontsIcon.tsx
@@ -1,0 +1,29 @@
+import { Group, Text } from "@optiaxiom/react";
+
+export const FontsIcon = () => (
+  <Group
+    flexDirection="row"
+    fontFamily="heading"
+    style={{ alignItems: "baseline" }}
+  >
+    <Text
+      color="fg.secondary"
+      fontWeight="600"
+      style={{
+        fontSize: "40px",
+        lineHeight: 1,
+      }}
+    >
+      A
+    </Text>
+    <Text
+      color="fg.tertiary"
+      style={{
+        fontSize: "36px",
+        lineHeight: 1,
+      }}
+    >
+      a
+    </Text>
+  </Group>
+);


### PR DESCRIPTION
## Summary

Adds a **Fonts** guide to the docs, mirroring the existing Icons guide. It covers:

- Installing the private `@optimizely/axiom-fonts` package
- Adding the bare import (`import "@optimizely/axiom-fonts";`) at the top of the app entry point, with a note that it must stay static/synchronous so fonts load from first paint
- A short "How it works" section explaining that brand fonts sit at the front of the font stacks and free web fonts are auto-loaded as fallback (so third-party devs can skip the package)

Registered in the guides nav after Icons (`apps/docs/app/_meta.global.tsx`).

## Notes

- Font names are intentionally left out of the page — the exact names are immaterial to consumers.
- Content was verified against the actual `@optimizely/axiom-fonts` package (pure `@font-face` declarations, `sideEffects: true`) and the `fontFamily` token stacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)