### PR TITLE
feat(mcp): add @optiaxiom/mcp/data subpath export

### DIFF
--- a/.changeset/mcp-data-export.md
+++ b/.changeset/mcp-data-export.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/mcp": minor
+---
+
+Added a `@optiaxiom/mcp/data` subpath export exposing the raw generated component, guide, icon, test, and token metadata for programmatic consumers.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,6 +26,17 @@
   "bin": {
     "axiom-mcp": "dist/src/index.js"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./data": {
+      "types": "./dist/data.d.ts",
+      "import": "./dist/src/data.js"
+    },
+    "./package.json": "./package.json"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/mcp/rolldown.config.mjs
+++ b/packages/mcp/rolldown.config.mjs
@@ -12,7 +12,7 @@ const external = new RegExp(
 export default defineConfig([
   {
     external,
-    input: "src/index.ts",
+    input: ["src/index.ts", "src/data.ts"],
     output: {
       dir: "dist",
       format: "es",
@@ -27,7 +27,7 @@ export default defineConfig([
     },
   },
   {
-    input: "src/index.ts",
+    input: ["src/index.ts", "src/data.ts"],
     output: {
       dir: "dist",
       format: "es",

--- a/packages/mcp/src/data.ts
+++ b/packages/mcp/src/data.ts
@@ -1,0 +1,21 @@
+import {
+  components as componentsData,
+  guides as guidesData,
+  icons as iconsData,
+  tests as testsData,
+  tokens as tokensData,
+} from "#mcp/data";
+
+import type {
+  ComponentInfo,
+  DesignTokens,
+  Guide,
+  IconInfo,
+  TestInfo,
+} from "./types.js";
+
+export const components: Record<string, ComponentInfo> = componentsData;
+export const guides: Record<string, Guide> = guidesData;
+export const icons: Record<string, IconInfo> = iconsData;
+export const tests: Record<string, TestInfo> = testsData;
+export const tokens: DesignTokens = tokensData;


### PR DESCRIPTION
Exposes the MCP server's generated metadata as a public `@optiaxiom/mcp/data` subpath export — the raw `components`, `guides`, `icons`, `tests`, and `tokens` objects, importable directly:

```ts
import { tokens, components } from "@optiaxiom/mcp/data";
```

## Why

The data is currently only reachable through the server's internal loaders. Exposing it as a typed entrypoint (like `@optiaxiom/proteus/spec`) lets tooling and consumers read it without re-deriving it. The immediate motivation is a follow-up CI check that diffs this generated data against the last published release to flag missing changesets — that check needs to `import` the data from both the local build and the released package. **This export is intentionally released on its own first**, so the follow-up can rely on `@optiaxiom/mcp/data` existing in a published version.

## Changes

- `src/data.ts` re-exports `#mcp/data` with concrete types from `./types.js` (so the emitted `.d.ts` is self-contained).
- Added as a second rolldown input to the JS and dts builds → `dist/src/data.js` + `dist/data.d.ts`.
- `package.json` gains an `exports` map (`.`, `./data`, `./package.json`); `main`/`types`/`bin` unchanged.

## Verification

- `pnpm -F mcp build`; `import('@optiaxiom/mcp/data')` resolves with all five sections.
- `tsgo -b`, `oxlint --type-aware` clean; `npm pack` includes `dist/src/data.js` + `dist/data.d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)