### PR TITLE
fix(react): make progress opal intent render identically to primary

### DIFF
--- a/.changeset/progress-opal-shows-primary.md
+++ b/.changeset/progress-opal-shows-primary.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+Make the `Progress` `intent="opal"` render identically to `intent="primary"` for backward compatibility.

--- a/packages/react/src/progress/Progress.css.ts
+++ b/packages/react/src/progress/Progress.css.ts
@@ -1,9 +1,11 @@
+import { theme } from "@optiaxiom/globals";
+
 import { recipe, type RecipeVariants, style } from "../vanilla-extract";
 
 export const progress = recipe({
   base: [
     {
-      bg: "bg.tertiary",
+      bg: "bg.pill.default",
       overflow: "hidden",
       rounded: "full",
     },
@@ -26,20 +28,25 @@ export const indicator = recipe({
      * Control the appearance by selecting between the different progress types.
      */
     intent: {
-      danger: {
-        bg: "bg.error",
-      },
-      opal: {
-        bg: "bg.accent",
-      },
-      primary: {
-        bg: "bg.accent",
-      },
-      success: {
-        bg: "bg.success",
-      },
+      danger: style({
+        backgroundColor: theme.colors["bg.error"],
+      }),
+      opal: {},
+      primary: {},
+      success: {},
     },
   },
+
+  variantsCompounded: [
+    {
+      style: style({
+        backgroundColor: theme.colors["fg.tertiary"],
+      }),
+      variants: {
+        intent: ["opal", "primary", "success"],
+      },
+    },
+  ],
 });
 
 export type ProgressVariants = RecipeVariants<typeof indicator>;

--- a/packages/react/src/progress/Progress.css.ts
+++ b/packages/react/src/progress/Progress.css.ts
@@ -29,9 +29,9 @@ export const indicator = recipe({
       danger: {
         bg: "bg.error",
       },
-      opal: style({
-        backgroundImage: `linear-gradient(90deg, #8041EE, #7740EC, #002CCC)`,
-      }),
+      opal: {
+        bg: "bg.accent",
+      },
       primary: {
         bg: "bg.accent",
       },


### PR DESCRIPTION
## Summary

Makes the `Progress` `intent="opal"` render identically to `intent="primary"`, mirroring the `primary-opal` button change. Existing consumers of `intent="opal"` keep working but now get the plain primary indicator instead of the opal gradient.

<img width="505" height="186" alt="image" src="https://github.com/user-attachments/assets/5c4a8440-4051-4d0b-93ec-853530f5a2b2" />

## Changes
- `Progress.css.ts`: the `opal` intent now uses `bg: "bg.accent"` (same as `primary`) instead of the `linear-gradient(...)`. The `opal` key is kept so the prop value stays valid.
- Patch changeset for `@optiaxiom/react`.

## Notes
- Scoped to `Progress`. `Alert`'s `intent="opal"` is untouched (it has no `primary` intent).