### PR TITLE
fix(react): move RichTextEditor to its own entrypoint to drop tiptap from barrel

### DIFF
--- a/.changeset/globals-remove-fonts-proxy.md
+++ b/.changeset/globals-remove-fonts-proxy.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/globals": patch
+"@optiaxiom/react": patch
+---
+
+remove the unused root CommonJS shims (`@optiaxiom/globals/fonts.js` and `@optiaxiom/react/unstable.js`) — these subpaths resolve through the package `exports` map, which every supported bundler and Node version honors

--- a/.changeset/rich-text-editor-entrypoint.md
+++ b/.changeset/rich-text-editor-entrypoint.md
@@ -1,0 +1,9 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/proteus": patch
+"@optiaxiom/web-components": patch
+---
+
+move `RichTextEditor` to its own entrypoint so importing from the main barrel no longer pulls in `@tiptap/*`. Consumers who don't use the editor no longer need the tiptap peer dependencies (now marked optional). Import the editor via `import { RichTextEditor } from "@optiaxiom/react/editor"`. Also corrected the `@optiaxiom/react/css-runtime` CommonJS export to point at the file that is actually built.
+
+`ax-rich-text-editor` is removed from `@optiaxiom/web-components` for now while the editor lives behind the dedicated entrypoint.

--- a/apps/storybook/src/components/RichTextEditor.stories.tsx
+++ b/apps/storybook/src/components/RichTextEditor.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { Group, RichTextEditor, Text } from "@optiaxiom/react";
+import { Group, Text } from "@optiaxiom/react";
+import { RichTextEditor } from "@optiaxiom/react/editor";
 import { useState } from "react";
 
 export default {

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -6,6 +6,7 @@
       "@optiaxiom/icons": ["../../packages/icons/src"],
       "@optiaxiom/proteus": ["../../packages/proteus/src"],
       "@optiaxiom/react": ["../../packages/react/src"],
+      "@optiaxiom/react/editor": ["../../packages/react/src/editor.ts"],
       "@optiaxiom/react/unstable": ["../../packages/react/src/unstable.ts"]
     }
   },

--- a/packages/globals/fonts.js
+++ b/packages/globals/fonts.js
@@ -1,3 +1,0 @@
-/* eslint-disable */
-// @ts-ignore
-module.exports = require("./dist/cjs/fonts.js");

--- a/packages/proteus/src/proteus-document/schemas.ts
+++ b/packages/proteus/src/proteus-document/schemas.ts
@@ -15,7 +15,6 @@ import type {
   HeadingProps,
   InputProps,
   LinkProps,
-  RichTextEditorProps,
   SelectContentProps,
   SelectTriggerProps,
   SeparatorProps,
@@ -23,6 +22,7 @@ import type {
   TextareaProps,
   TextProps,
 } from "@optiaxiom/react";
+import type { RichTextEditorProps } from "@optiaxiom/react/editor";
 import type { RangeProps, TimeProps } from "@optiaxiom/react/unstable";
 
 import { Validator } from "@cfworker/json-schema";

--- a/packages/proteus/src/proteus-rich-text-editor/ProteusRichTextEditor.tsx
+++ b/packages/proteus/src/proteus-rich-text-editor/ProteusRichTextEditor.tsx
@@ -1,4 +1,7 @@
-import { RichTextEditor, type RichTextEditorProps } from "@optiaxiom/react";
+import {
+  RichTextEditor,
+  type RichTextEditorProps,
+} from "@optiaxiom/react/editor";
 
 import { useProteusDocumentContext } from "../proteus-document/ProteusDocumentContext";
 import { useProteusDocumentPathContext } from "../proteus-document/ProteusDocumentPathContext";

--- a/packages/proteus/tsconfig.json
+++ b/packages/proteus/tsconfig.json
@@ -7,6 +7,7 @@
       "@optiaxiom/icons": ["../icons/src"],
       "@optiaxiom/react": ["../react/src"],
       "@optiaxiom/react/css-runtime": ["../react/src/css-runtime"],
+      "@optiaxiom/react/editor": ["../react/src/editor"],
       "@optiaxiom/react/unstable": ["../react/src/unstable"]
     }
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,12 @@
     "./css-runtime": {
       "types": "./dist/css-runtime.d.ts",
       "import": "./dist/esm/css-runtime.js",
-      "require": "./dist/cjs/css-runtime.cjs"
+      "require": "./dist/cjs/css-runtime.js"
+    },
+    "./editor": {
+      "types": "./dist/editor.d.ts",
+      "import": "./dist/esm/editor.js",
+      "require": "./dist/cjs/editor.js"
     },
     "./package.json": "./package.json",
     "./unstable": {
@@ -115,5 +120,34 @@
     "@tiptap/starter-kit": "^2.10.3",
     "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@tiptap/extension-link": {
+      "optional": true
+    },
+    "@tiptap/extension-placeholder": {
+      "optional": true
+    },
+    "@tiptap/extension-table": {
+      "optional": true
+    },
+    "@tiptap/extension-table-cell": {
+      "optional": true
+    },
+    "@tiptap/extension-table-header": {
+      "optional": true
+    },
+    "@tiptap/extension-table-row": {
+      "optional": true
+    },
+    "@tiptap/pm": {
+      "optional": true
+    },
+    "@tiptap/react": {
+      "optional": true
+    },
+    "@tiptap/starter-kit": {
+      "optional": true
+    }
   }
 }

--- a/packages/react/rolldown.config.mjs
+++ b/packages/react/rolldown.config.mjs
@@ -27,6 +27,7 @@ const external = new RegExp(
 export default defineConfig([
   ...getConfig({
     input: {
+      editor: "src/editor.ts",
       index: "src/index.ts",
       unstable: "src/unstable.ts",
     },

--- a/packages/react/src/editor.ts
+++ b/packages/react/src/editor.ts
@@ -1,0 +1,1 @@
+export * from "./rich-text-editor";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -41,7 +41,6 @@ export * from "./paper";
 export * from "./popover";
 export * from "./progress";
 export * from "./radio";
-export * from "./rich-text-editor";
 export * from "./search-input";
 export * from "./segmented-control";
 export * from "./select";

--- a/packages/react/unstable.js
+++ b/packages/react/unstable.js
@@ -1,3 +1,0 @@
-/* eslint-disable */
-// @ts-ignore
-module.exports = require("./dist/cjs/fonts.js");

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -124,7 +124,6 @@
     "./Progress": "./dist/components/Progress.js",
     "./Radio": "./dist/components/Radio.js",
     "./RadioGroup": "./dist/components/RadioGroup.js",
-    "./RichTextEditor": "./dist/components/RichTextEditor.js",
     "./SearchInput": "./dist/components/SearchInput.js",
     "./SegmentedControl": "./dist/components/SegmentedControl.js",
     "./SegmentedControlItem": "./dist/components/SegmentedControlItem.js",


### PR DESCRIPTION
## Summary

Fixes #1703. Since `@optiaxiom/react@3.1.x`, importing **anything** from the main barrel transitively pulls in `RichTextEditor`, which statically imports `@tiptap/*`. Those tiptap packages are declared as **required** peer dependencies, so any consumer who does not use the editor is still forced to install the whole tiptap/ProseMirror stack — or their build/tests break on an unresolved import (`Failed to resolve import "@tiptap/extension-link"`).

The root cause is the import graph, not the peer-dep declaration: the barrel statically re-exports RTE, RTE statically imports tiptap, and module **resolution happens before tree-shaking**. So an un-installed peer breaks every barrel consumer regardless of `sideEffects` / `optional`.

## Changes

- **New `@optiaxiom/react/editor` entrypoint** — RTE now ships from its own subpath (`src/editor.ts` → rolldown input → `exports` map). The main barrel no longer references tiptap at all, so editor-less consumers never trigger tiptap resolution.
- **`@tiptap/*` peers marked `optional`** via `peerDependenciesMeta`.
- **Migrated in-repo consumers** to `@optiaxiom/react/editor`: proteus (`ProteusRichTextEditor`, `schemas.ts` + tsconfig alias) and the Storybook story (+ tsconfig alias).
- **Removed `ax-rich-text-editor` from `@optiaxiom/web-components`** for now (its `./RichTextEditor` export depended on the React barrel exporting RTE).
- **Cleanup (separate commit)**: removed the unused root CommonJS shims `@optiaxiom/react/unstable.js` (also broken — pointed at a non-existent file) and `@optiaxiom/globals/fonts.js`; both subpaths resolve via the `exports` map. Also corrected the `./css-runtime` CommonJS export to the file that is actually built.

## Migration

```diff
-import { RichTextEditor } from "@optiaxiom/react";
+import { RichTextEditor } from "@optiaxiom/react/editor";
```

## Verification

- `pnpm --filter @optiaxiom/react build` → emits `dist/{esm,cjs}/editor.js` + `dist/editor.d.ts`; `grep tiptap dist/esm/index.js` → no hits (barrel clean); `dist/esm/editor.js` re-exports RTE.
- `pnpm lint` → 0 errors. `pnpm test` → 48/48 pass (incl. RTE spec).
- `pnpm --filter @optiaxiom/web-components build` → clean.

Changesets included for `@optiaxiom/react`, `@optiaxiom/proteus`, `@optiaxiom/web-components`, and `@optiaxiom/globals` (all `patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
