### PR TITLE
Proteus icon url fallback

### DIFF
--- a/.changeset/proteus-icon-url-fallback.md
+++ b/.changeset/proteus-icon-url-fallback.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": patch
+---
+
+Fall back to `<img src={name}>` for `Icon` elements when `name` is an `http(s)://` or `data:` URL not present in the `icons` map. Previously such names rendered nothing (or threw in strict mode). Registered icons continue to take precedence; unknown non-URL names keep the current null / strict-throw behavior.

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -54,6 +54,8 @@ export type ProteusDocumentShellProps = Pick<
   element: ProteusDocument;
   /**
    * Map of icon name to React component. Referenced by `{ $type: "Icon", name }` elements.
+   * If `name` is not in the map but starts with `http(s)://` or `data:`, it is
+   * rendered as `<img src={name}>` instead.
    */
   icons?: ProteusIconMap;
   /**

--- a/packages/proteus/src/proteus-element/ProteusElement.tsx
+++ b/packages/proteus/src/proteus-element/ProteusElement.tsx
@@ -181,9 +181,16 @@ export const ProteusElement = ({
       const { filled, name, ...rest } = resolve(element);
       const IconComp = icons?.[name as string];
       if (!IconComp) {
+        if (typeof name === "string" && /^(?:https?:\/\/|data:)/.test(name)) {
+          return (
+            <Box asChild {...rest}>
+              <img alt="" aria-hidden="true" src={name} />
+            </Box>
+          );
+        }
         if (strict) {
           throw new Error(
-            `Icon "${name}" not registered. Pass it via the \`icons\` prop on ProteusDocumentRenderer.`,
+            `Icon "${name}" not registered and not a URL. Pass it via the \`icons\` prop on ProteusDocumentRenderer, or use an http(s):// or data: URL.`,
           );
         }
         return null;


### PR DESCRIPTION
## Summary

When a Proteus document references `{ $type: "Icon", name }` and `name` isn't in the consumer's `icons` map but is a URL (`http(s)://` or `data:`), render it as `<img src={name}>` instead of nothing.

### Before

`ProteusElement` looked the name up in the `icons` map and bailed out otherwise:

```tsx
const IconComp = icons?.[name as string];
if (!IconComp) {
  if (strict) {
    throw new Error(`Icon "${name}" not registered. ...`);
  }
  return null;
}
```

## After

```tsx
const IconComp = icons?.[name as string];
if (!IconComp) {
  if (typeof name === "string" && /^(?:https?:\/\/|data:)/.test(name)) {
    return (
      <Box asChild {...rest}>
        <img alt="" aria-hidden="true" src={name} />
      </Box>
    );
  }
  if (strict) {
    throw new Error(
      `Icon "${name}" not registered and not a URL. Pass it via the \`icons\` prop on ProteusDocumentRenderer, or use an http(s):// or data: URL.`,
    );
  }
  return null;
}
```