### PR TITLE
fix(calendar): use narrow weekday headers to keep the calendar compact

### DIFF
--- a/packages/react/src/calendar/Calendar.tsx
+++ b/packages/react/src/calendar/Calendar.tsx
@@ -46,7 +46,7 @@ const weekStartsOn = (weekInfo.firstDay % 7) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
 const formatters: Partial<Formatters> = {
   formatCaption: (month) => formatDate(month, "LLLL yyyy"),
   formatDay: (day) => formatDate(day, "d"),
-  formatWeekdayName: (weekday) => formatDate(weekday, "cccccc"),
+  formatWeekdayName: (weekday) => formatDate(weekday, "ccccc"),
 };
 
 export type CalendarProps = BoxProps<

--- a/packages/react/src/utils/formatDate.ts
+++ b/packages/react/src/utils/formatDate.ts
@@ -16,7 +16,7 @@ const numberFormat = new Intl.NumberFormat(language, { useGrouping: false })
   .format;
 
 const tokens = {
-  cccccc: dateTimeFormat({ weekday: "short" }),
+  ccccc: dateTimeFormat({ weekday: "narrow" }),
   d: (date: Date) => numberFormat(date.getDate()),
   LLL: dateTimeFormat({ month: "short" }),
   LLLL: dateTimeFormat({ month: "long" }),
@@ -33,7 +33,7 @@ const tokens = {
  * - `LLL` — standalone short month (`Jan`)
  * - `LLLL` — standalone full month (`January`)
  * - `LLLL yyyy` — month and year (`January 2025`)
- * - `cccccc` — standalone short weekday (`Su`)
+ * - `ccccc` — standalone narrow weekday (`S`)
  *
  * Add new tokens to the map above as components need them, rather than parsing
  * arbitrary format strings.


### PR DESCRIPTION
## Problem

The locale change in #1698 switched weekday headers to `Intl` `"short"`, which is the **3-letter** form (`Sun Mon Tue…`). That widened the calendar versus the previous **2-letter** look (`Su Mo Tu…`) — a visible regression.

## Fix

Use `Intl` `"narrow"` (**1-letter**: `S M T W T F S`) for the weekday header.

`Intl` has no native 2-letter weekday option (that was a date-fns `cccccc` token specific). The realistic compact choices are 1-letter `narrow` or deriving 2-letters by slicing the long name — but slicing breaks for several scripts (e.g. Arabic yields `ال ال ال…` for every day). `narrow` is locale-safe everywhere:

| locale | narrow |
|---|---|
| en | S M T W T F S |
| ja | 日 月 火 水 木 金 土 |
| ar | (correct per-locale narrow forms) |

The `formatDate` token is renamed `cccccc` → `ccccc` to match date-fns's narrow-weekday token, keeping the vocabulary accurate.

No changeset — this is a follow-up to the unreleased #1698.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
