### PR TITLE
fix(calendar): localize Calendar, DateRangePicker, and Clock to browser locale

### DIFF
--- a/.changeset/calendar-browser-locale.md
+++ b/.changeset/calendar-browser-locale.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": minor
+---
+
+localize `Calendar`, `DateRangePicker`, and `Clock` to the browser locale (via `navigator.language`) instead of always rendering in English

--- a/packages/react/src/calendar/Calendar.tsx
+++ b/packages/react/src/calendar/Calendar.tsx
@@ -6,14 +6,14 @@ import {
   useRef,
   useState,
 } from "react";
-import { DayPicker, type Matcher } from "react-day-picker";
+import { DayPicker, type Formatters, type Matcher } from "react-day-picker";
 
 import { Box, type BoxProps } from "../box";
 import { Clock } from "../clock";
 import { Group } from "../group";
 import { usePopoverContentContext } from "../popover/internals";
 import { Text } from "../text";
-import { toInstant, toPlainDate, toPlainTime } from "../utils";
+import { formatDate, toInstant, toPlainDate, toPlainTime } from "../utils";
 import * as styles from "./Calendar.css";
 import { CalendarCaptionLabel } from "./CalendarCaptionLabel";
 import { CalendarChevron } from "./CalendarChevron";
@@ -30,12 +30,24 @@ import { CalendarWeekday } from "./CalendarWeekday";
 import { CalendarWeekdays } from "./CalendarWeekdays";
 import { toTimeZoneName } from "./toTimeZoneName";
 
-const locale = new Intl.Locale(navigator.language ?? "en-US");
+const locale = new Intl.Locale(
+  typeof navigator !== "undefined" ? navigator.language : "en-US",
+);
 const weekInfo =
   "getWeekInfo" in locale && typeof locale.getWeekInfo === "function"
     ? (locale.getWeekInfo() as { firstDay: number })
     : { firstDay: 0 };
 const weekStartsOn = (weekInfo.firstDay % 7) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+/**
+ * Override `react-day-picker`'s default formatters with locale-aware ones so the
+ * calendar localizes to the browser locale without a date-fns locale object.
+ */
+const formatters: Partial<Formatters> = {
+  formatCaption: (month) => formatDate(month, "LLLL yyyy"),
+  formatDay: (day) => formatDate(day, "d"),
+  formatWeekdayName: (weekday) => formatDate(weekday, "cccccc"),
+};
 
 export type CalendarProps = BoxProps<
   "div",
@@ -220,6 +232,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
                   ...(min ? [{ before: min }] : []),
                   ...(max ? [{ after: max }] : []),
                 ]}
+                formatters={formatters}
                 mode="single"
                 modifiers={{ holiday, weekend }}
                 month={month}
@@ -246,6 +259,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
                   ...(max ? [{ after: max }] : []),
                 ]}
                 fixedWeeks
+                formatters={formatters}
                 mode="range"
                 modifiers={{ holiday, weekend }}
                 month={month}

--- a/packages/react/src/calendar/CalendarCaptionLabel.tsx
+++ b/packages/react/src/calendar/CalendarCaptionLabel.tsx
@@ -4,8 +4,10 @@ import { IconAngleDown } from "@optiaxiom/icons";
 import { CaptionLabel } from "react-day-picker";
 
 import { Button } from "../button";
+import { formatDate } from "../utils";
 import { VisuallyHidden } from "../visually-hidden";
 import { useCalendarContext } from "./CalendarContext";
+import { withYear } from "./utils";
 
 export type CalendarCaptionLabelProps = ComponentPropsWithoutRef<
   typeof CaptionLabel
@@ -35,10 +37,11 @@ export function CalendarCaptionLabel({
       <CaptionLabel {...props}>
         {view === "year" ? (
           <>
-            {month.getFullYear()} - {month.getFullYear() + 11}
+            {formatDate(month, "yyyy")} -{" "}
+            {formatDate(withYear(month, month.getFullYear() + 11), "yyyy")}
           </>
         ) : view === "month" ? (
-          month.getFullYear()
+          formatDate(month, "yyyy")
         ) : (
           children
         )}

--- a/packages/react/src/calendar/CalendarMonthGrid.tsx
+++ b/packages/react/src/calendar/CalendarMonthGrid.tsx
@@ -2,26 +2,17 @@ import { type ComponentPropsWithoutRef, useEffect, useRef } from "react";
 import { MonthGrid } from "react-day-picker";
 
 import { Box } from "../box";
+import { formatDate } from "../utils";
 import { useCalendarContext } from "./CalendarContext";
 import { CalendarGrid } from "./CalendarGrid";
 import { withMonth, withYear } from "./utils";
 
 export type CalendarMonthGridProps = ComponentPropsWithoutRef<typeof MonthGrid>;
 
-const months = [
-  ["Jan", "January"] as const,
-  ["Feb", "February"] as const,
-  ["Mar", "March"] as const,
-  ["Apr", "April"] as const,
-  ["May", "May"] as const,
-  ["Jun", "June"] as const,
-  ["Jul", "July"] as const,
-  ["Aug", "August"] as const,
-  ["Sep", "September"] as const,
-  ["Oct", "October"] as const,
-  ["Nov", "November"] as const,
-  ["Dec", "December"] as const,
-];
+const months = Array.from({ length: 12 }, (_, month) => {
+  const date = new Date(2000, month, 1);
+  return [formatDate(date, "LLL"), formatDate(date, "LLLL")] as const;
+});
 
 export function CalendarMonthGrid({
   children,
@@ -79,7 +70,8 @@ export function CalendarMonthGrid({
         ) ?? [],
       );
       const focusedDay =
-        days.find((day) => day.textContent === `${month.getDate()}`) ?? days[0];
+        days.find((day) => day.textContent === formatDate(month, "d")) ??
+        days[0];
       focusedDay?.focus();
     }
     lastMonthRef.current = month;
@@ -96,9 +88,13 @@ export function CalendarMonthGrid({
           setMonth(withYear(month, month.getFullYear() + value));
           setView("month");
         }}
-        options={Array.from({ length: 12 }).map(
-          (_, index) => month.getFullYear() + index,
-        )}
+        options={Array.from({ length: 12 }).map((_, index) => {
+          const year = formatDate(
+            withYear(month, month.getFullYear() + index),
+            "yyyy",
+          );
+          return [year, year] as const;
+        })}
         value={0}
       />
     );

--- a/packages/react/src/clock/Clock.tsx
+++ b/packages/react/src/clock/Clock.tsx
@@ -5,7 +5,14 @@ import type { BoxProps } from "../box";
 
 import { Group } from "../group";
 import { Select, SelectContent, SelectTrigger } from "../select";
-import { format, is24Hour, parse, range } from "./utils";
+import {
+  format,
+  is24Hour,
+  parse,
+  range,
+  toLabel,
+  toMeridiemLabel,
+} from "./utils";
 
 export type ClockProps = BoxProps<
   "div",
@@ -64,7 +71,7 @@ export const Clock = forwardRef<HTMLDivElement, ClockProps>(
           onValueChange={(hour) =>
             hour && setValue(format({ ...parsed, hour }))
           }
-          options={hours.map((hour) => ({ label: hour, value: hour }))}
+          options={hours.map((hour) => ({ label: toLabel(hour), value: hour }))}
           value={parsed.hour}
         >
           <SelectTrigger aria-label="Select hour" flex="1" placeholder="HH" />
@@ -76,7 +83,7 @@ export const Clock = forwardRef<HTMLDivElement, ClockProps>(
           }
           options={minutes.map((minute) => ({
             ariaLabel: `${parseInt(minute)}`,
-            label: minute,
+            label: toLabel(minute),
             value: minute,
           }))}
           value={parsed.minute}
@@ -91,7 +98,7 @@ export const Clock = forwardRef<HTMLDivElement, ClockProps>(
               setValue(format({ ...parsed, meridiem }))
             }
             options={periods.map((period) => ({
-              label: period,
+              label: toMeridiemLabel(period),
               value: period,
             }))}
             value={parsed.meridiem}

--- a/packages/react/src/clock/utils.ts
+++ b/packages/react/src/clock/utils.ts
@@ -1,9 +1,41 @@
-const locale = new Intl.Locale(navigator.language ?? "en-US");
+const language =
+  typeof navigator !== "undefined" ? navigator.language : "en-US";
+const locale = new Intl.Locale(language);
 const hourCycles =
   "getHourCycles" in locale && typeof locale.getHourCycles === "function"
     ? (locale.getHourCycles() as string[])
     : ["h12"];
 export const is24Hour = hourCycles[0] === "h23";
+
+const numberFormatter = new Intl.NumberFormat(language, { useGrouping: false });
+
+/**
+ * Transliterates the digits of an already-formatted numeric string (e.g.
+ * `"05"`) into the browser locale's numbering system (e.g. `"०५"` for `mr-IN`),
+ * preserving any existing padding. This is digit transliteration rather than a
+ * date format because the clock's value is a `HH:mm` string, not a `Date` — the
+ * underlying Latin value stays unchanged so the time contract is preserved.
+ */
+export const toLabel = (value: string) =>
+  value
+    .split("")
+    .map((digit) => numberFormatter.format(Number(digit)))
+    .join("");
+
+const dayPeriodFormatter = new Intl.DateTimeFormat(language, {
+  hour: "numeric",
+  hour12: true,
+});
+
+/**
+ * Returns the localized AM/PM label — date-fns's `aaa` token, via `Intl`. Yields
+ * `"ص"`/`"م"` for `ar`, but still `"AM"`/`"PM"` for locales like `mr` that use
+ * them by convention.
+ */
+export const toMeridiemLabel = (meridiem: "AM" | "PM") =>
+  dayPeriodFormatter
+    .formatToParts(new Date(2025, 0, 1, meridiem === "AM" ? 9 : 21))
+    .find((part) => part.type === "dayPeriod")?.value ?? meridiem;
 
 export const format = ({
   hour,

--- a/packages/react/src/utils/formatDate.ts
+++ b/packages/react/src/utils/formatDate.ts
@@ -1,0 +1,42 @@
+/**
+ * The browser's preferred locale, used to localize dates without requiring a
+ * `locale` prop. Falls back to `en-US` when unavailable (e.g. SSR).
+ */
+const language =
+  typeof navigator !== "undefined" ? navigator.language : "en-US";
+
+const dateTimeFormat = (options: Intl.DateTimeFormatOptions) =>
+  new Intl.DateTimeFormat(language, options).format;
+/**
+ * Bare numbers go through `NumberFormat` rather than `DateTimeFormat` because
+ * the latter appends date-unit suffixes in some locales (e.g. `5日` in `zh`),
+ * which we don't want for day/year cells.
+ */
+const numberFormat = new Intl.NumberFormat(language, { useGrouping: false })
+  .format;
+
+const tokens = {
+  cccccc: dateTimeFormat({ weekday: "short" }),
+  d: (date: Date) => numberFormat(date.getDate()),
+  LLL: dateTimeFormat({ month: "short" }),
+  LLLL: dateTimeFormat({ month: "long" }),
+  "LLLL yyyy": dateTimeFormat({ month: "long", year: "numeric" }),
+  yyyy: (date: Date) => numberFormat(date.getFullYear()),
+};
+
+/**
+ * A locale-aware `formatDate(date, token)` modeled on date-fns's `format`, but
+ * backed by `Intl` and limited to the tokens we actually use:
+ *
+ * - `d` — day of month (`5`)
+ * - `yyyy` — year (`2025`)
+ * - `LLL` — standalone short month (`Jan`)
+ * - `LLLL` — standalone full month (`January`)
+ * - `LLLL yyyy` — month and year (`January 2025`)
+ * - `cccccc` — standalone short weekday (`Su`)
+ *
+ * Add new tokens to the map above as components need them, rather than parsing
+ * arbitrary format strings.
+ */
+export const formatDate = (date: Date, token: keyof typeof tokens) =>
+  tokens[token](date);

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -3,6 +3,7 @@ export * from "./decorateChildren";
 export * from "./ExcludeProps";
 export * from "./ExtendProps";
 export * from "./fallbackSpan";
+export * from "./formatDate";
 export * from "./isFocusCaptured";
 export * from "./isHoverSupported";
 export * from "./mapValues";


### PR DESCRIPTION
## Problem

`Calendar`, `DateRangePicker`, and `Clock` always rendered in English regardless of the user's locale (#1696). The locale was never passed through to `react-day-picker`, and several strings (the month-picker grid, day numbers) were hardcoded English.

## Approach

Localize automatically from `navigator.language` — **no new prop**, so consumers can't forget to set it. Backed entirely by the browser's `Intl` API rather than a date-fns locale object (date-fns is only present transitively via `react-day-picker`).

A shared, token-based `formatDate(date, token)` util — modeled on date-fns's public `format` API with a small hardcoded token map (`d`, `yyyy`, `LLL`, `LLLL`, `LLLL yyyy`, `cccccc`) — drives the calendar formatting. `react-day-picker`'s `formatters`/`weekStartsOn` props consume it.

## What's localized

- **Calendar**: month captions, weekday headers, day numbers, month/year picker grids, year labels
- **DateRangePicker**: range text (already browser-default)
- **Clock**: hour/minute digits and AM/PM labels (digit transliteration + `Intl` dayPeriod)
- First day of the week derived from the same locale

## Notes

- Day/year numbers use `Intl.NumberFormat`, not `DateTimeFormat`, to avoid date-unit suffixes (e.g. `5日` in `zh`/`ja`).
- AM/PM uses `Intl` dayPeriod, which correctly yields `ص`/`م` (Arabic), `上午`/`下午` (Chinese), but keeps `AM`/`PM` where that's the convention (e.g. `mr`).
- The Clock's underlying value stays Latin `HH:mm`; only the displayed label is localized, so the time contract is unchanged.
- DateInput's trigger is a native `<input type="datetime-local">`, already localized by the browser — untouched.

Closes #1696

🤖 Generated with [Claude Code](https://claude.com/claude-code)
