### PR TITLE
fix(react): exclude internal addon prop from Button public type

### DIFF
--- a/.changeset/button-exclude-addon-prop.md
+++ b/.changeset/button-exclude-addon-prop.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+Removed the internal `addon` prop from the public `Button` type. It is set internally based on leading/trailing content and was never meant for consumers.

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -20,6 +20,13 @@ export type ButtonProps<
   ExtendProps<
     {
       /**
+       * Internal prop set by `Button` based on leading/trailing content - not
+       * available to consumers.
+       *
+       * @internal
+       */
+      addon?: never;
+      /**
        * Display content inside the button after `children`.
        */
       addonAfter?: ReactNode;


### PR DESCRIPTION
## Summary

The internal `addon` prop was leaking onto the public `Button` type. `Button` extends `ButtonRootProps`, and `ButtonRoot` declares `addon` (marked `@internal`) — so it was reachable by consumers even though `Button` sets it itself based on leading/trailing content.

This adds `addon?: never` to the `Button`-level prop extension, which shadows `ButtonRoot`'s `addon` (via `ExtendProps`, where the extension overrides shared keys) and blocks consumers from passing it. Internal usage (`Button` setting `addon` on `ButtonRoot`) is unaffected.

The existing `ExcludeProps` util can't be used here: its `T extends keyof P` constraint fails because `addon` is nested inside the polymorphic `BoxProps` intersection and isn't a statically-provable top-level key.

## Changes
- `Button.tsx` — add `addon?: never` (`@internal`) to `ButtonProps`.

## Testing
- `pnpm tsgo -b` passes.
- `Button.spec.tsx` — all 7 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
