### PR TITLE
fix(react): only apply large primary button start padding with a leading icon

### DIFF
--- a/.changeset/button-large-primary-start-padding.md
+++ b/.changeset/button-large-primary-start-padding.md
@@ -1,0 +1,6 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+---
+
+Fixed large primary `Button` reserving extra left padding when it has no leading icon. The tightened left padding now only applies when an icon or addon precedes the label.

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -140,6 +140,16 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       );
     });
 
+    const addon = square
+      ? "only"
+      : addonBefore && addonAfter
+        ? "both"
+        : addonBefore
+          ? "start"
+          : addonAfter
+            ? "end"
+            : "none";
+
     const isIconMissingAriaLabel = isIconOnly && !props["aria-label"];
     useEffect(() => {
       if (isIconMissingAriaLabel) {
@@ -151,6 +161,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     return (
       <ButtonRoot
+        addon={addon}
         asChild
         justifyContent={
           square
@@ -167,7 +178,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         }}
         ref={ref}
         size={size}
-        square={square}
         {...props}
       >
         <Comp>{children}</Comp>

--- a/packages/react/src/button/ButtonRoot.css.ts
+++ b/packages/react/src/button/ButtonRoot.css.ts
@@ -57,6 +57,15 @@ const opalRing = (width: string) =>
 
 export const paddingInlineVar = createVar();
 
+// Every addon state that renders a label (i.e. not an icon-only/square button).
+// These share the same inline padding and sizing.
+const withLabel: Array<"both" | "end" | "none" | "start"> = [
+  "both",
+  "end",
+  "none",
+  "start",
+];
+
 export const className = style({});
 
 export const buttonBase = recipe({
@@ -98,6 +107,17 @@ export const buttonBase = recipe({
     }),
   ],
   variants: {
+    /**
+     * Which addons sit alongside the button label, or `only` for an icon-only
+     * (square) button with no label.
+     */
+    addon: {
+      both: {},
+      end: {},
+      none: {},
+      only: {},
+      start: {},
+    },
     intent: {
       danger: style({
         vars: {
@@ -157,13 +177,6 @@ export const buttonBase = recipe({
         fontSize: "lg",
         h: "lg",
       },
-    },
-    /**
-     * Whether button should have square shape.
-     */
-    square: {
-      false: {},
-      true: {},
     },
     variant: {
       outline: style({
@@ -324,12 +337,22 @@ export const buttonBase = recipe({
     {
       style: style({
         borderRadius: theme.borderRadius.lg,
+      }),
+      variants: {
+        addon: withLabel,
+        intent: "primary",
+        size: "lg",
+        variant: "strong",
+      },
+    },
+    {
+      style: style({
         paddingLeft: `calc(6px - ${borderWidthVar})`,
       }),
       variants: {
+        addon: ["both", "start"],
         intent: "primary",
         size: "lg",
-        square: false,
         variant: "strong",
       },
     },
@@ -338,8 +361,8 @@ export const buttonBase = recipe({
         w: "sm",
       },
       variants: {
+        addon: "only",
         size: "sm",
-        square: true,
       },
     },
     {
@@ -349,8 +372,8 @@ export const buttonBase = recipe({
         },
       }),
       variants: {
+        addon: withLabel,
         size: "sm",
-        square: false,
         variant: ["outline", "strong", "subtle"],
       },
     },
@@ -364,8 +387,8 @@ export const buttonBase = recipe({
         },
       }),
       variants: {
+        addon: withLabel,
         size: "sm",
-        square: false,
         variant: "outline-opal",
       },
     },
@@ -374,8 +397,8 @@ export const buttonBase = recipe({
         w: "md",
       },
       variants: {
+        addon: "only",
         size: "md",
-        square: true,
       },
     },
     {
@@ -385,8 +408,8 @@ export const buttonBase = recipe({
         },
       }),
       variants: {
+        addon: withLabel,
         size: "md",
-        square: false,
       },
     },
     {
@@ -394,8 +417,8 @@ export const buttonBase = recipe({
         w: "lg",
       },
       variants: {
+        addon: "only",
         size: "lg",
-        square: true,
       },
     },
     {
@@ -405,8 +428,8 @@ export const buttonBase = recipe({
         },
       }),
       variants: {
+        addon: withLabel,
         size: "lg",
-        square: false,
       },
     },
   ],

--- a/packages/react/src/button/ButtonRoot.tsx
+++ b/packages/react/src/button/ButtonRoot.tsx
@@ -39,7 +39,14 @@ export type ButtonRootProps<
 > = BoxProps<
   T,
   ExtendProps<
-    Omit<NonNullable<styles.ButtonVariants>, "intent" | "variant"> & {
+    Omit<NonNullable<styles.ButtonVariants>, "addon" | "intent" | "variant"> & {
+      /**
+       * Which addons sit alongside the button label. Set internally by `Button`
+       * based on the leading/trailing content.
+       *
+       * @internal
+       */
+      addon?: NonNullable<styles.ButtonVariants>["addon"];
       /**
        * Control the appearance by selecting between the different button types.
        */
@@ -53,6 +60,11 @@ export type ButtonRootProps<
        */
       loading?: boolean;
       /**
+       * Whether button should have square shape (an icon-only button with no
+       * label).
+       */
+      square?: boolean;
+      /**
        * The default behavior of the button.
        */
       type?: "button" | "reset" | "submit" | undefined;
@@ -64,6 +76,7 @@ export type ButtonRootProps<
 export const ButtonRoot = forwardRef<HTMLButtonElement, ButtonRootProps>(
   (
     {
+      addon = "none",
       appearance = "default",
       asChild,
       children,
@@ -92,9 +105,9 @@ export const ButtonRoot = forwardRef<HTMLButtonElement, ButtonRootProps>(
         data-loading={loading ? "" : undefined}
         {...styles.buttonBase(
           {
+            addon: square ? "only" : addon,
             intent,
             size,
-            square: Boolean(square),
             variant,
           },
           className,


### PR DESCRIPTION
## Summary

Large primary buttons (`size="lg"`, `appearance="primary"`) reserved tightened left padding (`calc(6px - borderWidth)`) even when they had no leading icon, shifting label-only and trailing-icon buttons. This applies that padding only when an icon or addon precedes the label.

## Approach

The `lg`/`primary`/`strong` compound was keyed off `square: false`, which matches *all* non-square buttons regardless of addon placement. Rather than detect "has a start icon" with a marker/`:has()`, we replaced the internal `square` recipe variant with a richer `addon` axis:

- `addon: none | start | end | both | only`, where `only` is the old `square: true` (icon-only) case.
- The padding compound now matches `addon: ["both", "start"]` (leading addon present).
- The `borderRadius: lg` for large primary strong buttons is split into its own compound matching every label-bearing state (`none`/`start`/`end`/`both`), preserving the original radius behavior.

The public `square` prop on `Button`/`ButtonRoot` is unchanged — `ButtonRoot` translates `square` to `addon: "only"` internally, so this is **not** a breaking change. `Button` derives `addon` from its leading/trailing content; the two direct `ButtonRoot` consumers (`Pagination`, `LabelMenuButton`) default to `addon: "none"`, identical to the old `square: false`.

## Testing

- `pnpm tsgo -b` — clean
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm vitest run --project=@optiaxiom/react button` — 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)