### PR TITLE
[APPX-13293] Add Proteus Diff element type

### DIFF
--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -2652,3 +2652,43 @@ export const PartialRendering: Story = {
     strict: false,
   },
 };
+
+export const WithDiff: Story = {
+  args: {
+    element: {
+      $type: "Document",
+      appName: "Opal",
+      body: [
+        {
+          $type: "Diff",
+          changes: [
+            {
+              field: "Status",
+              newValue: "Running",
+              oldValue: "Paused",
+              type: "modified",
+            },
+            {
+              field: "Traffic Allocation",
+              newValue: "50%",
+              oldValue: "25%",
+              type: "modified",
+            },
+            {
+              field: "Description",
+              newValue: "Updated experiment for Q3 launch",
+              type: "added",
+            },
+            {
+              field: "Legacy Flag",
+              oldValue: "enabled",
+              type: "removed",
+            },
+          ],
+          title: "Flag Configuration Changes",
+        },
+      ],
+      title: "Change History",
+    },
+  },
+};

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -2661,30 +2661,10 @@ export const WithDiff: Story = {
       body: [
         {
           $type: "Diff",
-          changes: [
-            {
-              field: "Status",
-              newValue: "Running",
-              oldValue: "Paused",
-              type: "modified",
-            },
-            {
-              field: "Traffic Allocation",
-              newValue: "50%",
-              oldValue: "25%",
-              type: "modified",
-            },
-            {
-              field: "Description",
-              newValue: "Updated experiment for Q3 launch",
-              type: "added",
-            },
-            {
-              field: "Legacy Flag",
-              oldValue: "enabled",
-              type: "removed",
-            },
-          ],
+          newText:
+            '{\n  "name": "homepage_redesign",\n  "status": "Running",\n  "traffic_allocation": 75,\n  "targeting": "all_users",\n  "description": "Updated experiment for Q3 launch"\n}',
+          oldText:
+            '{\n  "name": "homepage_redesign",\n  "status": "Paused",\n  "traffic_allocation": 50,\n  "legacy_flag": true\n}',
           title: "Flag Configuration Changes",
         },
       ],

--- a/packages/proteus/package.json
+++ b/packages/proteus/package.json
@@ -42,6 +42,7 @@
     "@radix-ui/react-roving-focus": "^1.1.11",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@tanstack/react-table": "^8.21.3",
+    "diff": "^7.0.0",
     "embla-carousel-react": "^8.6.0",
     "jsonpointer": "^5.0.1",
     "react-markdown": "^10.1.0",

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -130,6 +130,22 @@ const PROTEUS_COMPONENT_CONFIG = {
     },
     extends: "Fragment",
   },
+  Diff: {
+    allowedProps: ["changes", "newTitle", "oldTitle", "title"],
+    example: {
+      changes: [
+        {
+          field: "Status",
+          newValue: "Running",
+          oldValue: "Paused",
+          type: "modified",
+        },
+        { field: "Traffic", newValue: "50%", type: "added" },
+      ],
+      title: "Changes",
+    },
+    extends: "Fragment",
+  },
   DateInput: {
     allowedProps: ["name", "placeholder", "required", "type"],
     example: { name: "date_field", type: "date" },
@@ -1296,6 +1312,57 @@ function getPropTypeOverrides(additionalProperties = false) {
           { $ref: "#/definitions/ProteusExpression" },
           { $ref: "#/definitions/ProteusZip" },
         ],
+      },
+    },
+    Diff: {
+      changes: {
+        anyOf: [
+          {
+            description: "Array of change entries to display",
+            items: {
+              ...(additionalProperties ? {} : { additionalProperties: false }),
+              properties: {
+                field: {
+                  description: "Name of the changed field",
+                  type: "string",
+                },
+                newValue: {
+                  description: "New value after the change",
+                  type: "string",
+                },
+                oldValue: {
+                  description: "Previous value before the change",
+                  type: "string",
+                },
+                type: {
+                  anyOf: [
+                    { const: "added" },
+                    { const: "modified" },
+                    { const: "removed" },
+                  ],
+                  description:
+                    "Type of change. Inferred from oldValue/newValue if omitted.",
+                },
+              },
+              required: ["field"],
+              type: "object",
+            },
+            type: "array",
+          },
+          { $ref: "#/definitions/ProteusExpression" },
+        ],
+      },
+      newTitle: {
+        description: "Column header for new values. Defaults to 'New'.",
+        type: "string",
+      },
+      oldTitle: {
+        description: "Column header for old values. Defaults to 'Old'.",
+        type: "string",
+      },
+      title: {
+        description: "Optional heading displayed above the diff table",
+        type: "string",
       },
     },
     Federated: {

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -131,17 +131,10 @@ const PROTEUS_COMPONENT_CONFIG = {
     extends: "Fragment",
   },
   Diff: {
-    allowedProps: ["changes", "newTitle", "oldTitle", "title"],
+    allowedProps: ["newText", "newTitle", "oldText", "oldTitle", "title"],
     example: {
-      changes: [
-        {
-          field: "Status",
-          newValue: "Running",
-          oldValue: "Paused",
-          type: "modified",
-        },
-        { field: "Traffic", newValue: "50%", type: "added" },
-      ],
+      newText: '{\n  "status": "Running"\n}',
+      oldText: '{\n  "status": "Paused"\n}',
       title: "Changes",
     },
     extends: "Fragment",
@@ -1315,53 +1308,30 @@ function getPropTypeOverrides(additionalProperties = false) {
       },
     },
     Diff: {
-      changes: {
+      newText: {
         anyOf: [
-          {
-            description: "Array of change entries to display",
-            items: {
-              ...(additionalProperties ? {} : { additionalProperties: false }),
-              properties: {
-                field: {
-                  description: "Name of the changed field",
-                  type: "string",
-                },
-                newValue: {
-                  description: "New value after the change",
-                  type: "string",
-                },
-                oldValue: {
-                  description: "Previous value before the change",
-                  type: "string",
-                },
-                type: {
-                  anyOf: [
-                    { const: "added" },
-                    { const: "modified" },
-                    { const: "removed" },
-                  ],
-                  description:
-                    "Type of change. Inferred from oldValue/newValue if omitted.",
-                },
-              },
-              required: ["field"],
-              type: "object",
-            },
-            type: "array",
-          },
+          { type: "string" },
           { $ref: "#/definitions/ProteusExpression" },
         ],
+        description: "The new version of the text to compare",
       },
       newTitle: {
-        description: "Column header for new values. Defaults to 'New'.",
+        description: "Column header for the new text side. Defaults to 'New'.",
         type: "string",
       },
+      oldText: {
+        anyOf: [
+          { type: "string" },
+          { $ref: "#/definitions/ProteusExpression" },
+        ],
+        description: "The old version of the text to compare",
+      },
       oldTitle: {
-        description: "Column header for old values. Defaults to 'Old'.",
+        description: "Column header for the old text side. Defaults to 'Old'.",
         type: "string",
       },
       title: {
-        description: "Optional heading displayed above the diff table",
+        description: "Optional heading displayed above the diff viewer",
         type: "string",
       },
     },

--- a/packages/proteus/src/index.ts
+++ b/packages/proteus/src/index.ts
@@ -2,6 +2,7 @@ export * from "./proteus-action";
 export * from "./proteus-bridge";
 export * from "./proteus-chart";
 export * from "./proteus-data-table";
+export * from "./proteus-diff";
 export * from "./proteus-date-input";
 export * from "./proteus-document";
 export * from "./proteus-federated";

--- a/packages/proteus/src/proteus-diff/ProteusDiff.css.ts
+++ b/packages/proteus/src/proteus-diff/ProteusDiff.css.ts
@@ -1,0 +1,48 @@
+import { theme } from "@optiaxiom/react/css-runtime";
+
+import { recipe, style } from "../vanilla-extract";
+
+export const table = recipe({
+  base: [
+    style({
+      borderCollapse: "collapse",
+      width: "100%",
+    }),
+  ],
+});
+
+export const th = recipe({
+  base: [
+    {
+      color: "fg.tertiary",
+      fontSize: "sm",
+      fontWeight: "600",
+    },
+    style({
+      borderBottom: `1px solid ${theme.colors["border.default"]}`,
+      padding: "8px 12px",
+      textAlign: "left",
+    }),
+  ],
+});
+
+export const td = recipe({
+  base: [
+    {
+      fontSize: "sm",
+    },
+    style({
+      borderBottom: `1px solid ${theme.colors["border.default"]}`,
+      padding: "8px 12px",
+      verticalAlign: "top",
+    }),
+  ],
+});
+
+export const fieldCell = recipe({
+  base: [
+    {
+      fontWeight: "500",
+    },
+  ],
+});

--- a/packages/proteus/src/proteus-diff/ProteusDiff.css.ts
+++ b/packages/proteus/src/proteus-diff/ProteusDiff.css.ts
@@ -2,16 +2,27 @@ import { theme } from "@optiaxiom/react/css-runtime";
 
 import { recipe, style } from "../vanilla-extract";
 
-export const table = recipe({
+export const container = recipe({
+  base: [
+    style({
+      border: `1px solid ${theme.colors["border.default"]}`,
+      borderRadius: theme.borderRadius.md,
+      overflow: "hidden",
+    }),
+  ],
+});
+
+export const diffTable = recipe({
   base: [
     style({
       borderCollapse: "collapse",
+      tableLayout: "fixed",
       width: "100%",
     }),
   ],
 });
 
-export const th = recipe({
+export const headerCell = recipe({
   base: [
     {
       color: "fg.tertiary",
@@ -19,30 +30,81 @@ export const th = recipe({
       fontWeight: "600",
     },
     style({
+      backgroundColor: theme.colors["bg.secondary"],
       borderBottom: `1px solid ${theme.colors["border.default"]}`,
-      padding: "8px 12px",
+      padding: "6px 12px",
       textAlign: "left",
     }),
   ],
 });
 
-export const td = recipe({
+export const lineNumber = recipe({
+  base: [
+    {
+      color: "fg.tertiary",
+      fontSize: "sm",
+    },
+    style({
+      borderRight: `1px solid ${theme.colors["border.default"]}`,
+      padding: "0 8px",
+      textAlign: "right",
+      userSelect: "none",
+      verticalAlign: "top",
+      width: "1%",
+    }),
+  ],
+});
+
+export const lineContent = recipe({
   base: [
     {
       fontSize: "sm",
     },
     style({
-      borderBottom: `1px solid ${theme.colors["border.default"]}`,
-      padding: "8px 12px",
+      fontFamily: theme.fontFamily.mono,
+      padding: "0 12px",
       verticalAlign: "top",
+      whiteSpace: "pre-wrap",
+      wordBreak: "break-all",
+    }),
+  ],
+  variants: {
+    type: {
+      added: [
+        style({
+          backgroundColor: theme.colors["bg.success.subtle"],
+        }),
+      ],
+      empty: [
+        style({
+          backgroundColor: theme.colors["bg.secondary"],
+        }),
+      ],
+      removed: [
+        style({
+          backgroundColor: theme.colors["bg.error.subtlest"],
+        }),
+      ],
+      unchanged: [],
+    },
+  },
+});
+
+export const separator = recipe({
+  base: [
+    style({
+      borderRight: `1px solid ${theme.colors["border.default"]}`,
+      width: 0,
     }),
   ],
 });
 
-export const fieldCell = recipe({
-  base: [
-    {
-      fontWeight: "500",
-    },
-  ],
+export const removedToken = style({
+  backgroundColor: theme.colors["bg.error.light"],
+  borderRadius: theme.borderRadius.sm,
+});
+
+export const addedToken = style({
+  backgroundColor: theme.colors["bg.success.light"],
+  borderRadius: theme.borderRadius.sm,
 });

--- a/packages/proteus/src/proteus-diff/ProteusDiff.tsx
+++ b/packages/proteus/src/proteus-diff/ProteusDiff.tsx
@@ -1,47 +1,196 @@
-import { Badge, Box, Heading } from "@optiaxiom/react";
+import { Box, Heading } from "@optiaxiom/react";
+import { diffLines, diffWords } from "diff";
+import { useMemo } from "react";
 
 import * as styles from "./ProteusDiff.css";
 
-type DiffChange = {
-  field: string;
-  newValue?: string;
-  oldValue?: string;
-  type?: "added" | "modified" | "removed";
+type Token = {
+  type: "added" | "removed" | "unchanged";
+  value: string;
+};
+
+type DiffSide = {
+  lineNumber: number;
+  tokens?: Token[];
+  type: "added" | "removed" | "unchanged";
+} | null;
+
+type DiffRow = {
+  left: DiffSide;
+  right: DiffSide;
 };
 
 export type ProteusDiffProps = {
-  changes?: DiffChange[];
+  newText?: string;
   newTitle?: string;
+  oldText?: string;
   oldTitle?: string;
   title?: string;
 };
 
-function inferType(change: DiffChange): "added" | "modified" | "removed" {
-  if (change.type) {
-    return change.type;
+function computeWordTokens(
+  oldLine: string,
+  newLine: string,
+): { left: Token[]; right: Token[] } {
+  const changes = diffWords(oldLine, newLine);
+  const left: Token[] = [];
+  const right: Token[] = [];
+  for (const change of changes) {
+    if (change.added) {
+      right.push({ type: "added", value: change.value });
+    } else if (change.removed) {
+      left.push({ type: "removed", value: change.value });
+    } else {
+      left.push({ type: "unchanged", value: change.value });
+      right.push({ type: "unchanged", value: change.value });
+    }
   }
-  if (change.oldValue == null) {
-    return "added";
-  }
-  if (change.newValue == null) {
-    return "removed";
-  }
-  return "modified";
+  return { left, right };
 }
 
-const intentMap = {
-  added: "success",
-  modified: "warning",
-  removed: "danger",
-} as const;
+function buildRows(oldText: string, newText: string): DiffRow[] {
+  const changes = diffLines(oldText, newText);
+  const rows: DiffRow[] = [];
+  let leftLine = 1;
+  let rightLine = 1;
+
+  let i = 0;
+  while (i < changes.length) {
+    const change = changes[i];
+
+    if (!change.added && !change.removed) {
+      const lines = splitLines(change.value);
+      for (const line of lines) {
+        rows.push({
+          left: { lineNumber: leftLine++, type: "unchanged" },
+          right: { lineNumber: rightLine++, type: "unchanged" },
+        });
+        setPlainText(rows[rows.length - 1], "left", line);
+        setPlainText(rows[rows.length - 1], "right", line);
+      }
+      i++;
+    } else if (
+      change.removed &&
+      i + 1 < changes.length &&
+      changes[i + 1].added
+    ) {
+      const removedLines = splitLines(change.value);
+      const addedLines = splitLines(changes[i + 1].value);
+      const maxLen = Math.max(removedLines.length, addedLines.length);
+
+      for (let j = 0; j < maxLen; j++) {
+        const oldLine = j < removedLines.length ? removedLines[j] : null;
+        const newLine = j < addedLines.length ? addedLines[j] : null;
+
+        if (oldLine !== null && newLine !== null) {
+          const { left: leftTokens, right: rightTokens } = computeWordTokens(
+            oldLine,
+            newLine,
+          );
+          rows.push({
+            left: {
+              lineNumber: leftLine++,
+              tokens: leftTokens,
+              type: "removed",
+            },
+            right: {
+              lineNumber: rightLine++,
+              tokens: rightTokens,
+              type: "added",
+            },
+          });
+        } else if (oldLine !== null) {
+          rows.push({
+            left: { lineNumber: leftLine++, type: "removed" },
+            right: null,
+          });
+          setPlainText(rows[rows.length - 1], "left", oldLine);
+        } else if (newLine !== null) {
+          rows.push({
+            left: null,
+            right: { lineNumber: rightLine++, type: "added" },
+          });
+          setPlainText(rows[rows.length - 1], "right", newLine);
+        }
+      }
+      i += 2;
+    } else if (change.removed) {
+      const lines = splitLines(change.value);
+      for (const line of lines) {
+        rows.push({
+          left: { lineNumber: leftLine++, type: "removed" },
+          right: null,
+        });
+        setPlainText(rows[rows.length - 1], "left", line);
+      }
+      i++;
+    } else if (change.added) {
+      const lines = splitLines(change.value);
+      for (const line of lines) {
+        rows.push({
+          left: null,
+          right: { lineNumber: rightLine++, type: "added" },
+        });
+        setPlainText(rows[rows.length - 1], "right", line);
+      }
+      i++;
+    } else {
+      i++;
+    }
+  }
+
+  return rows;
+}
+
+function splitLines(text: string): string[] {
+  const lines = text.split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+  return lines;
+}
+
+function setPlainText(row: DiffRow, side: "left" | "right", text: string) {
+  const entry = row[side];
+  if (entry) {
+    entry.tokens = [{ type: "unchanged", value: text }];
+  }
+}
+
+function TokenSpan({ tokens }: { tokens: Token[] }) {
+  return (
+    <>
+      {tokens.map((token, i) => {
+        if (token.type === "removed") {
+          return (
+            <span className={styles.removedToken} key={i}>
+              {token.value}
+            </span>
+          );
+        }
+        if (token.type === "added") {
+          return (
+            <span className={styles.addedToken} key={i}>
+              {token.value}
+            </span>
+          );
+        }
+        return <span key={i}>{token.value}</span>;
+      })}
+    </>
+  );
+}
 
 export const ProteusDiff = ({
-  changes,
+  newText = "",
   newTitle = "New",
+  oldText = "",
   oldTitle = "Old",
   title,
 }: ProteusDiffProps) => {
-  if (!changes || changes.length === 0) {
+  const rows = useMemo(() => buildRows(oldText, newText), [oldText, newText]);
+
+  if (rows.length === 0) {
     return null;
   }
 
@@ -52,54 +201,102 @@ export const ProteusDiff = ({
           {title}
         </Heading>
       )}
-      <Box asChild {...styles.table()}>
-        <table>
-          <thead>
-            <tr>
-              <Box asChild {...styles.th()}>
-                <th>Field</th>
-              </Box>
-              <Box asChild {...styles.th()}>
-                <th>{oldTitle}</th>
-              </Box>
-              <Box asChild {...styles.th()}>
-                <th>{newTitle}</th>
-              </Box>
-              <Box asChild {...styles.th()}>
-                <th>Change</th>
-              </Box>
-            </tr>
-          </thead>
-          <tbody>
-            {changes.map((change, index) => {
-              const type = inferType(change);
-              return (
-                <tr key={index}>
-                  <Box
-                    asChild
-                    {...styles.fieldCell(
-                      undefined,
-                      styles.td().className,
-                    )}
-                  >
-                    <td>{change.field}</td>
+      <Box {...styles.container()}>
+        <Box asChild {...styles.diffTable()}>
+          <table>
+            <colgroup>
+              <col style={{ width: "3%" }} />
+              <col style={{ width: "47%" }} />
+              <col style={{ width: 0 }} />
+              <col style={{ width: "3%" }} />
+              <col style={{ width: "47%" }} />
+            </colgroup>
+            <thead>
+              <tr>
+                <Box asChild colSpan={2} {...styles.headerCell()}>
+                  <th>{oldTitle}</th>
+                </Box>
+                <th style={{ width: 0 }} />
+                <Box asChild colSpan={2} {...styles.headerCell()}>
+                  <th>{newTitle}</th>
+                </Box>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, i) => (
+                <tr key={i}>
+                  {row.left ? (
+                    <>
+                      <Box asChild {...styles.lineNumber()}>
+                        <td>{row.left.lineNumber}</td>
+                      </Box>
+                      <Box
+                        asChild
+                        {...styles.lineContent({ type: row.left.type })}
+                      >
+                        <td>
+                          {row.left.tokens && (
+                            <TokenSpan tokens={row.left.tokens} />
+                          )}
+                        </td>
+                      </Box>
+                    </>
+                  ) : (
+                    <>
+                      <Box
+                        asChild
+                        {...styles.lineContent({ type: "empty" })}
+                      >
+                        <td />
+                      </Box>
+                      <Box
+                        asChild
+                        {...styles.lineContent({ type: "empty" })}
+                      >
+                        <td />
+                      </Box>
+                    </>
+                  )}
+                  <Box asChild {...styles.separator()}>
+                    <td />
                   </Box>
-                  <Box asChild {...styles.td()}>
-                    <td>{change.oldValue ?? "—"}</td>
-                  </Box>
-                  <Box asChild {...styles.td()}>
-                    <td>{change.newValue ?? "—"}</td>
-                  </Box>
-                  <Box asChild {...styles.td()}>
-                    <td>
-                      <Badge intent={intentMap[type]}>{type}</Badge>
-                    </td>
-                  </Box>
+                  {row.right ? (
+                    <>
+                      <Box asChild {...styles.lineNumber()}>
+                        <td>{row.right.lineNumber}</td>
+                      </Box>
+                      <Box
+                        asChild
+                        {...styles.lineContent({ type: row.right.type })}
+                      >
+                        <td>
+                          {row.right.tokens && (
+                            <TokenSpan tokens={row.right.tokens} />
+                          )}
+                        </td>
+                      </Box>
+                    </>
+                  ) : (
+                    <>
+                      <Box
+                        asChild
+                        {...styles.lineContent({ type: "empty" })}
+                      >
+                        <td />
+                      </Box>
+                      <Box
+                        asChild
+                        {...styles.lineContent({ type: "empty" })}
+                      >
+                        <td />
+                      </Box>
+                    </>
+                  )}
                 </tr>
-              );
-            })}
-          </tbody>
-        </table>
+              ))}
+            </tbody>
+          </table>
+        </Box>
       </Box>
     </Box>
   );

--- a/packages/proteus/src/proteus-diff/ProteusDiff.tsx
+++ b/packages/proteus/src/proteus-diff/ProteusDiff.tsx
@@ -1,0 +1,102 @@
+import { Badge, Box, Heading } from "@optiaxiom/react";
+
+import * as styles from "./ProteusDiff.css";
+
+type DiffChange = {
+  field: string;
+  newValue?: string;
+  oldValue?: string;
+  type?: "added" | "modified" | "removed";
+};
+
+export type ProteusDiffProps = {
+  changes?: DiffChange[];
+  newTitle?: string;
+  oldTitle?: string;
+  title?: string;
+};
+
+function inferType(change: DiffChange): "added" | "modified" | "removed" {
+  if (change.type) {
+    return change.type;
+  }
+  if (change.oldValue == null) {
+    return "added";
+  }
+  if (change.newValue == null) {
+    return "removed";
+  }
+  return "modified";
+}
+
+const intentMap = {
+  added: "success",
+  modified: "warning",
+  removed: "danger",
+} as const;
+
+export const ProteusDiff = ({
+  changes,
+  newTitle = "New",
+  oldTitle = "Old",
+  title,
+}: ProteusDiffProps) => {
+  if (!changes || changes.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box>
+      {title && (
+        <Heading level="3" mb="8">
+          {title}
+        </Heading>
+      )}
+      <Box asChild className={styles.table()}>
+        <table>
+          <thead>
+            <tr>
+              <Box asChild className={styles.th()}>
+                <th>Field</th>
+              </Box>
+              <Box asChild className={styles.th()}>
+                <th>{oldTitle}</th>
+              </Box>
+              <Box asChild className={styles.th()}>
+                <th>{newTitle}</th>
+              </Box>
+              <Box asChild className={styles.th()}>
+                <th>Change</th>
+              </Box>
+            </tr>
+          </thead>
+          <tbody>
+            {changes.map((change, index) => {
+              const type = inferType(change);
+              return (
+                <tr key={index}>
+                  <Box asChild className={`${styles.td()} ${styles.fieldCell()}`}>
+                    <td>{change.field}</td>
+                  </Box>
+                  <Box asChild className={styles.td()}>
+                    <td>{change.oldValue ?? "—"}</td>
+                  </Box>
+                  <Box asChild className={styles.td()}>
+                    <td>{change.newValue ?? "—"}</td>
+                  </Box>
+                  <Box asChild className={styles.td()}>
+                    <td>
+                      <Badge intent={intentMap[type]}>{type}</Badge>
+                    </td>
+                  </Box>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </Box>
+    </Box>
+  );
+};
+
+ProteusDiff.displayName = "@optiaxiom/proteus/ProteusDiff";

--- a/packages/proteus/src/proteus-diff/ProteusDiff.tsx
+++ b/packages/proteus/src/proteus-diff/ProteusDiff.tsx
@@ -52,20 +52,20 @@ export const ProteusDiff = ({
           {title}
         </Heading>
       )}
-      <Box asChild className={styles.table()}>
+      <Box asChild {...styles.table()}>
         <table>
           <thead>
             <tr>
-              <Box asChild className={styles.th()}>
+              <Box asChild {...styles.th()}>
                 <th>Field</th>
               </Box>
-              <Box asChild className={styles.th()}>
+              <Box asChild {...styles.th()}>
                 <th>{oldTitle}</th>
               </Box>
-              <Box asChild className={styles.th()}>
+              <Box asChild {...styles.th()}>
                 <th>{newTitle}</th>
               </Box>
-              <Box asChild className={styles.th()}>
+              <Box asChild {...styles.th()}>
                 <th>Change</th>
               </Box>
             </tr>
@@ -75,16 +75,22 @@ export const ProteusDiff = ({
               const type = inferType(change);
               return (
                 <tr key={index}>
-                  <Box asChild className={`${styles.td()} ${styles.fieldCell()}`}>
+                  <Box
+                    asChild
+                    {...styles.fieldCell(
+                      undefined,
+                      styles.td().className,
+                    )}
+                  >
                     <td>{change.field}</td>
                   </Box>
-                  <Box asChild className={styles.td()}>
+                  <Box asChild {...styles.td()}>
                     <td>{change.oldValue ?? "—"}</td>
                   </Box>
-                  <Box asChild className={styles.td()}>
+                  <Box asChild {...styles.td()}>
                     <td>{change.newValue ?? "—"}</td>
                   </Box>
-                  <Box asChild className={styles.td()}>
+                  <Box asChild {...styles.td()}>
                     <td>
                       <Badge intent={intentMap[type]}>{type}</Badge>
                     </td>

--- a/packages/proteus/src/proteus-diff/index.ts
+++ b/packages/proteus/src/proteus-diff/index.ts
@@ -1,0 +1,1 @@
+export { ProteusDiff } from "./ProteusDiff";

--- a/packages/proteus/src/proteus-document/schemas.ts
+++ b/packages/proteus/src/proteus-document/schemas.ts
@@ -32,6 +32,7 @@ import type { ProteusBridgeProps } from "../proteus-bridge/ProteusBridge";
 import type { ProteusCardLinkProps } from "../proteus-card-link/ProteusCardLink";
 import type { ProteusChartProps } from "../proteus-chart/ProteusChart";
 import type { ProteusDataTableProps } from "../proteus-data-table/ProteusDataTable";
+import type { ProteusDiffProps } from "../proteus-diff/ProteusDiff";
 import type { ProteusFederatedProps } from "../proteus-federated/ProteusFederated";
 import type { ProteusFileIconProps } from "../proteus-file-icon/ProteusFileIcon";
 import type { ProteusFileUploadProps } from "../proteus-file-upload/ProteusFileUpload";
@@ -74,6 +75,7 @@ export type ProteusElement =
   | (ProteusCardLinkProps & { $type: "CardLink" })
   | (ProteusChartProps & { $type: "Chart" })
   | (ProteusDataTableProps & { $type: "DataTable" })
+  | (ProteusDiffProps & { $type: "Diff" })
   | (ProteusFederatedProps & { $type: "Federated" })
   | (ProteusFileIconProps & { $type: "FileIcon" })
   | (ProteusFileUploadProps & { $type: "FileUpload" })

--- a/packages/proteus/src/proteus-element/ProteusElement.tsx
+++ b/packages/proteus/src/proteus-element/ProteusElement.tsx
@@ -25,6 +25,7 @@ import { ProteusAction } from "../proteus-action/ProteusAction";
 import { ProteusBridge } from "../proteus-bridge/ProteusBridge";
 import { ProteusCardLink } from "../proteus-card-link/ProteusCardLink";
 import { ProteusDataTable } from "../proteus-data-table/ProteusDataTable";
+import { ProteusDiff } from "../proteus-diff/ProteusDiff";
 import { ProteusDateInput } from "../proteus-date-input/ProteusDateInput";
 import { useProteusDocumentContext } from "../proteus-document/ProteusDocumentContext";
 import { useProteusDocumentPathContext } from "../proteus-document/ProteusDocumentPathContext";
@@ -148,6 +149,14 @@ export const ProteusElement = ({
         <ProteusDataTable
           {...(resolve(element) as ComponentPropsWithoutRef<
             typeof ProteusDataTable
+          >)}
+        />
+      );
+    case "Diff":
+      return (
+        <ProteusDiff
+          {...(resolve(element) as ComponentPropsWithoutRef<
+            typeof ProteusDiff
           >)}
         />
       );

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -2758,66 +2758,37 @@
       "examples": [
         {
           "$type": "Diff",
-          "changes": [
-            {
-              "field": "Status",
-              "newValue": "Running",
-              "oldValue": "Paused",
-              "type": "modified"
-            },
-            { "field": "Traffic", "newValue": "50%", "type": "added" }
-          ],
+          "newText": "{\n  \"status\": \"Running\"\n}",
+          "oldText": "{\n  \"status\": \"Paused\"\n}",
           "title": "Changes"
         }
       ],
       "properties": {
         "$type": { "const": "Diff" },
-        "changes": {
+        "newText": {
           "anyOf": [
-            {
-              "description": "Array of change entries to display",
-              "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "field": {
-                    "description": "Name of the changed field",
-                    "type": "string"
-                  },
-                  "newValue": {
-                    "description": "New value after the change",
-                    "type": "string"
-                  },
-                  "oldValue": {
-                    "description": "Previous value before the change",
-                    "type": "string"
-                  },
-                  "type": {
-                    "anyOf": [
-                      { "const": "added" },
-                      { "const": "modified" },
-                      { "const": "removed" }
-                    ],
-                    "description": "Type of change. Inferred from oldValue/newValue if omitted."
-                  }
-                },
-                "required": ["field"],
-                "type": "object"
-              },
-              "type": "array"
-            },
+            { "type": "string" },
             { "$ref": "#/definitions/ProteusExpression" }
-          ]
+          ],
+          "description": "The new version of the text to compare"
         },
         "newTitle": {
-          "description": "Column header for new values. Defaults to 'New'.",
+          "description": "Column header for the new text side. Defaults to 'New'.",
           "type": "string"
         },
+        "oldText": {
+          "anyOf": [
+            { "type": "string" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "The old version of the text to compare"
+        },
         "oldTitle": {
-          "description": "Column header for old values. Defaults to 'Old'.",
+          "description": "Column header for the old text side. Defaults to 'Old'.",
           "type": "string"
         },
         "title": {
-          "description": "Optional heading displayed above the diff table",
+          "description": "Optional heading displayed above the diff viewer",
           "type": "string"
         }
       },

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -1370,6 +1370,7 @@
         { "$ref": "#/definitions/ProteusChart" },
         { "$ref": "#/definitions/ProteusConcat" },
         { "$ref": "#/definitions/ProteusDataTable" },
+        { "$ref": "#/definitions/ProteusDiff" },
         { "$ref": "#/definitions/ProteusDateInput" },
         { "$ref": "#/definitions/ProteusDisclosure" },
         { "$ref": "#/definitions/ProteusDisclosureContent" },
@@ -2747,6 +2748,77 @@
             { "$ref": "#/definitions/ProteusExpression" },
             { "$ref": "#/definitions/ProteusZip" }
           ]
+        }
+      },
+      "required": ["$type"],
+      "type": "object"
+    },
+    "ProteusDiff": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "$type": "Diff",
+          "changes": [
+            {
+              "field": "Status",
+              "newValue": "Running",
+              "oldValue": "Paused",
+              "type": "modified"
+            },
+            { "field": "Traffic", "newValue": "50%", "type": "added" }
+          ],
+          "title": "Changes"
+        }
+      ],
+      "properties": {
+        "$type": { "const": "Diff" },
+        "changes": {
+          "anyOf": [
+            {
+              "description": "Array of change entries to display",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "field": {
+                    "description": "Name of the changed field",
+                    "type": "string"
+                  },
+                  "newValue": {
+                    "description": "New value after the change",
+                    "type": "string"
+                  },
+                  "oldValue": {
+                    "description": "Previous value before the change",
+                    "type": "string"
+                  },
+                  "type": {
+                    "anyOf": [
+                      { "const": "added" },
+                      { "const": "modified" },
+                      { "const": "removed" }
+                    ],
+                    "description": "Type of change. Inferred from oldValue/newValue if omitted."
+                  }
+                },
+                "required": ["field"],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ]
+        },
+        "newTitle": {
+          "description": "Column header for new values. Defaults to 'New'.",
+          "type": "string"
+        },
+        "oldTitle": {
+          "description": "Column header for old values. Defaults to 'Old'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Optional heading displayed above the diff table",
+          "type": "string"
         }
       },
       "required": ["$type"],

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -2718,65 +2718,37 @@
       "examples": [
         {
           "$type": "Diff",
-          "changes": [
-            {
-              "field": "Status",
-              "newValue": "Running",
-              "oldValue": "Paused",
-              "type": "modified"
-            },
-            { "field": "Traffic", "newValue": "50%", "type": "added" }
-          ],
+          "newText": "{\n  \"status\": \"Running\"\n}",
+          "oldText": "{\n  \"status\": \"Paused\"\n}",
           "title": "Changes"
         }
       ],
       "properties": {
         "$type": { "const": "Diff" },
-        "changes": {
+        "newText": {
           "anyOf": [
-            {
-              "description": "Array of change entries to display",
-              "items": {
-                "properties": {
-                  "field": {
-                    "description": "Name of the changed field",
-                    "type": "string"
-                  },
-                  "newValue": {
-                    "description": "New value after the change",
-                    "type": "string"
-                  },
-                  "oldValue": {
-                    "description": "Previous value before the change",
-                    "type": "string"
-                  },
-                  "type": {
-                    "anyOf": [
-                      { "const": "added" },
-                      { "const": "modified" },
-                      { "const": "removed" }
-                    ],
-                    "description": "Type of change. Inferred from oldValue/newValue if omitted."
-                  }
-                },
-                "required": ["field"],
-                "type": "object"
-              },
-              "type": "array"
-            },
+            { "type": "string" },
             { "$ref": "#/definitions/ProteusExpression" }
-          ]
+          ],
+          "description": "The new version of the text to compare"
         },
         "newTitle": {
-          "description": "Column header for new values. Defaults to 'New'.",
+          "description": "Column header for the new text side. Defaults to 'New'.",
           "type": "string"
         },
+        "oldText": {
+          "anyOf": [
+            { "type": "string" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "The old version of the text to compare"
+        },
         "oldTitle": {
-          "description": "Column header for old values. Defaults to 'Old'.",
+          "description": "Column header for the old text side. Defaults to 'Old'.",
           "type": "string"
         },
         "title": {
-          "description": "Optional heading displayed above the diff table",
+          "description": "Optional heading displayed above the diff viewer",
           "type": "string"
         }
       },

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -1359,6 +1359,7 @@
         { "$ref": "#/definitions/ProteusChart" },
         { "$ref": "#/definitions/ProteusConcat" },
         { "$ref": "#/definitions/ProteusDataTable" },
+        { "$ref": "#/definitions/ProteusDiff" },
         { "$ref": "#/definitions/ProteusDateInput" },
         { "$ref": "#/definitions/ProteusDisclosure" },
         { "$ref": "#/definitions/ProteusDisclosureContent" },
@@ -2708,6 +2709,75 @@
             { "$ref": "#/definitions/ProteusExpression" },
             { "$ref": "#/definitions/ProteusZip" }
           ]
+        }
+      },
+      "required": ["$type"],
+      "type": "object"
+    },
+    "ProteusDiff": {
+      "examples": [
+        {
+          "$type": "Diff",
+          "changes": [
+            {
+              "field": "Status",
+              "newValue": "Running",
+              "oldValue": "Paused",
+              "type": "modified"
+            },
+            { "field": "Traffic", "newValue": "50%", "type": "added" }
+          ],
+          "title": "Changes"
+        }
+      ],
+      "properties": {
+        "$type": { "const": "Diff" },
+        "changes": {
+          "anyOf": [
+            {
+              "description": "Array of change entries to display",
+              "items": {
+                "properties": {
+                  "field": {
+                    "description": "Name of the changed field",
+                    "type": "string"
+                  },
+                  "newValue": {
+                    "description": "New value after the change",
+                    "type": "string"
+                  },
+                  "oldValue": {
+                    "description": "Previous value before the change",
+                    "type": "string"
+                  },
+                  "type": {
+                    "anyOf": [
+                      { "const": "added" },
+                      { "const": "modified" },
+                      { "const": "removed" }
+                    ],
+                    "description": "Type of change. Inferred from oldValue/newValue if omitted."
+                  }
+                },
+                "required": ["field"],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ]
+        },
+        "newTitle": {
+          "description": "Column header for new values. Defaults to 'New'.",
+          "type": "string"
+        },
+        "oldTitle": {
+          "description": "Column header for old values. Defaults to 'Old'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Optional heading displayed above the diff table",
+          "type": "string"
         }
       },
       "required": ["$type"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,6 +402,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      diff:
+        specifier: ^7.0.0
+        version: 7.0.0
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@18.3.1)
@@ -5287,6 +5290,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@7.0.0:
+    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+    engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -13984,6 +13991,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@7.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a new `Diff` Proteus element type that renders a **side-by-side text diff viewer** inside Opal chat
- Accepts `oldText` and `newText` string props, computes diffs client-side using the [`diff`](https://www.npmjs.com/package/diff) npm package
- Renders a two-pane table with line numbers, red/green backgrounds for removed/added lines, and word-level inline token highlighting for modified lines
- Uses Axiom design tokens (`bg.error.subtlest`, `bg.success.subtle`, etc.) and recipe variants for styling
- Includes a `WithDiff` Storybook story with a JSON diff example

## Test Plan 🔬

- [x] `pnpm build` passes — schema generated, TypeScript compiles, dist files produced
- [x] Diff definition with `oldText`/`newText`/`oldTitle`/`newTitle`/`title` props present in generated `runtime-schema.json` and `public-schema.json`
- [x] `pnpm -F storybook dev` → `WithDiff` story renders side-by-side diff with line numbers, colored backgrounds, and inline token highlights

## Jira 📂

- [APPX-13293](https://optimizely-ext.atlassian.net/browse/APPX-13293)