### PR TITLE
ci: flag missing @optiaxiom/mcp changesets vs last published release

### DIFF
--- a/.changeset/mcp-data-export.md
+++ b/.changeset/mcp-data-export.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/mcp": minor
+---
+
+Added a `@optiaxiom/mcp/data` subpath export exposing the raw generated component, guide, icon, test, and token metadata for programmatic consumers.

--- a/.changeset/mcp-regenerate-data.md
+++ b/.changeset/mcp-regenerate-data.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/mcp": patch
+---
+
+Regenerated the bundled component, token, icon, and guide data so the MCP server reflects the latest `@optiaxiom/react` and `@optiaxiom/globals` output — including updated font family tokens, the new fonts guide, and newly added icons. Demo and test collection is now sorted so generated output is deterministic across platforms.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           echo ${{ github.event.number }} > ./pr/ID
           pnpm build
           pnpm --silent bundle-size compare bundle-size-base.json > ./pr/bundle-size.md
+          pnpm --silent changeset-drift > ./pr/changeset-drift.md || true
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -76,3 +76,85 @@ jobs:
                 repo: context.repo.repo,
               });
             }
+
+  changeset-drift:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const matchArtifact = allArtifacts.data.artifacts.filter(
+              (artifact) => artifact.name == "pr-build"
+            )[0];
+            const download = await github.rest.actions.downloadArtifact({
+              archive_format: "zip",
+              artifact_id: matchArtifact.id,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const fs = require("fs");
+            fs.writeFileSync(
+              `${process.env.GITHUB_WORKSPACE}/pr-build.zip`,
+              Buffer.from(download.data)
+            );
+
+      - run: unzip pr-build.zip
+
+      - uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+            const issue_number = Number(fs.readFileSync("./ID"));
+            const marker = "<!-- changeset-drift-report -->";
+            const report = fs.existsSync("./changeset-drift.md")
+              ? fs.readFileSync("./changeset-drift.md", "utf-8")
+              : "";
+
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const botComment = comments.find(
+              (comment) => comment.user.type === "Bot" && comment.body.includes(marker)
+            );
+
+            // Only surface a comment when mcp output actually drifted with no
+            // changeset. Otherwise remove any stale comment so a fixed PR clears.
+            const drifted = report.includes("⚠️");
+            if (!drifted) {
+              if (botComment) {
+                await github.rest.issues.deleteComment({
+                  comment_id: botComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                });
+              }
+              return;
+            }
+
+            const body = marker + "\n" + report;
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                body,
+                comment_id: botComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                body,
+                issue_number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+            }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "pnpm -F \"./packages/**\" build",
     "bundle-size": "oas-bundle-size",
+    "changeset-drift": "oas-changeset-drift",
     "design-tokens": "oas-design-tokens",
     "dev": "pnpm run --parallel -F !web-components dev",
     "dev:docs": "pnpm -F docs... --parallel dev",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,6 +26,17 @@
   "bin": {
     "axiom-mcp": "dist/src/index.js"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./data": {
+      "types": "./dist/data.d.ts",
+      "import": "./dist/src/data.js"
+    },
+    "./package.json": "./package.json"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/mcp/plugins/generators.mjs
+++ b/packages/mcp/plugins/generators.mjs
@@ -252,7 +252,9 @@ export async function generateTests() {
 
   /** @param {string} dir */
   async function walk(dir) {
-    const entries = await readdir(dir, { withFileTypes: true });
+    const entries = (await readdir(dir, { withFileTypes: true })).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
     for (const entry of entries) {
       const fullPath = join(dir, entry.name);
       if (entry.isDirectory()) {

--- a/packages/mcp/plugins/parsers.mjs
+++ b/packages/mcp/plugins/parsers.mjs
@@ -50,7 +50,9 @@ export async function parseDemosFromFiles(componentName) {
   );
 
   try {
-    const folders = await readdir(demosPath, { withFileTypes: true });
+    const folders = (await readdir(demosPath, { withFileTypes: true })).sort(
+      (a, b) => a.name.localeCompare(b.name),
+    );
     /** @type {Example[]} */
     const examples = [];
 
@@ -63,7 +65,9 @@ export async function parseDemosFromFiles(componentName) {
 
       try {
         // Read all files in the demo folder
-        const files = await readdir(folderPath, { withFileTypes: true });
+        const files = (await readdir(folderPath, { withFileTypes: true })).sort(
+          (a, b) => a.name.localeCompare(b.name),
+        );
         /** @type {Record<string, string>} */
         const code = {};
 

--- a/packages/mcp/rolldown.config.mjs
+++ b/packages/mcp/rolldown.config.mjs
@@ -12,7 +12,7 @@ const external = new RegExp(
 export default defineConfig([
   {
     external,
-    input: "src/index.ts",
+    input: ["src/index.ts", "src/data.ts"],
     output: {
       dir: "dist",
       format: "es",
@@ -27,7 +27,7 @@ export default defineConfig([
     },
   },
   {
-    input: "src/index.ts",
+    input: ["src/index.ts", "src/data.ts"],
     output: {
       dir: "dist",
       format: "es",

--- a/packages/mcp/src/data.ts
+++ b/packages/mcp/src/data.ts
@@ -1,0 +1,21 @@
+import {
+  components as componentsData,
+  guides as guidesData,
+  icons as iconsData,
+  tests as testsData,
+  tokens as tokensData,
+} from "#mcp/data";
+
+import type {
+  ComponentInfo,
+  DesignTokens,
+  Guide,
+  IconInfo,
+  TestInfo,
+} from "./types.js";
+
+export const components: Record<string, ComponentInfo> = componentsData;
+export const guides: Record<string, Guide> = guidesData;
+export const icons: Record<string, IconInfo> = iconsData;
+export const tests: Record<string, TestInfo> = testsData;
+export const tokens: DesignTokens = tokensData;

--- a/packages/shared/bin/changeset-drift.mjs
+++ b/packages/shared/bin/changeset-drift.mjs
@@ -1,0 +1,204 @@
+import { isCI } from "ci-info";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The published `@optiaxiom/mcp` package is *generated* at build time from
+ * @optiaxiom/react, @optiaxiom/globals, and @optiaxiom/shared. Its consumer-
+ * facing output can therefore change without anyone touching the mcp package, so
+ * the changeset that bumps it is easy to forget.
+ *
+ * This tool hashes that generated output (per section) and compares the locally
+ * built data against the **last published release on npm**. Comparing against
+ * the release (rather than the PR base branch) means an unbumped change can't be
+ * silenced by merging it once — the drift keeps being flagged until a release
+ * actually ships the changeset.
+ */
+const PACKAGE_NAME = "@optiaxiom/mcp";
+
+const SECTIONS = /** @type {const} */ ([
+  "components",
+  "guides",
+  "icons",
+  "tests",
+  "tokens",
+]);
+
+/**
+ * Read the set of package names that have a pending changeset in `.changeset/`.
+ *
+ * @returns {Promise<Set<string>>}
+ */
+async function changesetPackages() {
+  const dir = resolve(process.cwd(), ".changeset");
+  /** @type {Set<string>} */
+  const packages = new Set();
+  let files;
+  try {
+    files = await readdir(dir);
+  } catch {
+    return packages;
+  }
+  for (const file of files) {
+    if (!file.endsWith(".md") || file === "README.md") {
+      continue;
+    }
+    const content = await readFile(resolve(dir, file), { encoding: "utf-8" });
+    const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!frontmatter) {
+      continue;
+    }
+    for (const line of frontmatter[1].split("\n")) {
+      const match = line.match(/^["']([^"']+)["']\s*:/);
+      if (match) {
+        packages.add(match[1]);
+      }
+    }
+  }
+  return packages;
+}
+
+/**
+ * Hash each top-level section of the generated data independently so a drift
+ * report can name which sections changed.
+ *
+ * @param {Record<string, unknown>} data
+ * @returns {Record<string, string>}
+ */
+function digest(data) {
+  /** @type {Record<string, string>} */
+  const hashes = {};
+  for (const section of SECTIONS) {
+    hashes[section] = createHash("sha256")
+      .update(JSON.stringify(data[section]))
+      .digest("hex");
+  }
+  return hashes;
+}
+
+/**
+ * Import the mcp data from a built package directory. Prefers the public
+ * `./data` export and falls back to the internal data chunk so older releases
+ * (published before the export existed) still work.
+ *
+ * @param {string} dir - Package root containing `dist/`.
+ * @returns {Promise<Record<string, unknown>>}
+ */
+async function loadDataFrom(dir) {
+  for (const rel of [
+    "dist/src/data.js",
+    "dist/_virtual/_virtual_mcp-data/index.js",
+  ]) {
+    try {
+      return await import(`file://${join(dir, rel)}`);
+    } catch {
+      continue;
+    }
+  }
+  throw new Error(`Could not load ${PACKAGE_NAME} data from ${dir}.`);
+}
+
+/**
+ * Load the locally built data (this checkout's `packages/mcp`).
+ *
+ * @returns {Promise<Record<string, unknown>>}
+ */
+async function loadLocal() {
+  return loadDataFrom(resolve(process.cwd(), "packages/mcp"));
+}
+
+/**
+ * Download the last published release from npm and load its data.
+ *
+ * @returns {Promise<Record<string, unknown>>}
+ */
+async function loadPublished() {
+  const dir = await mkdtemp(join(tmpdir(), "mcp-drift-"));
+  try {
+    const { stdout } = await execFileAsync(
+      "npm",
+      ["pack", PACKAGE_NAME, "--json"],
+      { cwd: dir },
+    );
+    const filename = JSON.parse(stdout)[0].filename;
+    await execFileAsync("tar", ["xzf", filename], { cwd: dir });
+    return await loadDataFrom(join(dir, "package"));
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+void yargs(hideBin(process.argv))
+  .command({
+    builder: {
+      output: {
+        choices: ["cli", "markdown"],
+        default: isCI ? "markdown" : "cli",
+      },
+    },
+    command: ["compare", "$0"],
+    handler: async ({ output }) => {
+      const [local, published] = await Promise.all([
+        loadLocal(),
+        loadPublished(),
+      ]);
+      const head = digest(local);
+      const base = digest(published);
+      const changed = SECTIONS.filter(
+        (section) => base[section] !== head[section],
+      );
+      const hasChangeset = (await changesetPackages()).has(PACKAGE_NAME);
+      const drifted = changed.length > 0;
+
+      if (output === "markdown") {
+        if (!drifted) {
+          console.log(
+            `## Generated package changeset check\n\n✅ \`${PACKAGE_NAME}\` output matches the last release — no changeset needed.`,
+          );
+        } else if (hasChangeset) {
+          console.log(
+            `## Generated package changeset check\n\n✅ \`${PACKAGE_NAME}\` output changed since the last release (${changed.join(", ")}) and a changeset is present.`,
+          );
+        } else {
+          console.log(
+            [
+              "## Generated package changeset check",
+              "",
+              `⚠️ \`${PACKAGE_NAME}\` generated output changed since the last release but **no \`${PACKAGE_NAME}\` changeset was found**.`,
+              "",
+              "Its published `dist` is generated from `@optiaxiom/react`, `@optiaxiom/globals`, and `@optiaxiom/shared`, so this change reaches consumers without bumping its version. Please add a changeset:",
+              "",
+              "```sh",
+              "pnpm changeset",
+              "```",
+              "",
+              `Changed sections: ${changed.map((section) => `\`${section}\``).join(", ")}.`,
+            ].join("\n"),
+          );
+        }
+      } else if (!drifted) {
+        console.log(`✓ ${PACKAGE_NAME}: matches last release`);
+      } else if (hasChangeset) {
+        console.log(
+          `✓ ${PACKAGE_NAME}: changed since release (${changed.join(", ")}), changeset present`,
+        );
+      } else {
+        console.log(
+          `✗ ${PACKAGE_NAME}: changed since release (${changed.join(", ")}), NO changeset`,
+        );
+      }
+
+      if (drifted && !hasChangeset) {
+        process.exitCode = 1;
+      }
+    },
+  })
+  .parse();

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.0",
   "bin": {
     "oas-bundle-size": "bin/bundle-size.mjs",
+    "oas-changeset-drift": "bin/changeset-drift.mjs",
     "oas-design-tokens": "bin/design-tokens.mjs",
     "oas-lint": "bin/lint.sh"
   },


### PR DESCRIPTION
## Problem

`@optiaxiom/mcp`'s published `dist` is **generated** at build time from `@optiaxiom/react`, `@optiaxiom/globals`, and `@optiaxiom/shared` (via `packages/mcp/plugins/generators.mjs`). When someone changes a font token, a prop description, or adds an icon, they add a changeset for `react`/`globals` — but nothing tells them the **MCP output also changed**, so `mcp` never gets bumped and silently falls behind (confirmed: `main` already differs from published `3.0.2`).

`changeset-bot` only checks whether a changeset *file* exists — it can't know a `globals`/`react` edit *should* also bump `mcp`. This adds the missing signal.

## Approach

1. **Deterministic generation (prerequisite).** A content hash is only a valid drift signal if the data is byte-stable across machines. Three `readdir` sites ordered demo/test collection by on-disk order (macOS sorted, Linux inode-order). Sorted them. Prop/enum-value order (e.g. `padding: 2 | 4 | 6`) comes from the committed `docs.json` + react-docgen declaration order — already stable and **semantically meaningful**, so it's preserved (not sorted).

2. **`@optiaxiom/mcp/data` subpath export.** The package now exposes its raw generated `components`/`guides`/`icons`/`tests`/`tokens` (like `@optiaxiom/proteus/spec`), so the check imports the package's own data instead of a hardcoded list.

3. **Compare against the last published release, not the PR base branch.** `oas-changeset-drift` builds the local data, `npm pack`s the latest `@optiaxiom/mcp`, and hashes each section to diff. Comparing against the **release** is deliberate: if you compared against `main`, merging an unbumped change once would make it the new baseline and **permanently silence** the warning. Against the release, the drift keeps being flagged until a release actually ships the changeset.

4. **`comment.yml`** posts a changeset-bot-style ⚠️ comment when mcp output drifted since the last release with no changeset, and clears it once resolved. Non-blocking (`|| true`). The check is self-contained (no base checkout), so it's a single PR.

## Changesets

- `@optiaxiom/mcp` **minor** — new `./data` public entrypoint.
- `@optiaxiom/mcp` **patch** — regenerated data already stale on `main` (font tokens, fonts guide, new icons) + deterministic generation.

## Verification

- Determinism: `pnpm --silent changeset-drift hash`-equivalent digest is identical across fresh runs.
- `node -e "import('@optiaxiom/mcp/data').then(d=>console.log(Object.keys(d)))"` → `components, guides, icons, tests, tokens`.
- Drift states (local build vs published `3.0.2`): matches release → exit 0; changed + no changeset → ⚠️ + exit 1; changed + changeset → ✅ + exit 0.
- `tsgo -b`, `oxlint --type-aware`, `oxfmt`, `vitest --project=@optiaxiom/mcp` all pass. `npm pack` includes `dist/src/data.js` + `dist/data.d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
