### PR TITLE
feat(proteus): add watch(path, fn) for reactive script watchers

### DIFF
--- a/.changeset/proteus-script-watch.md
+++ b/.changeset/proteus-script-watch.md
@@ -1,0 +1,7 @@
+---
+"@optiaxiom/proteus": minor
+---
+
+Scripts can react to data changes with `watch(path, fn)` — the push counterpart to `register`. It runs edge-triggered whenever the value at `path` changes: `watch('/items', (ctx, current, previous) => ...)`; use `watch('/', fn)` for all data. Watchers can only `ctx.emit` existing events and don't react to changes their own emit causes, so they can't loop.
+
+Script callbacks now take `ctx` (`emit`, `getValue`) first with invocation data positional after: `register(name, (ctx, params) => ...)` and `watch(path, (ctx, current, previous) => ...)`. `params` is no longer on `ctx`.

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -2153,15 +2153,15 @@ export const Scripts: Story = {
       // `ctx.emit` — they have no DOM or host access of their own.
       scripts: {
         main: [
-          "register('addTag', (ctx) => {",
-          "  const tag = ctx.params.tag;",
+          "register('addTag', (ctx, params) => {",
+          "  const tag = params.tag;",
           "  if (!tag) return;",
           "  ctx.emit({ action: 'pushValue', path: '/tags', value: tag });",
           "});",
-          "register('renameFirst', (ctx) => {",
+          "register('renameFirst', (ctx, params) => {",
           "  const tags = ctx.getValue('/tags') || [];",
-          "  if (!tags.length || !ctx.params.newTag) return;",
-          "  ctx.emit({ action: 'setValue', path: '/tags/0', value: ctx.params.newTag });",
+          "  if (!tags.length || !params.newTag) return;",
+          "  ctx.emit({ action: 'setValue', path: '/tags/0', value: params.newTag });",
           "});",
           "register('announce', (ctx) => {",
           "  const tags = ctx.getValue('/tags') || [];",
@@ -2174,6 +2174,72 @@ export const Scripts: Story = {
   },
   render: function Render(args) {
     const [data, setData] = useState<Record<string, unknown>>({ tags: [] });
+    return (
+      <ProteusDocumentRenderer {...args} data={data} onDataChange={setData} />
+    );
+  },
+};
+
+export const ScriptsWatch: Story = {
+  args: {
+    element: {
+      $type: "Document",
+      appName: "Opal",
+      body: [
+        {
+          $type: "Text",
+          children: "Tick every item to unlock the next step.",
+          color: "fg.secondary",
+        },
+        {
+          $type: "Group",
+          children: {
+            $type: "Map",
+            children: {
+              $type: "Switch",
+              children: { $type: "Value", path: "label" },
+              name: "done",
+            },
+            path: "/items",
+          },
+          flexDirection: "column",
+          gap: "8",
+        },
+        {
+          $type: "Show",
+          children: {
+            $type: "Alert",
+            children: "All items complete — you're good to go!",
+            intent: "success",
+          },
+          when: { "!!": { $type: "Value", path: "/all_done" } },
+        },
+      ],
+      // A watcher reacts to data changes (edge-triggered) — the push counterpart
+      // to `register`. When every item is ticked it flips `/all_done` (so the
+      // Show reveals) and fires an interaction. Runs once on the false→true
+      // edge, and its own setValue write does not re-trigger it.
+      scripts: {
+        main: [
+          "watch('/items', (ctx, current) => {",
+          "  const items = current || [];",
+          "  const done = items.length > 0 && items.every((i) => i.done === true);",
+          "  ctx.emit({ action: 'setValue', path: '/all_done', value: done });",
+          "  if (done) ctx.emit({ interaction: 'all_complete' });",
+          "});",
+        ].join("\n"),
+      },
+      title: "Reactive watcher",
+    },
+  },
+  render: function Render(args) {
+    const [data, setData] = useState<Record<string, unknown>>({
+      items: [
+        { done: false, label: "Accept terms" },
+        { done: false, label: "Verify email" },
+        { done: false, label: "Add payment method" },
+      ],
+    });
     return (
       <ProteusDocumentRenderer {...args} data={data} onDataChange={setData} />
     );

--- a/packages/proteus/src/proteus-script/index.ts
+++ b/packages/proteus/src/proteus-script/index.ts
@@ -1,2 +1,2 @@
-export type { ScriptContext, ScriptHandler } from "./protocol";
+export type { ScriptContext, ScriptHandler, WatchHandler } from "./protocol";
 export { useProteusScripts } from "./useProteusScripts";

--- a/packages/proteus/src/proteus-script/protocol.ts
+++ b/packages/proteus/src/proteus-script/protocol.ts
@@ -24,14 +24,25 @@ export type HostToWorkerMessage =
       invokeId: number;
       params: Record<string, unknown>;
       type: "invoke";
+    }
+  | {
+      /** The value at the watched path now — passed as the 2nd callback arg. */
+      current: unknown;
+      /** Snapshot of form data readable via `ctx.getValue`. */
+      data: Record<string, unknown>;
+      /** The value at the watched path before this change — 3rd callback arg. */
+      previous: unknown;
+      type: "runWatcher";
+      /** Index into the worker's `watchers` array to run. */
+      watchId: number;
     };
 
 /**
- * The single argument passed to a registered script handler. Its `emit`,
- * `getValue`, and `params` members are everything the handler is given to work
- * with — no capability leaks beyond re-emitting existing Proteus events.
+ * The capabilities every script callback receives as its first argument. These
+ * are everything a callback is given to affect the document — no capability
+ * leaks beyond re-emitting existing Proteus events.
  *
- * Trust note: this grants a handler exactly the authority the document already
+ * Trust note: this grants a callback exactly the authority the document already
  * has — it can read all form data (`getValue("/")`) and emit any event the
  * document could. It is NOT a boundary against untrusted input; author the
  * `scripts` map with the same trust as the rest of the document.
@@ -43,7 +54,7 @@ export type ScriptContext = {
    * value — only `interaction` returns something meaningful; the client-side
    * actions resolve to `undefined`.
    *
-   * This is the handler's only outward capability; it can do nothing the host
+   * This is the callback's only outward capability; it can do nothing the host
    * dispatcher would not do for a document-declared event.
    */
   emit: (event: ProteusEventHandler) => Promise<unknown>;
@@ -51,19 +62,47 @@ export type ScriptContext = {
    * Read from the form-data snapshot captured at invoke time (JSON pointer,
    * same semantics as `Value`). `getValue("/")` returns the whole snapshot.
    * Read-only — a mutating `emit` (e.g. pushValue) is NOT observable within the
-   * same handler run. Writes must go through `emit`.
+   * same callback run. Writes must go through `emit`.
    */
   getValue: (path: string) => unknown;
-  /** Resolved params from the triggering event. */
-  params: Record<string, unknown>;
 };
 
-export type ScriptHandler = (ctx: ScriptContext) => unknown;
+/**
+ * A handler registered with `register(name, fn)`. Invoked as `(ctx, params)`
+ * when a UI element triggers `{ script: "module:name", params }` — `params` is
+ * the resolved params object the document supplied.
+ */
+export type ScriptHandler = (
+  ctx: ScriptContext,
+  params: Record<string, unknown>,
+) => unknown;
+
+/**
+ * A watcher registered with `watch(path, fn)` inside a script — the push
+ * counterpart to `register`'s pull. Invoked as `(ctx, current, previous)`
+ * (edge-triggered) whenever the value at `path` changes: `current` is the value
+ * now, `previous` the value before this change. Use `watch("/", fn)` to observe
+ * all data.
+ */
+export type WatchHandler = (
+  ctx: ScriptContext,
+  current: unknown,
+  previous: unknown,
+) => unknown;
 
 /**
  * Messages posted from the worker back to the host (main thread).
  */
 export type WorkerToHostMessage =
+  | {
+      /**
+       * The JSON-pointer path each registered watcher observes, sent once after
+       * `init`. Index = watcher id; the host edge-detects each path and posts a
+       * `runWatcher` when the value there changes.
+       */
+      paths: string[];
+      type: "watchers";
+    }
   | {
       /** A `ctx.emit(event)` call — the host re-dispatches it through `onEvent`. */
       emitId: number;

--- a/packages/proteus/src/proteus-script/useProteusScripts.ts
+++ b/packages/proteus/src/proteus-script/useProteusScripts.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { get } from "jsonpointer";
 import { useEffect, useRef } from "react";
 
 import type { ProteusEventHandler } from "../proteus-document/schemas";
@@ -9,10 +10,10 @@ import { useEffectEvent } from "../hooks";
 import { WORKER_SCRIPT } from "./workerScript";
 
 type UseProteusScriptsOptions = {
-  /** Current form data — snapshotted per invoke and shipped to the worker. */
+  /** Current form data — snapshotted per invoke and edge-detected for watchers. */
   data: Record<string, unknown>;
   /**
-   * Re-dispatch an event the running handler emitted. Wired to the shell's
+   * Re-dispatch an event a handler or watcher emitted. Wired to the shell's
    * `onEvent` so scripts can only trigger the existing Proteus events.
    */
   onEmit: (event: ProteusEventHandler) => Promise<unknown>;
@@ -33,11 +34,20 @@ const INVOKE_TIMEOUT_MS = 5000;
 /**
  * Spins up a single sandbox Web Worker for the document's `scripts` and returns
  * a `runScript(handler, params)` that invokes a named handler inside it. Events
- * the handler emits are routed back through `onEmit` (the shell dispatcher) and
- * their results returned to the worker, so `ctx.emit` round-trips work.
+ * a handler or watcher emits are routed back through `onEmit` (the shell
+ * dispatcher) and their results returned to the worker, so `ctx.emit`
+ * round-trips work.
  *
- * Returns a no-op runner when the document ships no scripts — no worker is
- * spawned until the first `runScript` call.
+ * Watchers (`watch(path, fn)` in a script) are driven from here: the worker
+ * reports its watched paths after `init`, and this hook edge-detects each path
+ * against `data` on every change, posting `runWatcher` when the value there
+ * changes. A watcher does NOT re-fire on data changes caused by a script's own
+ * `emit` (see `emitDepthRef`) — watchers observe user/host state changes, which
+ * both prevents emit→watcher→emit loops and gives a predictable "reacts to what
+ * the user did" semantic.
+ *
+ * Returns a no-op runner when the document ships no scripts — the worker is
+ * spawned eagerly when scripts exist (watchers can fire before any interaction).
  */
 export function useProteusScripts({
   data,
@@ -65,35 +75,19 @@ export function useProteusScripts({
   const nextId = useRef(1);
   const workerRef = useRef<null | Worker>(null);
 
-  const spawnWorker = useEffectEvent(() => {
-    const url = URL.createObjectURL(
-      new Blob([WORKER_SCRIPT], { type: "text/javascript" }),
-    );
-    const instance = new Worker(url);
-    URL.revokeObjectURL(url);
-    instance.postMessage({ scripts, type: "init" });
+  // Watcher state: the paths reported by the worker, and the last-evaluated
+  // slice at each (serialized) for edge-detection.
+  const watchedPaths = useRef<string[]>([]);
+  const lastEval = useRef<string[]>([]);
+  // >0 while a script-emitted event is being dispatched. Data changes during
+  // this window are script-induced, so watchers must not react to them.
+  const emitDepth = useRef(0);
 
-    instance.addEventListener(
-      "message",
-      async (e: MessageEvent<WorkerToHostMessage>) => {
-        const msg = e.data;
-        if (msg.type === "emit") {
-          const result = await emit(msg.event);
-          instance.postMessage({
-            emitId: msg.emitId,
-            result,
-            type: "emitResult",
-          });
-        } else if (msg.type === "invokeResult") {
-          // A failed handler (bad name / thrown) resolves to undefined —
-          // matching the non-strict "fail silently" default of the other
-          // Proteus ops. The error travels on `msg.error` for future
-          // strict-mode surfacing.
-          settle(msg.invokeId, msg.result);
-        }
-      },
+  /** Snapshot every watched path from `data` into `lastEval` without firing. */
+  const seedWatchers = useEffectEvent((data: Record<string, unknown>) => {
+    lastEval.current = watchedPaths.current.map((path) =>
+      JSON.stringify(getByPointer(data, path) ?? null),
     );
-    return instance;
   });
 
   /** Resolve a pending run (if still pending) and clear its timeout. */
@@ -107,31 +101,119 @@ export function useProteusScripts({
     entry.resolve(result);
   });
 
+  const spawnWorker = useEffectEvent(() => {
+    const url = URL.createObjectURL(
+      new Blob([WORKER_SCRIPT], { type: "text/javascript" }),
+    );
+    const instance = new Worker(url);
+    URL.revokeObjectURL(url);
+    instance.postMessage({ scripts, type: "init" });
+
+    instance.addEventListener(
+      "message",
+      async (e: MessageEvent<WorkerToHostMessage>) => {
+        const msg = e.data;
+        if (msg.type === "emit") {
+          // Tag data changes caused by this emit as script-induced so watchers
+          // ignore them (reentrancy guard).
+          emitDepth.current += 1;
+          let result: unknown;
+          try {
+            result = await emit(msg.event);
+          } finally {
+            emitDepth.current -= 1;
+          }
+          instance.postMessage({
+            emitId: msg.emitId,
+            result,
+            type: "emitResult",
+          });
+        } else if (msg.type === "invokeResult") {
+          // A failed handler (bad name / thrown) resolves to undefined —
+          // matching the non-strict "fail silently" default of the other
+          // Proteus ops. The error travels on `msg.error` for future
+          // strict-mode surfacing.
+          settle(msg.invokeId, msg.result);
+        } else if (msg.type === "watchers") {
+          watchedPaths.current = msg.paths;
+          // Seed from current data so pre-existing values are not treated as a
+          // change on mount — a watcher fires on the first edge after load.
+          seedWatchers(dataRef.current);
+        }
+      },
+    );
+    return instance;
+  });
+
+  /** Ensure the worker exists, spawning it on first need. */
+  const ensureWorker = useEffectEvent(() => {
+    if (!workerRef.current) {
+      workerRef.current = spawnWorker();
+    }
+    return workerRef.current;
+  });
+
   /** Tear down the current worker and abandon every in-flight run. */
   const teardown = useEffectEvent(() => {
     workerRef.current?.terminate();
     workerRef.current = null;
+    watchedPaths.current = [];
+    lastEval.current = [];
     for (const [invokeId] of pending) {
       settle(invokeId, undefined);
     }
   });
 
   // Respawn on a new `scripts` map (and dispose the old worker); dispose on
-  // unmount. The worker itself is created lazily by `runScript`.
+  // unmount. Spawn eagerly so watchers can fire before any user interaction.
   useEffect(() => {
     teardown();
+    if (hasScripts) {
+      ensureWorker();
+    }
     return teardown;
-  }, [scripts]);
+  }, [scripts, hasScripts]);
+
+  // Edge-detect watched paths on every data change and run the ones that
+  // changed — unless the change was caused by a script's own emit.
+  useEffect(() => {
+    const worker = workerRef.current;
+    if (!worker || watchedPaths.current.length === 0) {
+      return;
+    }
+    if (emitDepth.current > 0) {
+      // Script-induced change: refresh baselines but do not fire watchers.
+      seedWatchers(data);
+      return;
+    }
+    watchedPaths.current.forEach((path, watchId) => {
+      const current = getByPointer(data, path) ?? null;
+      const serialized = JSON.stringify(current);
+      const prevSerialized = lastEval.current[watchId];
+      if (serialized !== prevSerialized) {
+        lastEval.current[watchId] = serialized;
+        // Hand the watcher both sides of the edge. `previous` is parsed from the
+        // serialized baseline the edge-detector already keeps (undefined on the
+        // first change after seeding).
+        const previous =
+          prevSerialized === undefined ? undefined : JSON.parse(prevSerialized);
+        worker.postMessage({
+          current,
+          data,
+          previous,
+          type: "runWatcher",
+          watchId,
+        });
+      }
+    });
+  }, [data]);
 
   return useEffectEvent(
     (handler: string, params?: Record<string, unknown>): Promise<unknown> => {
       if (!hasScripts) {
         return Promise.resolve(undefined);
       }
-      if (!workerRef.current) {
-        workerRef.current = spawnWorker();
-      }
-      const worker = workerRef.current;
+      const worker = ensureWorker();
       const invokeId = nextId.current++;
       return new Promise((resolve) => {
         const timer = setTimeout(() => {
@@ -151,4 +233,16 @@ export function useProteusScripts({
       });
     },
   );
+}
+
+/** Read a JSON-pointer slice, matching the worker's getByPointer semantics. */
+function getByPointer(data: Record<string, unknown>, path: string): unknown {
+  if (!path || path === "/") {
+    return data;
+  }
+  try {
+    return get(data, path);
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/proteus/src/proteus-script/workerScript.ts
+++ b/packages/proteus/src/proteus-script/workerScript.ts
@@ -19,6 +19,7 @@ export const WORKER_SCRIPT = /* js */ `
 "use strict";
 
 const handlers = new Map();
+const watchers = [];
 const pendingEmits = new Map();
 let nextEmitId = 1;
 
@@ -42,13 +43,21 @@ function register(name, fn) {
   handlers.set(name, fn);
 }
 
-// Evaluate one module's source in a scope that exposes \`register\`. Handlers are
-// keyed by "moduleName:handlerName" via a per-module register wrapper.
+function watch(path, fn) {
+  if (typeof path !== "string" || typeof fn !== "function") {
+    throw new Error("watch(path, fn) requires a string path and a function");
+  }
+  watchers.push({ fn, path });
+}
+
+// Evaluate one module's source in a scope that exposes \`register\` and \`watch\`.
+// Handlers are keyed by "moduleName:handlerName" via a per-module register
+// wrapper; watchers are collected globally (order = watch id).
 function loadModule(moduleName, source) {
   const scopedRegister = (name, fn) => register(moduleName + ":" + name, fn);
   // eslint-disable-next-line no-new-func
-  const factory = new Function("register", source);
-  factory(scopedRegister);
+  const factory = new Function("register", "watch", source);
+  factory(scopedRegister, watch);
 }
 
 function emit(event) {
@@ -71,6 +80,8 @@ self.onmessage = async (e) => {
         // surface a "not found" error at call time.
       }
     }
+    // Report watched paths so the host can edge-detect and drive runWatcher.
+    self.postMessage({ paths: watchers.map((w) => w.path), type: "watchers" });
     return;
   }
 
@@ -98,10 +109,9 @@ self.onmessage = async (e) => {
     const ctx = {
       emit,
       getValue: (path) => getByPointer(data, path),
-      params: params ?? {},
     };
     try {
-      const result = await fn(ctx);
+      const result = await fn(ctx, params ?? {});
       self.postMessage({ invokeId, result, type: "invokeResult" });
     } catch (err) {
       self.postMessage({
@@ -110,6 +120,26 @@ self.onmessage = async (e) => {
         result: undefined,
         type: "invokeResult",
       });
+    }
+    return;
+  }
+
+  if (msg.type === "runWatcher") {
+    const { current, data, previous, watchId } = msg;
+    const watcher = watchers[watchId];
+    if (!watcher) {
+      return;
+    }
+    const ctx = {
+      emit,
+      getValue: (path) => getByPointer(data, path),
+    };
+    try {
+      // Fire-and-forget: watchers return nothing to any caller. Errors are
+      // swallowed to match the fail-silent default of the other ops.
+      await watcher.fn(ctx, current, previous);
+    } catch (err) {
+      // Intentionally ignored.
     }
   }
 };


### PR DESCRIPTION
## What

Adds **`watch(path, fn)`** to Proteus scripts — the *push* counterpart to `register`'s *pull*. A script can now react to data changing, not just to a UI element triggering it:

```js
// inside the document's scripts map
watch('/items', (ctx, current, previous) => {
  if (current.every(i => i.done)) ctx.emit({ interaction: 'all_complete' });
});
```

This closes the gap where "do X when all checkboxes are ticked" had no expression — `Show` could conditionally *render* on such a condition but couldn't *run an action*, and no per-field change hook existed.

## Callback signatures (breaking, unreleased)

Both script callbacks now take `ctx` (capabilities: `emit`, `getValue`) as their **first** argument, with invocation data passed **positionally** after it:

```js
register('addTag', (ctx, params) => { ... });          // params = author-supplied event params
watch('/items', (ctx, current, previous) => { ... });  // both sides of the edge
```

`params` is **no longer a member of `ctx`** — it moved to a positional arg on `register` handlers. This is a breaking change to the `register` API introduced in the (still-unreleased) scripting feature; scripts are strings inside documents, so it breaks at runtime, not author time. Doing it now while nothing is released. The shape mirrors React lifecycle callbacks (positional prev/next), and it keeps `params` from being overloaded — on `ctx` it would have collided with the document-author "event params" meaning.

## Design

- **In-script, symmetric with `register`.** `watch` is a second worker-scope function, not a new document field or schema variant. Same `ctx`, same sandbox, same `emit`-only capability. One language for condition + reaction (full JS, not the `ProteusCondition` vocabulary).
- **`path` is required** — `watch('/', fn)` observes all data. No optional-arg overload.
- **Edge-triggered** — a watcher runs only when the value at its `path` actually changed since the last evaluation, not on every mutation. It receives `current` and `previous` positionally.
- **No loops** — watchers ignore data changes caused by a script's own `emit`, so reaction-then-mutation (e.g. a watcher that emits `setValue`) can't re-trigger itself. Semantically: watchers react to user/host state changes.

## How it works

- **Worker** ([workerScript.ts](packages/proteus/src/proteus-script/workerScript.ts)) owns `watch(path, fn)` registrations (exposed to module scope alongside `register`, preserving the isolation invariant). After `init` it posts its watched paths back to the host; it handles `runWatcher` by calling the watcher's `fn(ctx, current, previous)`.
- **Host hook** ([useProteusScripts.ts](packages/proteus/src/proteus-script/useProteusScripts.ts)) edge-detects each watched path against form data on every change (reusing `jsonpointer` `get`), posts `runWatcher` with the current + previous slice for changed paths, and suppresses watcher runs during a script-emit window (`emitDepth`) — the reentrancy guard. `previous` is parsed from the serialized baseline the edge-detector already keeps, so no extra bookkeeping. The worker is now spawned eagerly when scripts exist, since a watcher can fire before any user interaction.
- **Edge-detection uses value comparison** (`JSON.stringify` of the slice), not reference: the shell's `onDataChange` does `structuredClone(prev)` on every write, so every subtree gets a new reference — a reference/shallow check would fire every watcher on every change. Value comparison is also robust to however the host produces `data` (Redux, query cache, re-parsed JSON), which reference comparison would not be.
- No wire-format change → no schema regeneration.

## Verification

Verified end-to-end via Playwright:

- **`ScriptsWatch`** story (three switches + `watch('/items', (ctx, current) => ...)` that sets `/all_done` and fires `all_complete`): toggling switches one by one → the completion interaction fires **exactly once**, on the false→true edge (Actions badge = 1), not per toggle. Un-toggle clears, re-toggle re-fires (badge = 2) — re-crosses correctly, not stuck. The watcher's own `setValue` emit does **not** loop.
- **`Scripts`** story: confirms the new `(ctx, params)` handler shape — `addTag`/`renameFirst` read `params.tag`/`params.newTag` and push/edit correctly (`RENAMED BETA`, count preserved).
- `pnpm lint` (tsgo + eslint) clean; no `eslint-disable`.

## Changeset

`@optiaxiom/proteus`: **minor**. `proteus-script` is internal (not re-exported from the package root), so the only consumer-facing surface is the in-script `watch` function and the callback signatures — both documented in the changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
