### PR TITLE
fix(proteus): use primary button appearance in ask user question

### DIFF
--- a/.changeset/proteus-question-primary-button.md
+++ b/.changeset/proteus-question-primary-button.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": patch
+---
+
+use primary button appearance in ask user question

--- a/packages/proteus/src/proteus-question/ProteusQuestion.tsx
+++ b/packages/proteus/src/proteus-question/ProteusQuestion.tsx
@@ -418,7 +418,7 @@ export function ProteusQuestion({
                 </RovingFocus.Item>
                 {type === "single_select" && (
                   <Button
-                    appearance={otherValue ? "primary-opal" : "default"}
+                    appearance={otherValue ? "primary" : "default"}
                     aria-label={otherValue && (isLast ? "Submit" : "Next")}
                     icon={otherValue && <IconArrowRight />}
                     ml="auto"
@@ -459,7 +459,7 @@ export function ProteusQuestion({
             Skip
           </Button>
           <Button
-            appearance={valid ? "primary-opal" : "default"}
+            appearance={valid ? "primary" : "default"}
             aria-label={isLast ? "Submit" : "Next"}
             disabled={!valid}
             icon={<IconArrowRight />}


### PR DESCRIPTION
Switches the Submit/Next action buttons in `ProteusQuestion` (ask user question) from the Opal-branded `primary-opal` appearance to the rebranded `primary` appearance.

- `primary-opal` → `variant: strong-opal` (old Opal style)
- `primary` → `variant: strong` (rebranded primary)

Same `intent: primary`, just the non-Opal visual variant.