### PR TITLE
ci: run changeset-drift snapshot/compare in build job

### DIFF
--- a/.changeset/mcp-regenerate-data.md
+++ b/.changeset/mcp-regenerate-data.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/mcp": patch
+---
+
+Regenerated the bundled component, token, icon, and guide data so the MCP server reflects the latest `@optiaxiom/react` and `@optiaxiom/globals` output — including updated font family tokens, the new fonts guide, and newly added icons.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,14 @@ jobs:
       - run: |
           pnpm build
           pnpm --silent bundle-size > bundle-size-base.json
+          pnpm --silent changeset-drift snapshot > changeset-drift-base.json
 
       - uses: actions/upload-artifact@v7
         with:
           if-no-files-found: error
-          path: bundle-size-base.json
+          path: |
+            bundle-size-base.json
+            changeset-drift-base.json
 
       - uses: actions/checkout@v6
 
@@ -59,6 +62,7 @@ jobs:
           echo ${{ github.event.number }} > ./pr/ID
           pnpm build
           pnpm --silent bundle-size compare bundle-size-base.json > ./pr/bundle-size.md
+          pnpm --silent changeset-drift compare changeset-drift-base.json > ./pr/changeset-drift.md || true
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -76,3 +76,86 @@ jobs:
                 repo: context.repo.repo,
               });
             }
+
+  changeset-drift:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const matchArtifact = allArtifacts.data.artifacts.filter(
+              (artifact) => artifact.name == "pr-build"
+            )[0];
+            const download = await github.rest.actions.downloadArtifact({
+              archive_format: "zip",
+              artifact_id: matchArtifact.id,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const fs = require("fs");
+            fs.writeFileSync(
+              `${process.env.GITHUB_WORKSPACE}/pr-build.zip`,
+              Buffer.from(download.data)
+            );
+
+      - run: unzip pr-build.zip
+
+      - uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+            const issue_number = Number(fs.readFileSync("./ID"));
+            const marker = "<!-- changeset-drift-report -->";
+            const report = fs.existsSync("./changeset-drift.md")
+              ? fs.readFileSync("./changeset-drift.md", "utf-8")
+              : "";
+
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const botComment = comments.find(
+              (comment) => comment.user.type === "Bot" && comment.body.includes(marker)
+            );
+
+            // Only surface a comment when a generated package actually drifted.
+            // When nothing drifted (or a previously-flagged drift was resolved),
+            // remove any stale comment so a fixed PR clears the warning.
+            const drifted = report.includes("⚠️");
+            if (!drifted) {
+              if (botComment) {
+                await github.rest.issues.deleteComment({
+                  comment_id: botComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                });
+              }
+              return;
+            }
+
+            const body = marker + "\n" + report;
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                body,
+                comment_id: botComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                body,
+                issue_number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+            }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "pnpm -F \"./packages/**\" build",
     "bundle-size": "oas-bundle-size",
+    "changeset-drift": "oas-changeset-drift",
     "design-tokens": "oas-design-tokens",
     "dev": "pnpm run --parallel -F !web-components dev",
     "dev:docs": "pnpm -F docs... --parallel dev",

--- a/packages/shared/bin/changeset-drift.mjs
+++ b/packages/shared/bin/changeset-drift.mjs
@@ -1,0 +1,282 @@
+import { isCI } from "ci-info";
+import { readdir, readFile } from "fs/promises";
+import { resolve } from "path";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+/**
+ * Packages whose published output is *generated* from other source (react,
+ * globals, shared, …) rather than written by hand. A PR can change their output
+ * transitively without touching the package — so the changeset that bumps them
+ * is easy to forget. Each entry knows how to produce a deterministic snapshot of
+ * its generated output so we can diff base-vs-PR.
+ *
+ * @type {Array<{ name: string; snapshot: () => Promise<Record<string, unknown>> }>}
+ */
+const derivedPackages = [
+  {
+    name: "@optiaxiom/mcp",
+    async snapshot() {
+      // Imported via a non-literal specifier so the typechecker does not pull
+      // generators.mjs (a sibling project) into this package's program.
+      const specifier = "../../mcp/plugins/generators.mjs";
+      const {
+        generateComponents,
+        generateGuides,
+        generateIcons,
+        generateTests,
+        generateTokens,
+      } = await import(specifier);
+      return {
+        components: await generateComponents(),
+        guides: await generateGuides(),
+        icons: await generateIcons(),
+        tests: await generateTests(),
+        tokens: await generateTokens(),
+      };
+    },
+  },
+];
+
+/**
+ * Read the set of package names that have a pending changeset in `.changeset/`.
+ *
+ * @returns {Promise<Set<string>>}
+ */
+async function changesetPackages() {
+  const dir = resolve(process.cwd(), ".changeset");
+  /** @type {Set<string>} */
+  const packages = new Set();
+  let files;
+  try {
+    files = await readdir(dir);
+  } catch {
+    return packages;
+  }
+  for (const file of files) {
+    if (!file.endsWith(".md") || file === "README.md") {
+      continue;
+    }
+    const content = await readFile(resolve(dir, file), { encoding: "utf-8" });
+    const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!frontmatter) {
+      continue;
+    }
+    for (const line of frontmatter[1].split("\n")) {
+      const match = line.match(/^["']([^"']+)["']\s*:/);
+      if (match) {
+        packages.add(match[1]);
+      }
+    }
+  }
+  return packages;
+}
+
+/**
+ * @param {Awaited<ReturnType<typeof compare>>} reports
+ */
+function cliReporter(reports) {
+  for (const report of reports) {
+    if (!report.drifted) {
+      console.log(`✓ ${report.name}: no output change`);
+    } else if (report.hasChangeset) {
+      console.log(`✓ ${report.name}: output changed, changeset present`);
+    } else {
+      console.log(
+        `✗ ${report.name}: output changed, NO changeset (${Object.keys(report.sections).join(", ")})`,
+      );
+    }
+  }
+}
+
+/**
+ * @param {{ file: string }} options
+ */
+async function compare({ file }) {
+  const base = JSON.parse(
+    await readFile(resolve(process.cwd(), file), { encoding: "utf-8" }),
+  );
+  const head = await snapshot();
+  const changesets = await changesetPackages();
+
+  return derivedPackages.map((pkg) => {
+    const baseData = base[pkg.name] ?? {};
+    const headData = head[pkg.name] ?? {};
+    /** @type {Record<string, ReturnType<typeof diffSection>>} */
+    const sections = {};
+    for (const section of new Set([
+      ...Object.keys(baseData),
+      ...Object.keys(headData),
+    ])) {
+      const diff = diffSection(baseData[section], headData[section]);
+      if (diff.added.length || diff.removed.length || diff.changed.length) {
+        sections[section] = diff;
+      }
+    }
+    return {
+      drifted: Object.keys(sections).length > 0,
+      hasChangeset: changesets.has(pkg.name),
+      name: pkg.name,
+      sections,
+    };
+  });
+}
+
+/**
+ * Summarise the difference between two generated sections (each a keyed object).
+ *
+ * @param {unknown} baseSection
+ * @param {unknown} headSection
+ */
+function diffSection(baseSection, headSection) {
+  const base = /** @type {Record<string, unknown>} */ (baseSection ?? {});
+  const head = /** @type {Record<string, unknown>} */ (headSection ?? {});
+  const baseKeys = Object.keys(base);
+  const headKeys = Object.keys(head);
+  const added = headKeys.filter((key) => !baseKeys.includes(key));
+  const removed = baseKeys.filter((key) => !headKeys.includes(key));
+  const changed = headKeys.filter(
+    (key) =>
+      baseKeys.includes(key) &&
+      JSON.stringify(base[key]) !== JSON.stringify(head[key]),
+  );
+  return { added, changed, removed };
+}
+
+/**
+ * @param {Awaited<ReturnType<typeof compare>>} reports
+ */
+function markdownReporter(reports) {
+  const lines = ["## Generated package changeset check", ""];
+
+  const drifted = reports.filter((report) => report.drifted);
+  if (drifted.length === 0) {
+    lines.push(
+      "✅ No generated package output changed — no extra changesets needed.",
+    );
+    console.log(lines.join("\n"));
+    return;
+  }
+
+  for (const report of reports) {
+    if (!report.drifted) {
+      continue;
+    }
+
+    const summary = Object.entries(report.sections)
+      .map(([section, diff]) => {
+        const parts = [];
+        if (diff.added.length) {
+          parts.push(`+${diff.added.length}`);
+        }
+        if (diff.removed.length) {
+          parts.push(`-${diff.removed.length}`);
+        }
+        if (diff.changed.length) {
+          parts.push(`~${diff.changed.length}`);
+        }
+        return `\`${section}\` (${parts.join(" ")})`;
+      })
+      .join(", ");
+
+    if (report.hasChangeset) {
+      lines.push(
+        `✅ \`${report.name}\` output changed and a changeset is present — ${summary}.`,
+      );
+    } else {
+      lines.push(
+        `⚠️ \`${report.name}\` generated output changed but **no \`${report.name}\` changeset was found**.`,
+        "",
+        `Its published \`dist\` is generated from other packages, so this PR changes what consumers receive without bumping its version. Please add a changeset:`,
+        "",
+        "```sh",
+        "pnpm changeset",
+        "```",
+        "",
+        `Changed sections: ${summary} _(+added / -removed / ~changed entries)_.`,
+      );
+
+      for (const [section, diff] of Object.entries(report.sections)) {
+        const total =
+          diff.added.length + diff.removed.length + diff.changed.length;
+        const examples = [
+          ...diff.added.map((key) => `+${key}`),
+          ...diff.removed.map((key) => `-${key}`),
+          ...diff.changed.map((key) => `~${key}`),
+        ]
+          .slice(0, 10)
+          .join(", ");
+        lines.push(`- **${section}**: ${examples}${total > 10 ? ", …" : ""}`);
+      }
+    }
+    lines.push("");
+  }
+
+  console.log(lines.join("\n").trimEnd());
+}
+
+/**
+ * Build a deterministic snapshot of every derived package's generated output.
+ *
+ * @returns {Promise<Record<string, Record<string, unknown>>>}
+ */
+async function snapshot() {
+  /** @type {Record<string, Record<string, unknown>>} */
+  const result = {};
+  for (const pkg of derivedPackages) {
+    result[pkg.name] = /** @type {Record<string, unknown>} */ (
+      sortKeysDeep(await pkg.snapshot())
+    );
+  }
+  return result;
+}
+
+/**
+ * Recursively sort object keys so JSON.stringify is stable regardless of the
+ * insertion order the generators happen to use.
+ *
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function sortKeysDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, sortKeysDeep(/** @type {any} */ (value)[key])]),
+    );
+  }
+  return value;
+}
+
+void yargs(hideBin(process.argv))
+  .command({
+    builder: {
+      output: {
+        choices: ["cli", "markdown"],
+        default: isCI ? "markdown" : "cli",
+      },
+    },
+    command: "compare <file>",
+    handler: async ({ file, output }) => {
+      const reports = await compare({ file: /** @type {string} */ (file) });
+      if (output === "markdown") {
+        markdownReporter(reports);
+      } else {
+        cliReporter(reports);
+      }
+      if (reports.some((report) => report.drifted && !report.hasChangeset)) {
+        process.exitCode = 1;
+      }
+    },
+  })
+  .command({
+    command: ["snapshot", "$0"],
+    handler: async () => {
+      console.log(JSON.stringify(await snapshot()));
+    },
+  })
+  .parse();

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.0",
   "bin": {
     "oas-bundle-size": "bin/bundle-size.mjs",
+    "oas-changeset-drift": "bin/changeset-drift.mjs",
     "oas-design-tokens": "bin/design-tokens.mjs",
     "oas-lint": "bin/lint.sh"
   },


### PR DESCRIPTION
> **Stacked — part 2 of 2.** Depends on #1718. Base is the part-1 branch, so this diff is just the `ci.yml` wiring. Merge #1718 first, then retarget this to `main` (or merge after).

## What

Wires the `oas-changeset-drift` tool (added in #1718) into the existing `build` job:

- **Base checkout**: `pnpm --silent changeset-drift snapshot > changeset-drift-base.json`, uploaded alongside `bundle-size-base.json`.
- **PR checkout**: `pnpm --silent changeset-drift compare changeset-drift-base.json > ./pr/changeset-drift.md || true`, shipped in the existing `pr-build` artifact for `comment.yml` to surface.

The `compare` uses `|| true` so a missing changeset never fails the build — the signal is the PR comment, matching the `changeset-bot` non-blocking behavior.

## Why separate from #1718

The base checkout runs against `main`, so the `oas-changeset-drift` command must already exist there. #1718 lands the command on `main`; this PR can only safely merge afterward. (The first attempt that combined both failed here: the base checkout on `main` had no `changeset-drift` command and the build step exited 254.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
