### PR TITLE
ci: flag missing @optiaxiom/mcp changesets vs last published release

### DIFF
--- a/.changeset/mcp-data-export.md
+++ b/.changeset/mcp-data-export.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/mcp": minor
+---
+
+Added a `@optiaxiom/mcp/data` subpath export exposing the raw generated component, guide, icon, test, and token metadata for programmatic consumers.

--- a/.changeset/mcp-deterministic-data.md
+++ b/.changeset/mcp-deterministic-data.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/mcp": patch
+---
+
+Sorted demo and test collection during data generation so the bundled metadata is deterministic across platforms.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           echo ${{ github.event.number }} > ./pr/ID
           pnpm build
           pnpm --silent bundle-size compare bundle-size-base.json > ./pr/bundle-size.md
+          pnpm --silent changeset-drift > ./pr/changeset-drift.md || true
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -76,3 +76,85 @@ jobs:
                 repo: context.repo.repo,
               });
             }
+
+  changeset-drift:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const matchArtifact = allArtifacts.data.artifacts.filter(
+              (artifact) => artifact.name == "pr-build"
+            )[0];
+            const download = await github.rest.actions.downloadArtifact({
+              archive_format: "zip",
+              artifact_id: matchArtifact.id,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const fs = require("fs");
+            fs.writeFileSync(
+              `${process.env.GITHUB_WORKSPACE}/pr-build.zip`,
+              Buffer.from(download.data)
+            );
+
+      - run: unzip pr-build.zip
+
+      - uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+            const issue_number = Number(fs.readFileSync("./ID"));
+            const marker = "<!-- changeset-drift-report -->";
+            const report = fs.existsSync("./changeset-drift.md")
+              ? fs.readFileSync("./changeset-drift.md", "utf-8")
+              : "";
+
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const botComment = comments.find(
+              (comment) => comment.user.type === "Bot" && comment.body.includes(marker)
+            );
+
+            // Only surface a comment when mcp output actually drifted with no
+            // changeset. Otherwise remove any stale comment so a fixed PR clears.
+            const drifted = report.includes("⚠️");
+            if (!drifted) {
+              if (botComment) {
+                await github.rest.issues.deleteComment({
+                  comment_id: botComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                });
+              }
+              return;
+            }
+
+            const body = marker + "\n" + report;
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                body,
+                comment_id: botComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                body,
+                issue_number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+            }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "pnpm -F \"./packages/**\" build",
     "bundle-size": "oas-bundle-size",
+    "changeset-drift": "oas-changeset-drift",
     "design-tokens": "oas-design-tokens",
     "dev": "pnpm run --parallel -F !web-components dev",
     "dev:docs": "pnpm -F docs... --parallel dev",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,6 +26,17 @@
   "bin": {
     "axiom-mcp": "dist/src/index.js"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./data": {
+      "types": "./dist/data.d.ts",
+      "import": "./dist/src/data.js"
+    },
+    "./package.json": "./package.json"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/mcp/plugins/generators.mjs
+++ b/packages/mcp/plugins/generators.mjs
@@ -252,7 +252,10 @@ export async function generateTests() {
 
   /** @param {string} dir */
   async function walk(dir) {
-    const entries = await readdir(dir, { withFileTypes: true });
+    // Sort for deterministic output (readdir order is filesystem-dependent).
+    const entries = (await readdir(dir, { withFileTypes: true })).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
     for (const entry of entries) {
       const fullPath = join(dir, entry.name);
       if (entry.isDirectory()) {

--- a/packages/mcp/plugins/parsers.mjs
+++ b/packages/mcp/plugins/parsers.mjs
@@ -50,7 +50,11 @@ export async function parseDemosFromFiles(componentName) {
   );
 
   try {
-    const folders = await readdir(demosPath, { withFileTypes: true });
+    // Sort so generated output is deterministic across platforms (readdir
+    // order is filesystem-dependent).
+    const folders = (await readdir(demosPath, { withFileTypes: true })).sort(
+      (a, b) => a.name.localeCompare(b.name),
+    );
     /** @type {Example[]} */
     const examples = [];
 
@@ -62,8 +66,9 @@ export async function parseDemosFromFiles(componentName) {
       const folderPath = join(demosPath, folder.name);
 
       try {
-        // Read all files in the demo folder
-        const files = await readdir(folderPath, { withFileTypes: true });
+        const files = (await readdir(folderPath, { withFileTypes: true })).sort(
+          (a, b) => a.name.localeCompare(b.name),
+        );
         /** @type {Record<string, string>} */
         const code = {};
 

--- a/packages/mcp/rolldown.config.mjs
+++ b/packages/mcp/rolldown.config.mjs
@@ -12,7 +12,7 @@ const external = new RegExp(
 export default defineConfig([
   {
     external,
-    input: "src/index.ts",
+    input: ["src/index.ts", "src/data.ts"],
     output: {
       dir: "dist",
       format: "es",
@@ -27,7 +27,7 @@ export default defineConfig([
     },
   },
   {
-    input: "src/index.ts",
+    input: ["src/index.ts", "src/data.ts"],
     output: {
       dir: "dist",
       format: "es",

--- a/packages/mcp/src/data.ts
+++ b/packages/mcp/src/data.ts
@@ -1,0 +1,21 @@
+import {
+  components as componentsData,
+  guides as guidesData,
+  icons as iconsData,
+  tests as testsData,
+  tokens as tokensData,
+} from "#mcp/data";
+
+import type {
+  ComponentInfo,
+  DesignTokens,
+  Guide,
+  IconInfo,
+  TestInfo,
+} from "./types.js";
+
+export const components: Record<string, ComponentInfo> = componentsData;
+export const guides: Record<string, Guide> = guidesData;
+export const icons: Record<string, IconInfo> = iconsData;
+export const tests: Record<string, TestInfo> = testsData;
+export const tokens: DesignTokens = tokensData;

--- a/packages/shared/bin/changeset-drift.mjs
+++ b/packages/shared/bin/changeset-drift.mjs
@@ -1,0 +1,175 @@
+import { isCI } from "ci-info";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+const execFileAsync = promisify(execFile);
+
+// @optiaxiom/mcp's published data is generated from other packages, so it can
+// drift without anyone touching it. Hash the local build against the last npm
+// release (not the PR base — that would let one merge silence the warning).
+const PACKAGE_NAME = "@optiaxiom/mcp";
+
+/** @returns {Promise<Set<string>>} Package names with a pending changeset. */
+async function changesetPackages() {
+  const dir = resolve(process.cwd(), ".changeset");
+  /** @type {Set<string>} */
+  const packages = new Set();
+  let files;
+  try {
+    files = await readdir(dir);
+  } catch {
+    return packages;
+  }
+  for (const file of files) {
+    if (!file.endsWith(".md") || file === "README.md") {
+      continue;
+    }
+    const content = await readFile(resolve(dir, file), { encoding: "utf-8" });
+    const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!frontmatter) {
+      continue;
+    }
+    for (const line of frontmatter[1].split("\n")) {
+      const match = line.match(/^["']([^"']+)["']\s*:/);
+      if (match) {
+        packages.add(match[1]);
+      }
+    }
+  }
+  return packages;
+}
+
+/**
+ * Hash each section separately so the report can name what changed. Sections
+ * are derived from the data itself, so a new section is covered automatically.
+ *
+ * @param {Record<string, unknown>} data
+ * @returns {Record<string, string>}
+ */
+function digest(data) {
+  /** @type {Record<string, string>} */
+  const hashes = {};
+  for (const section of Object.keys(data).sort()) {
+    hashes[section] = createHash("sha256")
+      .update(JSON.stringify(data[section]))
+      .digest("hex");
+  }
+  return hashes;
+}
+
+/**
+ * Import a package's `./data` export from its install root, honoring its own
+ * exports map. Returns null if the package predates the export.
+ *
+ * @param {string} root - Directory containing the package's `package.json`.
+ * @returns {Promise<Record<string, unknown> | null>}
+ */
+async function loadDataExport(root) {
+  const pkg = JSON.parse(
+    await readFile(join(root, "package.json"), { encoding: "utf-8" }),
+  );
+  const entry = pkg.exports?.["./data"]?.import ?? pkg.exports?.["./data"];
+  return entry ? import(`file://${join(root, entry)}`) : null;
+}
+
+/** @returns {Promise<Record<string, unknown> | null>} This checkout's data. */
+async function loadLocal() {
+  return loadDataExport(resolve(process.cwd(), "packages/mcp"));
+}
+
+/**
+ * Install the last published release into a temp dir and import its `./data`
+ * export. Returns null if that release predates the export.
+ *
+ * @returns {Promise<Record<string, unknown> | null>}
+ */
+async function loadPublished() {
+  const dir = await mkdtemp(join(tmpdir(), "mcp-drift-"));
+  try {
+    await execFileAsync("npm", ["install", PACKAGE_NAME, "--prefix", dir], {
+      cwd: dir,
+    });
+    return await loadDataExport(join(dir, "node_modules", PACKAGE_NAME));
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+void yargs(hideBin(process.argv))
+  .command({
+    builder: {
+      output: {
+        choices: ["cli", "markdown"],
+        default: isCI ? "markdown" : "cli",
+      },
+    },
+    command: ["compare", "$0"],
+    handler: async ({ output }) => {
+      const [local, published] = await Promise.all([
+        loadLocal(),
+        loadPublished(),
+      ]);
+      if (!local || !published) {
+        console.log(
+          `Skipping changeset drift check — ${PACKAGE_NAME} \`./data\` export is unavailable (build the package, or the published release predates it).`,
+        );
+        return;
+      }
+      const head = digest(local);
+      const base = digest(published);
+      const changed = [...new Set([...Object.keys(base), ...Object.keys(head)])]
+        .sort()
+        .filter((section) => base[section] !== head[section]);
+      const hasChangeset = (await changesetPackages()).has(PACKAGE_NAME);
+      const drifted = changed.length > 0;
+
+      if (output === "markdown") {
+        if (!drifted) {
+          console.log(
+            `## Generated package changeset check\n\n✅ \`${PACKAGE_NAME}\` output matches the last release — no changeset needed.`,
+          );
+        } else if (hasChangeset) {
+          console.log(
+            `## Generated package changeset check\n\n✅ \`${PACKAGE_NAME}\` output changed since the last release (${changed.join(", ")}) and a changeset is present.`,
+          );
+        } else {
+          console.log(
+            [
+              "## Generated package changeset check",
+              "",
+              `⚠️ \`${PACKAGE_NAME}\` generated output changed since the last release but **no \`${PACKAGE_NAME}\` changeset was found**.`,
+              "",
+              "Its published `dist` is generated from `@optiaxiom/react`, `@optiaxiom/globals`, and `@optiaxiom/shared`, so this change reaches consumers without bumping its version. Please add a changeset:",
+              "",
+              "```sh",
+              "pnpm changeset",
+              "```",
+              "",
+              `Changed sections: ${changed.map((section) => `\`${section}\``).join(", ")}.`,
+            ].join("\n"),
+          );
+        }
+      } else if (!drifted) {
+        console.log(`✓ ${PACKAGE_NAME}: matches last release`);
+      } else if (hasChangeset) {
+        console.log(
+          `✓ ${PACKAGE_NAME}: changed since release (${changed.join(", ")}), changeset present`,
+        );
+      } else {
+        console.log(
+          `✗ ${PACKAGE_NAME}: changed since release (${changed.join(", ")}), NO changeset`,
+        );
+      }
+
+      if (drifted && !hasChangeset) {
+        process.exitCode = 1;
+      }
+    },
+  })
+  .parse();

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.0",
   "bin": {
     "oas-bundle-size": "bin/bundle-size.mjs",
+    "oas-changeset-drift": "bin/changeset-drift.mjs",
     "oas-design-tokens": "bin/design-tokens.mjs",
     "oas-lint": "bin/lint.sh"
   },


### PR DESCRIPTION
> **Depends on #1720** (the `@optiaxiom/mcp/data` export). Merge + release #1720 first; until a release ships the export, this check skips. This PR is stacked on #1720, so its diff shows only the tooling once #1720 merges.

## Problem

`@optiaxiom/mcp`'s published `dist` is **generated** at build time from `@optiaxiom/react`, `@optiaxiom/globals`, and `@optiaxiom/shared`. Its consumer-facing output can change without anyone touching the package, so the changeset that bumps it gets forgotten (`main` already differs from published `3.0.2`). `changeset-bot` only checks whether a changeset *file* exists — it can't know a `globals`/`react` edit *should* bump `mcp`.

## Approach

`oas-changeset-drift`:
- imports the local `@optiaxiom/mcp/data` export and the **same export from the last npm release** (installed into a temp dir, resolved via the package's own `exports` map);
- hashes each section and flags drift that has no matching `@optiaxiom/mcp` changeset.

**Why compare against the release, not the PR base branch:** if you diffed against `main`, merging an unbumped change once would make it the new baseline and **permanently silence** the warning. Against the release, it keeps firing until a release actually ships the changeset.

**Sections are derived from the data** (`Object.keys`), so a newly added section is covered automatically — nothing hardcoded.

**Determinism (prerequisite):** three `readdir` sites ordered demo/test collection by on-disk order (macOS sorted, Linux inode-order). Sorted them so the hash is reliable across platforms. Prop/enum-value order is unchanged (it comes from `docs.json` + react-docgen and is semantically meaningful).

`ci.yml` writes the report in the build job; `comment.yml` posts a changeset-bot-style comment when output drifted with no changeset, and clears it once resolved. Non-blocking.

## Changeset

- `@optiaxiom/mcp` **patch** — deterministic data generation (sorted demo/test collection).

## Verification

- Against real npm (`3.0.2`, no `./data` yet) → skips cleanly, exit 0.
- Against a simulated release that has `./data`: identical → no drift; mutated local section → reports exactly that section as changed.
- `tsgo -b`, `oxlint --type-aware`, `oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
