### PR TITLE
fix(proteus): use rebranded avatar color for document header icon

### DIFF
--- a/.changeset/proteus-titleicon-rebrand-color.md
+++ b/.changeset/proteus-titleicon-rebrand-color.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": patch
+---
+
+Use the rebranded `bg.accent.subtle` color for the document header agent avatar instead of the pre-rebrand `bg.avatar.purple`, so a custom `titleIcon` no longer shows a lavender ring and the no-icon fallback matches the current brand.

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -335,7 +335,7 @@ export function ProteusDocumentShell({
             >
               {element.titleIcon && (
                 <Group
-                  bg="bg.avatar.purple"
+                  bg="bg.accent.subtle"
                   flex="none"
                   justifyContent="center"
                   rounded="lg"


### PR DESCRIPTION
## Summary

The proteus `UI.Document` card header rendered its agent avatar wrapper with **`bg.avatar.purple`** (lavender `#EDE9FE`) — a pre-rebrand token in an otherwise green theme. With a custom green `titleIcon` (whose own fill is `bg.accent.subtle` `#EEFFD9`) sitting inset in the 32px wrapper, that lavender showed as a ring around the icon.

## Fix
Point the wrapper at the **rebranded** `bg.accent.subtle` (the same green the Opal agents-page avatar and the icon use):

```diff
- <Group bg="bg.avatar.purple" ... size="md">
+ <Group bg="bg.accent.subtle" ... size="md">
```

This fixes it on both paths:
- **Custom icon** — the wrapper bg now equals the icon's own `bg.accent.subtle`, so the inset ring is the same green → invisible.
- **No-icon fallback** — the default agent avatar is now the current brand color instead of lavender.

## Why not redefine `bg.avatar.purple`?
That token is literally named `purple`, maps to the purple palette, and backs Axiom `Avatar`'s public `colorScheme="purple"` option. Redefining it to green would be a misleading token and would silently change every purple avatar in the system. The right scope is the card's reference, not the global token.

## Changes
- `ProteusDocumentShell.tsx`: wrapper `bg` → `bg.accent.subtle`.
- Patch changeset for `@optiaxiom/proteus`.