### PR TITLE
fix(react): render alert opal intent with neutral background

### DIFF
--- a/.changeset/alert-opal-neutral-background.md
+++ b/.changeset/alert-opal-neutral-background.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+Render the `Alert` `intent="opal"` with the neutral background instead of the opal gradient, for backward compatibility. The opal icon is unchanged.

--- a/packages/react/src/alert/Alert.css.ts
+++ b/packages/react/src/alert/Alert.css.ts
@@ -31,7 +31,7 @@ export const alert = recipe({
         bg: "bg.secondary",
       },
       opal: {
-        backgroundImage: `gradient.opal`,
+        bg: "bg.secondary",
       },
       success: {
         bg: "bg.success.subtle",


### PR DESCRIPTION
## Summary

Renders the `Alert` `intent="opal"` with the **neutral** background instead of the opal gradient, for backward compatibility. Existing consumers of `intent="opal"` (e.g. `SuggestionAlert`) keep working but get the standard grey alert background.

Alert has no `primary` intent, so neutral (the component's default) is the standard-look analog of the `primary-opal` button / `opal` progress changes.

## Changes
- `Alert.css.ts`: the `opal` intent background is now `bg.secondary` (same as `neutral`) instead of `gradient.opal`.
- The `opal` key is kept so the prop value stays valid.
- **The opal orb icon is intentionally kept** — only the background changes.
- Patch changeset for `@optiaxiom/react`.

## Notes
- Separate from the Progress opal change (#1686).