### PR TITLE
feat(proteus): add cell templates + DataTableRow to DataTable

### DIFF
--- a/.changeset/datatable-cell-templates.md
+++ b/.changeset/datatable-cell-templates.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": minor
+---
+
+Add custom cell rendering to `DataTable`. A column can now carry a `cell` node template instead of plain text, and a new `DataTableRow` element/expression reads the current row inside it — `{ $type: "DataTableRow", path: "status" }` reads a field, or omit `path` for the whole row (mirroring how `MapIndex` exposes the current index inside a `Map`). This lets a column render a `Badge`, `Icon`, link, or any element composition, with `Show` picking what to render per row (e.g. a change-history table whose "Change" column is a badge whose intent depends on the row). Columns without `cell` are unchanged; `cell` takes precedence over `format`.

--- a/.changeset/fix-watch-subscription-race.md
+++ b/.changeset/fix-watch-subscription-race.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": patch
+---
+
+Fix `watch(path, fn)` script watchers missing edges that happened during startup. The worker reports its watched paths asynchronously after init; if the user changed the watched data before that message arrived, the change was swallowed and the watcher never fired. The watcher now seeds its baseline from the mount-time data and runs an immediate edge-detect the moment its paths are registered, so any change made during the async handshake fires correctly. `register` handlers and watcher-less documents are unaffected.

--- a/.changeset/show-else-branch.md
+++ b/.changeset/show-else-branch.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": minor
+---
+
+Add an `else` branch to `Show`. When the condition is false, `Show` now renders `else` instead of nothing — for element children and, since `Show` also resolves as a value, for props. Chain nested `Show`/`else` to express multi-way choices in a single expression (e.g. a `Badge` whose `intent` maps a value to one of several tokens), instead of repeating the element once per case. `Show` without an `else` is unchanged.

--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -38,6 +38,10 @@ Use `Group` as a flexbox container to arrange child elements. It supports `flexD
 
 <Demo component="proteus/data-display" />
 
+#### Icon
+
+`Icon` renders a named icon from the `icons` map passed to the renderer. If `name` is instead an `http(s)://` or `data:` URL not present in the map, it falls back to rendering an `<img>` with that source — so you can drop in a remote or inline SVG without registering it. Registered icons always take precedence.
+
 #### Custom table cells
 
 By default a `DataTable` column renders its value as text. Give a column a `cell` instead to render a Proteus node for that column. Inside a `cell`, read the current row with `DataTableRow` — `{ $type: "DataTableRow", path: "status" }` reads the row's `status` field, and omitting `path` gives the whole row object (the same way `MapIndex` exposes the current index inside a `Map`). This lets a table column render a `Badge`, `Icon`, link, or any composition of elements, with `Show` picking what to render per row. A change-history / diff view, for example, is just a `DataTable` whose "Change" column is a badge whose intent depends on the row:
@@ -121,6 +125,26 @@ Sends a text message back to the LLM:
 Triggers a file download:
 
 <Demo component="proteus/action-download" />
+
+### Data operations
+
+Actions can also edit form data directly, without a round-trip to your server. `setValue` writes `value` at a JSON-pointer `path`, replacing any existing value; `pushValue` appends to the array at `path`; and `removeValue` removes the array element at `path`. Paths resolve like `Value` (absolute `/x`, relative to the current context, or `''` for the current context itself).
+
+<Demo component="proteus/action-set-value" />
+
+## Scripting
+
+### Scripts
+
+For logic that shouldn't require a server round-trip, a document can ship JavaScript in a `scripts` map. Each module registers named handlers with `register(name, fn)`; trigger one from any event source with `{ script: "module:handler", params }`. Handlers run in a sandboxed Web Worker whose only capability is `ctx.emit` — they get exactly the authority the document already has (emitting the existing Proteus events), so treat `scripts` with the same trust as the rest of the document.
+
+<Demo component="proteus/scripting" />
+
+### Reactive watchers
+
+`watch(path, fn)` is the push counterpart to `register`: it runs edge-triggered whenever the value at `path` changes (use `'/'` to watch all data). A watcher can only `ctx.emit` existing events and does not react to changes its own emit causes, so it can't loop.
+
+<Demo component="proteus/scripting-watch" />
 
 ## Proteus Designer
 

--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -96,7 +96,7 @@ This template renders a list of search results dynamically from a tool response:
 
 ### Show
 
-Use `Show` to render content only when a condition is met:
+Use `Show` to render content only when a condition is met. Add an `else` to render a fallback when the condition is false — this works for element children and, since `Show` also resolves as a value, for props too. Chain nested `Show`/`else` to express multi-way choices (e.g. mapping a value to one of several outputs, like a `Badge` intent):
 
 <Demo component="proteus/show" />
 

--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -38,6 +38,12 @@ Use `Group` as a flexbox container to arrange child elements. It supports `flexD
 
 <Demo component="proteus/data-display" />
 
+#### Custom table cells
+
+By default a `DataTable` column renders its value as text. Give a column a `cell` instead to render a Proteus node for that column. Inside a `cell`, read the current row with `DataTableRow` — `{ $type: "DataTableRow", path: "status" }` reads the row's `status` field, and omitting `path` gives the whole row object (the same way `MapIndex` exposes the current index inside a `Map`). This lets a table column render a `Badge`, `Icon`, link, or any composition of elements, with `Show` picking what to render per row. A change-history / diff view, for example, is just a `DataTable` whose "Change" column is a badge whose intent depends on the row:
+
+<Demo component="proteus/data-table-cell" />
+
 ### Form controls
 
 Wrap inputs with `Field` to add a label. Available inputs include `Input`, `Textarea`, `Select` (composed from `SelectTrigger` and `SelectContent`), `Switch`, `Range`, and `Question` (a multi-question dynamic form).
@@ -169,6 +175,10 @@ The [Proteus Designer](/guides/proteus-designer) is a visual editor for building
 #### DataTable
 
 <ProteusElementRef type="DataTable" />
+
+#### DataTableRow
+
+<ProteusElementRef type="DataTableRow" />
 
 #### Chart
 

--- a/apps/docs/demos/proteus/action-set-value/App.tsx
+++ b/apps/docs/demos/proteus/action-set-value/App.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+import { useState } from "react";
+
+export function App() {
+  const [data, setData] = useState<Record<string, unknown>>({
+    status: "draft",
+  });
+
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        data={data}
+        element={{
+          $type: "Document",
+          actions: [
+            {
+              $type: "Action",
+              appearance: "primary",
+              children: "Mark as published",
+              // `setValue` writes `value` at `path`, replacing any existing
+              // value. `pushValue` / `removeValue` cover appending to and
+              // removing from arrays.
+              onClick: {
+                action: "setValue",
+                path: "/status",
+                value: "published",
+              },
+            },
+          ],
+          body: [
+            {
+              $type: "Text",
+              children: [
+                "Current status: ",
+                { $type: "Value", path: "/status" },
+              ],
+            },
+          ],
+          title: "In-place data edits",
+        }}
+        onDataChange={setData}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/data-table-cell/App.tsx
+++ b/apps/docs/demos/proteus/data-table-cell/App.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+
+export function App() {
+  return (
+    <Box maxW="lg" w="full">
+      <ProteusDocumentRenderer
+        data={{
+          changes: [
+            {
+              field: "Status",
+              newValue: "Running",
+              oldValue: "Paused",
+              type: "modified",
+            },
+            {
+              field: "Description",
+              newValue: "Updated experiment for Q3 launch",
+              oldValue: "—",
+              type: "added",
+            },
+            {
+              field: "Legacy Flag",
+              newValue: "—",
+              oldValue: "enabled",
+              type: "removed",
+            },
+          ],
+        }}
+        element={{
+          $type: "Document",
+          body: {
+            $type: "DataTable",
+            columns: [
+              { accessorKey: "field", header: "Field", size: 150 },
+              { accessorKey: "oldValue", header: "Old", size: 110 },
+              { accessorKey: "newValue", header: "New", size: 170 },
+              {
+                accessorKey: "type",
+                // `cell` is a regular Proteus node. `DataTableRow` reads the
+                // current row inside it, and Show picks the badge intent per row.
+                cell: [
+                  {
+                    $type: "Show",
+                    children: {
+                      $type: "Badge",
+                      children: { $type: "DataTableRow", path: "type" },
+                      intent: "success",
+                    },
+                    when: {
+                      "==": [{ $type: "DataTableRow", path: "type" }, "added"],
+                    },
+                  },
+                  {
+                    $type: "Show",
+                    children: {
+                      $type: "Badge",
+                      children: { $type: "DataTableRow", path: "type" },
+                      intent: "warning",
+                    },
+                    when: {
+                      "==": [
+                        { $type: "DataTableRow", path: "type" },
+                        "modified",
+                      ],
+                    },
+                  },
+                  {
+                    $type: "Show",
+                    children: {
+                      $type: "Badge",
+                      children: { $type: "DataTableRow", path: "type" },
+                      intent: "danger",
+                    },
+                    when: {
+                      "==": [
+                        { $type: "DataTableRow", path: "type" },
+                        "removed",
+                      ],
+                    },
+                  },
+                ],
+                header: "Change",
+                size: 120,
+              },
+            ],
+            data: { $type: "Value", path: "/changes" },
+          },
+          title: "Flag Configuration Changes",
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/data-table-cell/App.tsx
+++ b/apps/docs/demos/proteus/data-table-cell/App.tsx
@@ -40,48 +40,30 @@ export function App() {
               {
                 accessorKey: "type",
                 // `cell` is a regular Proteus node. `DataTableRow` reads the
-                // current row inside it, and Show picks the badge intent per row.
-                cell: [
-                  {
+                // current row inside it, and a Show/else chain picks the badge
+                // intent per row.
+                cell: {
+                  $type: "Badge",
+                  children: { $type: "DataTableRow", path: "type" },
+                  intent: {
                     $type: "Show",
-                    children: {
-                      $type: "Badge",
-                      children: { $type: "DataTableRow", path: "type" },
-                      intent: "success",
+                    children: "success",
+                    else: {
+                      $type: "Show",
+                      children: "danger",
+                      else: "warning",
+                      when: {
+                        "==": [
+                          { $type: "DataTableRow", path: "type" },
+                          "removed",
+                        ],
+                      },
                     },
                     when: {
                       "==": [{ $type: "DataTableRow", path: "type" }, "added"],
                     },
                   },
-                  {
-                    $type: "Show",
-                    children: {
-                      $type: "Badge",
-                      children: { $type: "DataTableRow", path: "type" },
-                      intent: "warning",
-                    },
-                    when: {
-                      "==": [
-                        { $type: "DataTableRow", path: "type" },
-                        "modified",
-                      ],
-                    },
-                  },
-                  {
-                    $type: "Show",
-                    children: {
-                      $type: "Badge",
-                      children: { $type: "DataTableRow", path: "type" },
-                      intent: "danger",
-                    },
-                    when: {
-                      "==": [
-                        { $type: "DataTableRow", path: "type" },
-                        "removed",
-                      ],
-                    },
-                  },
-                ],
+                },
                 header: "Change",
                 size: 120,
               },

--- a/apps/docs/demos/proteus/scripting-watch/App.tsx
+++ b/apps/docs/demos/proteus/scripting-watch/App.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+import { useState } from "react";
+
+export function App() {
+  const [data, setData] = useState<Record<string, unknown>>({
+    items: [
+      { done: false, label: "Accept terms" },
+      { done: false, label: "Verify email" },
+      { done: false, label: "Add payment method" },
+    ],
+  });
+
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        data={data}
+        element={{
+          $type: "Document",
+          body: [
+            {
+              $type: "Text",
+              children: "Tick every item to unlock the next step.",
+              color: "fg.secondary",
+            },
+            {
+              $type: "Group",
+              children: {
+                $type: "Map",
+                children: {
+                  $type: "Switch",
+                  children: { $type: "Value", path: "label" },
+                  name: "done",
+                },
+                path: "/items",
+              },
+              flexDirection: "column",
+              gap: "8",
+            },
+            {
+              $type: "Show",
+              children: {
+                $type: "Alert",
+                children: "All items complete — you're good to go!",
+                intent: "success",
+              },
+              when: { "!!": { $type: "Value", path: "/all_done" } },
+            },
+          ],
+          // A watcher reacts to data changes (edge-triggered) — the push
+          // counterpart to `register`. It runs once on the false→true edge and
+          // its own setValue write does not re-trigger it, so it can't loop.
+          scripts: {
+            main: [
+              "watch('/items', (ctx, current) => {",
+              "  const items = current || [];",
+              "  const done = items.length > 0 && items.every((i) => i.done === true);",
+              "  ctx.emit({ action: 'setValue', path: '/all_done', value: done });",
+              "});",
+            ].join("\n"),
+          },
+          title: "Reactive watcher",
+        }}
+        onDataChange={setData}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/scripting/App.tsx
+++ b/apps/docs/demos/proteus/scripting/App.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
+import { Box } from "@optiaxiom/react";
+import { useState } from "react";
+
+export function App() {
+  const [data, setData] = useState<Record<string, unknown>>({ tags: [] });
+
+  return (
+    <Box maxW="md" w="full">
+      <ProteusDocumentRenderer
+        data={data}
+        element={{
+          $type: "Document",
+          actions: [
+            {
+              $type: "Action",
+              appearance: "primary",
+              children: "Add tag",
+              // Triggers a named handler from the `scripts` map. The handler
+              // decides which events to emit — here it appends the input value.
+              onClick: {
+                params: { tag: { $type: "Value", path: "/tag" } },
+                script: "main:addTag",
+              },
+            },
+          ],
+          body: [
+            {
+              $type: "Field",
+              children: {
+                $type: "Input",
+                name: "tag",
+                placeholder: "Enter a tag",
+              },
+              label: "Tag",
+            },
+            {
+              $type: "Group",
+              children: {
+                $type: "Map",
+                children: {
+                  $type: "Badge",
+                  children: { $type: "Value", path: "" },
+                },
+                path: "/tags",
+              },
+              flexDirection: "row",
+              gap: "8",
+            },
+          ],
+          // Scripts run in a sandboxed Web Worker. A handler's only capability
+          // is `ctx.emit`, so it can affect the document only through the
+          // existing Proteus events.
+          scripts: {
+            main: [
+              "register('addTag', (ctx, params) => {",
+              "  const tag = params.tag;",
+              "  if (!tag) return;",
+              "  ctx.emit({ action: 'pushValue', path: '/tags', value: tag });",
+              "});",
+            ].join("\n"),
+          },
+          title: "Scripted actions",
+        }}
+        onDataChange={setData}
+      />
+    </Box>
+  );
+}

--- a/apps/docs/demos/proteus/show/App.tsx
+++ b/apps/docs/demos/proteus/show/App.tsx
@@ -32,6 +32,8 @@ export function App() {
               label: "Target by",
             },
             {
+              // Show renders `children` when the condition holds, otherwise the
+              // `else` branch — here a whole different field.
               $type: "Show",
               children: {
                 $type: "Field",
@@ -42,13 +44,7 @@ export function App() {
                 },
                 label: "URL",
               },
-              when: {
-                "==": [{ $type: "Value", path: "/target_by" }, "url"],
-              },
-            },
-            {
-              $type: "Show",
-              children: {
+              else: {
                 $type: "Field",
                 children: {
                   $type: "Select",
@@ -66,7 +62,7 @@ export function App() {
                 label: "Saved Page",
               },
               when: {
-                "==": [{ $type: "Value", path: "/target_by" }, "page"],
+                "==": [{ $type: "Value", path: "/target_by" }, "url"],
               },
             },
           ],

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -1236,6 +1236,108 @@ export const WithDataTable: Story = {
   },
 };
 
+// A change-history / diff view built entirely from the generic `DataTable`
+// element — no dedicated element needed. Each column's `cell` is a regular
+// Proteus element template; `DataTableRow` reads the current row inside it. The
+// "Change" column renders a `Badge` whose intent is chosen per row via `Show`
+// conditions on the row's `type`.
+export const WithDataTableCell: Story = {
+  args: {
+    data: {
+      changes: [
+        {
+          field: "Status",
+          newValue: "Running",
+          oldValue: "Paused",
+          type: "modified",
+        },
+        {
+          field: "Traffic Allocation",
+          newValue: "50%",
+          oldValue: "25%",
+          type: "modified",
+        },
+        {
+          field: "Description",
+          newValue: "Updated experiment for Q3 launch",
+          oldValue: "—",
+          type: "added",
+        },
+        {
+          field: "Legacy Flag",
+          newValue: "—",
+          oldValue: "enabled",
+          type: "removed",
+        },
+      ],
+    },
+    element: {
+      $type: "Document",
+      appName: "Opal",
+      body: [
+        {
+          $type: "Heading",
+          children: "Flag Configuration Changes",
+          fontSize: "md",
+          fontWeight: "600",
+          level: "3",
+          mb: "8",
+        },
+        {
+          $type: "DataTable",
+          columns: [
+            { accessorKey: "field", header: "Field", size: 150 },
+            { accessorKey: "oldValue", header: "Old", size: 110 },
+            { accessorKey: "newValue", header: "New", size: 170 },
+            {
+              accessorKey: "type",
+              cell: [
+                {
+                  $type: "Show",
+                  children: {
+                    $type: "Badge",
+                    children: { $type: "DataTableRow", path: "type" },
+                    intent: "success",
+                  },
+                  when: {
+                    "==": [{ $type: "DataTableRow", path: "type" }, "added"],
+                  },
+                },
+                {
+                  $type: "Show",
+                  children: {
+                    $type: "Badge",
+                    children: { $type: "DataTableRow", path: "type" },
+                    intent: "warning",
+                  },
+                  when: {
+                    "==": [{ $type: "DataTableRow", path: "type" }, "modified"],
+                  },
+                },
+                {
+                  $type: "Show",
+                  children: {
+                    $type: "Badge",
+                    children: { $type: "DataTableRow", path: "type" },
+                    intent: "danger",
+                  },
+                  when: {
+                    "==": [{ $type: "DataTableRow", path: "type" }, "removed"],
+                  },
+                },
+              ],
+              header: "Change",
+              size: 120,
+            },
+          ],
+          data: { $type: "Value", path: "/changes" },
+        },
+      ],
+      title: "Change History",
+    },
+  },
+};
+
 export const WithChart: Story = {
   args: {
     element: {

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -1239,8 +1239,8 @@ export const WithDataTable: Story = {
 // A change-history / diff view built entirely from the generic `DataTable`
 // element — no dedicated element needed. Each column's `cell` is a regular
 // Proteus element template; `DataTableRow` reads the current row inside it. The
-// "Change" column renders a `Badge` whose intent is chosen per row via `Show`
-// conditions on the row's `type`.
+// "Change" column is a single `Badge` whose intent is picked by a `Show`/`else`
+// chain on the row's `type`.
 export const WithDataTableCell: Story = {
   args: {
     data: {
@@ -1291,41 +1291,30 @@ export const WithDataTableCell: Story = {
             { accessorKey: "newValue", header: "New", size: 170 },
             {
               accessorKey: "type",
-              cell: [
-                {
+              // One Badge whose intent is chosen by a Show/else chain on the
+              // row's `type` — `DataTableRow` reads the current row's field.
+              cell: {
+                $type: "Badge",
+                children: { $type: "DataTableRow", path: "type" },
+                intent: {
                   $type: "Show",
-                  children: {
-                    $type: "Badge",
-                    children: { $type: "DataTableRow", path: "type" },
-                    intent: "success",
+                  children: "success",
+                  else: {
+                    $type: "Show",
+                    children: "danger",
+                    else: "warning",
+                    when: {
+                      "==": [
+                        { $type: "DataTableRow", path: "type" },
+                        "removed",
+                      ],
+                    },
                   },
                   when: {
                     "==": [{ $type: "DataTableRow", path: "type" }, "added"],
                   },
                 },
-                {
-                  $type: "Show",
-                  children: {
-                    $type: "Badge",
-                    children: { $type: "DataTableRow", path: "type" },
-                    intent: "warning",
-                  },
-                  when: {
-                    "==": [{ $type: "DataTableRow", path: "type" }, "modified"],
-                  },
-                },
-                {
-                  $type: "Show",
-                  children: {
-                    $type: "Badge",
-                    children: { $type: "DataTableRow", path: "type" },
-                    intent: "danger",
-                  },
-                  when: {
-                    "==": [{ $type: "DataTableRow", path: "type" }, "removed"],
-                  },
-                },
-              ],
+              },
               header: "Change",
               size: 120,
             },

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -130,6 +130,11 @@ const PROTEUS_COMPONENT_CONFIG = {
     },
     extends: "Fragment",
   },
+  DataTableRow: {
+    allowedProps: ["path"],
+    example: { path: "status" },
+    extends: "Fragment",
+  },
   DateInput: {
     allowedProps: ["name", "placeholder", "required", "type"],
     example: { name: "date_field", type: "date" },
@@ -502,6 +507,7 @@ function generateSpec(additionalProperties = false) {
             { type: "number" },
             { type: "boolean" },
             { type: "null" },
+            { $ref: "#/definitions/ProteusDataTableRow" },
             { $ref: "#/definitions/ProteusLength" },
             { $ref: "#/definitions/ProteusMapIndex" },
             { $ref: "#/definitions/ProteusValue" },
@@ -1011,6 +1017,7 @@ function generateSpec(additionalProperties = false) {
         },
         ProteusExpression: {
           anyOf: [
+            { $ref: "#/definitions/ProteusDataTableRow" },
             { $ref: "#/definitions/ProteusLength" },
             { $ref: "#/definitions/ProteusMap" },
             { $ref: "#/definitions/ProteusMapIndex" },
@@ -1250,6 +1257,11 @@ function getPropTypeOverrides(additionalProperties = false) {
                   description: "Key in data objects",
                   type: "string",
                 },
+                cell: {
+                  $ref: "#/definitions/ProteusNode",
+                  description:
+                    "A Proteus node template rendered for each cell in this column. Read the current row with DataTableRow (e.g. { $type: 'DataTableRow', path: 'status' } reads the row's 'status', or omit 'path' for the whole row). Can be a single element or an array — use Show elements to conditionally render (e.g. a Badge whose intent depends on the row value). When set, takes precedence over 'format'.",
+                },
                 format: {
                   anyOf: [
                     {
@@ -1296,6 +1308,13 @@ function getPropTypeOverrides(additionalProperties = false) {
           { $ref: "#/definitions/ProteusExpression" },
           { $ref: "#/definitions/ProteusZip" },
         ],
+      },
+    },
+    DataTableRow: {
+      path: {
+        description:
+          "JSON pointer path to a field within the current row (e.g. 'status' or '/status'). When omitted, resolves to the whole row object. Only meaningful inside a DataTable column's `cell`.",
+        type: "string",
       },
     },
     Federated: {

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -299,7 +299,7 @@ const PROTEUS_COMPONENT_CONFIG = {
     allowedProps: [],
   },
   Show: {
-    allowedProps: ["when", "children"],
+    allowedProps: ["when", "children", "else"],
     example: {
       children: { $type: "Text", children: "Shown conditionally" },
       when: { "!!": { $type: "Value", path: "/field_name" } },
@@ -1596,6 +1596,11 @@ function getPropTypeOverrides(additionalProperties = false) {
       children: {
         $ref: "#/definitions/ProteusNode",
         description: "Content to show when condition is true",
+      },
+      else: {
+        $ref: "#/definitions/ProteusNode",
+        description:
+          "Content to render when the condition is false. Omitting it renders nothing. Chain nested Show/else to express multi-way choices (e.g. mapping a value to one of several outputs).",
       },
       when: {
         anyOf: [

--- a/packages/proteus/src/index.ts
+++ b/packages/proteus/src/index.ts
@@ -2,6 +2,7 @@ export * from "./proteus-action";
 export * from "./proteus-bridge";
 export * from "./proteus-chart";
 export * from "./proteus-data-table";
+export * from "./proteus-data-table-row";
 export * from "./proteus-date-input";
 export * from "./proteus-document";
 export * from "./proteus-federated";

--- a/packages/proteus/src/proteus-data-table-row/ProteusDataTableRow.tsx
+++ b/packages/proteus/src/proteus-data-table-row/ProteusDataTableRow.tsx
@@ -1,0 +1,43 @@
+import { get } from "jsonpointer";
+
+import { useProteusDataTableRowContext } from "../proteus-document/ProteusDataTableRowContext";
+
+export type ProteusDataTableRowProps = {
+  /**
+   * JSON pointer path to a field within the current row (e.g. `type` or
+   * `/type`). When omitted, resolves to the whole row object.
+   */
+  path?: string;
+};
+
+export function ProteusDataTableRow({ path }: ProteusDataTableRowProps) {
+  const { row } = useProteusDataTableRowContext(
+    "@optiaxiom/proteus/ProteusDataTableRow",
+  );
+  const value = getDataTableRowValue(row, path);
+  return value == null || typeof value === "object" ? null : String(value);
+}
+
+ProteusDataTableRow.displayName = "@optiaxiom/proteus/ProteusDataTableRow";
+
+/**
+ * Reads a value out of a `DataTable` row for the `DataTableRow` element and
+ * expression. With no `path`, returns the whole row; otherwise reads the field
+ * at `path` (leading `/` optional).
+ */
+export function getDataTableRowValue(
+  row: Record<string, unknown> | undefined,
+  path?: string,
+): unknown {
+  if (!row) {
+    return undefined;
+  }
+  if (!path) {
+    return row;
+  }
+  try {
+    return get(row, path.startsWith("/") ? path : `/${path}`);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/proteus/src/proteus-data-table-row/index.ts
+++ b/packages/proteus/src/proteus-data-table-row/index.ts
@@ -1,0 +1,1 @@
+export { ProteusDataTableRow } from "./ProteusDataTableRow";

--- a/packages/proteus/src/proteus-data-table/ProteusDataTable.tsx
+++ b/packages/proteus/src/proteus-data-table/ProteusDataTable.tsx
@@ -5,6 +5,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { get } from "jsonpointer";
+import { type ReactNode } from "react";
 
 import { applyFormatter } from "../proteus-document/getProteusValue";
 
@@ -21,6 +22,12 @@ export type ProteusDataTableProps = {
 
 type ColumnDef = {
   accessorKey: string;
+  /**
+   * Renders a cell for this column from the row's data. When set, takes
+   * precedence over `format`. Wired up from a Proteus `cell` template by
+   * `ProteusElement`.
+   */
+  cell?: (row: Record<string, unknown>) => ReactNode;
   format?: string | { options?: Record<string, unknown>; type: string };
   header: string;
   size?: number;
@@ -40,6 +47,9 @@ export const ProteusDataTable = ({ columns, data }: ProteusDataTableProps) => {
         header: col.header,
         id: col.accessorKey,
         size: col.size,
+        ...(col.cell && {
+          cell: ({ row }) => col.cell?.(row.original),
+        }),
       },
     );
   });

--- a/packages/proteus/src/proteus-document/ProteusDataTableRowContext.ts
+++ b/packages/proteus/src/proteus-document/ProteusDataTableRowContext.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { createContext } from "@radix-ui/react-context";
+
+/**
+ * Holds the current `DataTable` row while a column's `cell` template renders.
+ * `DataTableRow` reads from here to give the cell pointer access to its row,
+ * the same way `MapIndex` exposes the current index inside a `Map`.
+ */
+export const [ProteusDataTableRowProvider, useProteusDataTableRowContext] =
+  createContext<{
+    row: Record<string, unknown> | undefined;
+  }>("@optiaxiom/proteus/ProteusDataTableRow", {
+    row: undefined,
+  });

--- a/packages/proteus/src/proteus-document/resolveProteusProp.tsx
+++ b/packages/proteus/src/proteus-document/resolveProteusProp.tsx
@@ -1,3 +1,4 @@
+import { getDataTableRowValue } from "../proteus-data-table-row/ProteusDataTableRow";
 import { ProteusElement } from "../proteus-element";
 import { getProteusValue } from "./getProteusValue";
 import {
@@ -10,6 +11,7 @@ export function resolveProteusProp(
   data: Record<string, unknown>,
   parentPath: string,
   mapIndices: number[] = [],
+  dataTableRow?: Record<string, unknown>,
 ): unknown {
   if (typeof value !== "object" || value === null) {
     return value;
@@ -17,6 +19,15 @@ export function resolveProteusProp(
 
   if ("$type" in value && value.$type === "MapIndex") {
     return mapIndices.at(-1);
+  }
+
+  if ("$type" in value && value.$type === "DataTableRow") {
+    return getDataTableRowValue(
+      dataTableRow,
+      "path" in value && typeof value.path === "string"
+        ? value.path
+        : undefined,
+    );
   }
 
   if (
@@ -40,7 +51,13 @@ export function resolveProteusProp(
     const resolved: Record<string, unknown[]> = {};
     let length = 0;
     for (const [k, v] of Object.entries(sources)) {
-      const arr = resolveProteusProp(v, data, parentPath, mapIndices);
+      const arr = resolveProteusProp(
+        v,
+        data,
+        parentPath,
+        mapIndices,
+        dataTableRow,
+      );
       if (Array.isArray(arr)) {
         resolved[k] = arr;
         length = Math.max(length, arr.length);
@@ -64,12 +81,24 @@ export function resolveProteusProp(
     const conditions = Array.isArray(value.when) ? value.when : [value.when];
     const shouldShow = conditions.every(
       (condition: ProteusCondition | undefined) =>
-        evaluateCondition(condition, data, parentPath, mapIndices),
+        evaluateCondition(
+          condition,
+          data,
+          parentPath,
+          mapIndices,
+          dataTableRow,
+        ),
     );
     if (!shouldShow) {
       return undefined;
     }
-    return resolveProteusProp(value.children, data, parentPath, mapIndices);
+    return resolveProteusProp(
+      value.children,
+      data,
+      parentPath,
+      mapIndices,
+      dataTableRow,
+    );
   }
 
   return "$type" in value ||

--- a/packages/proteus/src/proteus-document/resolveProteusProp.tsx
+++ b/packages/proteus/src/proteus-document/resolveProteusProp.tsx
@@ -89,11 +89,13 @@ export function resolveProteusProp(
           dataTableRow,
         ),
     );
-    if (!shouldShow) {
-      return undefined;
-    }
+    const branch = shouldShow
+      ? value.children
+      : "else" in value
+        ? value.else
+        : undefined;
     return resolveProteusProp(
-      value.children,
+      branch,
       data,
       parentPath,
       mapIndices,

--- a/packages/proteus/src/proteus-document/resolveProteusValue.tsx
+++ b/packages/proteus/src/proteus-document/resolveProteusValue.tsx
@@ -1,3 +1,4 @@
+import { getDataTableRowValue } from "../proteus-data-table-row/ProteusDataTableRow";
 import { getProteusValue } from "./getProteusValue";
 
 export type ProteusCondition =
@@ -17,6 +18,7 @@ type ComparisonValue =
   | null
   | number
   | string
+  | { $type: "DataTableRow"; path?: string }
   | { $type: "Length"; path: string }
   | { $type: "MapIndex" }
   | { $type: "Value"; path: string };
@@ -26,6 +28,7 @@ export function evaluateCondition(
   data: Record<string, unknown>,
   parentPath: string,
   mapIndices: number[] = [],
+  dataTableRow?: Record<string, unknown>,
 ): boolean {
   if (!condition) {
     return true;
@@ -33,13 +36,13 @@ export function evaluateCondition(
 
   if ("and" in condition) {
     return condition.and.every((cond) =>
-      evaluateCondition(cond, data, parentPath, mapIndices),
+      evaluateCondition(cond, data, parentPath, mapIndices, dataTableRow),
     );
   }
 
   if ("or" in condition) {
     return condition.or.some((cond) =>
-      evaluateCondition(cond, data, parentPath, mapIndices),
+      evaluateCondition(cond, data, parentPath, mapIndices, dataTableRow),
     );
   }
 
@@ -49,6 +52,7 @@ export function evaluateCondition(
       data,
       parentPath,
       mapIndices,
+      dataTableRow,
     );
     return !!value;
   }
@@ -59,6 +63,7 @@ export function evaluateCondition(
       data,
       parentPath,
       mapIndices,
+      dataTableRow,
     );
     return !value;
   }
@@ -66,19 +71,31 @@ export function evaluateCondition(
   if ("==" in condition) {
     const [left, right] = condition["=="];
     return (
-      resolveProteusValue(left, data, parentPath, mapIndices) ===
-      resolveProteusValue(right, data, parentPath, mapIndices)
+      resolveProteusValue(left, data, parentPath, mapIndices, dataTableRow) ===
+      resolveProteusValue(right, data, parentPath, mapIndices, dataTableRow)
     );
   } else if ("!=" in condition) {
     const [left, right] = condition["!="];
     return (
-      resolveProteusValue(left, data, parentPath, mapIndices) !==
-      resolveProteusValue(right, data, parentPath, mapIndices)
+      resolveProteusValue(left, data, parentPath, mapIndices, dataTableRow) !==
+      resolveProteusValue(right, data, parentPath, mapIndices, dataTableRow)
     );
   } else if ("<" in condition) {
     const [left, right] = condition["<"];
-    const leftVal = resolveProteusValue(left, data, parentPath, mapIndices);
-    const rightVal = resolveProteusValue(right, data, parentPath, mapIndices);
+    const leftVal = resolveProteusValue(
+      left,
+      data,
+      parentPath,
+      mapIndices,
+      dataTableRow,
+    );
+    const rightVal = resolveProteusValue(
+      right,
+      data,
+      parentPath,
+      mapIndices,
+      dataTableRow,
+    );
     return (
       typeof leftVal === "number" &&
       typeof rightVal === "number" &&
@@ -86,8 +103,20 @@ export function evaluateCondition(
     );
   } else if ("<=" in condition) {
     const [left, right] = condition["<="];
-    const leftVal = resolveProteusValue(left, data, parentPath, mapIndices);
-    const rightVal = resolveProteusValue(right, data, parentPath, mapIndices);
+    const leftVal = resolveProteusValue(
+      left,
+      data,
+      parentPath,
+      mapIndices,
+      dataTableRow,
+    );
+    const rightVal = resolveProteusValue(
+      right,
+      data,
+      parentPath,
+      mapIndices,
+      dataTableRow,
+    );
     return (
       typeof leftVal === "number" &&
       typeof rightVal === "number" &&
@@ -95,8 +124,20 @@ export function evaluateCondition(
     );
   } else if (">" in condition) {
     const [left, right] = condition[">"];
-    const leftVal = resolveProteusValue(left, data, parentPath, mapIndices);
-    const rightVal = resolveProteusValue(right, data, parentPath, mapIndices);
+    const leftVal = resolveProteusValue(
+      left,
+      data,
+      parentPath,
+      mapIndices,
+      dataTableRow,
+    );
+    const rightVal = resolveProteusValue(
+      right,
+      data,
+      parentPath,
+      mapIndices,
+      dataTableRow,
+    );
     return (
       typeof leftVal === "number" &&
       typeof rightVal === "number" &&
@@ -104,8 +145,20 @@ export function evaluateCondition(
     );
   } else if (">=" in condition) {
     const [left, right] = condition[">="];
-    const leftVal = resolveProteusValue(left, data, parentPath, mapIndices);
-    const rightVal = resolveProteusValue(right, data, parentPath, mapIndices);
+    const leftVal = resolveProteusValue(
+      left,
+      data,
+      parentPath,
+      mapIndices,
+      dataTableRow,
+    );
+    const rightVal = resolveProteusValue(
+      right,
+      data,
+      parentPath,
+      mapIndices,
+      dataTableRow,
+    );
     return (
       typeof leftVal === "number" &&
       typeof rightVal === "number" &&
@@ -121,6 +174,7 @@ export function resolveProteusValue(
   data: Record<string, unknown>,
   parentPath: string,
   mapIndices: number[] = [],
+  dataTableRow?: Record<string, unknown>,
 ): unknown {
   if (typeof value !== "object" || value === null) {
     return value;
@@ -129,6 +183,15 @@ export function resolveProteusValue(
   if ("$type" in value) {
     if (value.$type === "MapIndex") {
       return mapIndices.at(-1);
+    }
+
+    if (value.$type === "DataTableRow") {
+      return getDataTableRowValue(
+        dataTableRow,
+        "path" in value && typeof value.path === "string"
+          ? value.path
+          : undefined,
+      );
     }
 
     if (
@@ -176,6 +239,7 @@ export function resolveProteusValue(
             data,
             `${resolvedPath}/${index}`,
             [...mapIndices, index],
+            dataTableRow,
           ),
         )
         .filter((v: unknown) => v !== undefined);
@@ -186,6 +250,7 @@ export function resolveProteusValue(
           data,
           parentPath,
           mapIndices,
+          dataTableRow,
         );
         return result.join(typeof sep === "string" ? sep : "");
       }
@@ -196,12 +261,24 @@ export function resolveProteusValue(
       const conditions = Array.isArray(value.when) ? value.when : [value.when];
       const shouldShow = conditions.every(
         (condition: ProteusCondition | undefined) =>
-          evaluateCondition(condition, data, parentPath, mapIndices),
+          evaluateCondition(
+            condition,
+            data,
+            parentPath,
+            mapIndices,
+            dataTableRow,
+          ),
       );
       if (!shouldShow) {
         return undefined;
       }
-      return resolveProteusValue(value.children, data, parentPath, mapIndices);
+      return resolveProteusValue(
+        value.children,
+        data,
+        parentPath,
+        mapIndices,
+        dataTableRow,
+      );
     }
 
     if (value.$type === "Concat" && "children" in value) {
@@ -210,7 +287,13 @@ export function resolveProteusValue(
       }
       return value.children
         .map((child: unknown) =>
-          resolveProteusValue(child, data, parentPath, mapIndices),
+          resolveProteusValue(
+            child,
+            data,
+            parentPath,
+            mapIndices,
+            dataTableRow,
+          ),
         )
         .filter((v: unknown) => v !== undefined)
         .join("");
@@ -221,13 +304,21 @@ export function resolveProteusValue(
 
   if (Array.isArray(value)) {
     return value
-      .map((v) => resolveProteusValue(v, data, parentPath, mapIndices))
+      .map((v) =>
+        resolveProteusValue(v, data, parentPath, mapIndices, dataTableRow),
+      )
       .filter((v) => v !== undefined);
   }
 
   const resolved: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(value)) {
-    const r = resolveProteusValue(v, data, parentPath, mapIndices);
+    const r = resolveProteusValue(
+      v,
+      data,
+      parentPath,
+      mapIndices,
+      dataTableRow,
+    );
     if (r !== undefined) resolved[k] = r;
   }
   return resolved;

--- a/packages/proteus/src/proteus-document/resolveProteusValue.tsx
+++ b/packages/proteus/src/proteus-document/resolveProteusValue.tsx
@@ -269,11 +269,16 @@ export function resolveProteusValue(
             dataTableRow,
           ),
       );
-      if (!shouldShow) {
+      const branch = shouldShow
+        ? value.children
+        : "else" in value
+          ? value.else
+          : undefined;
+      if (branch === undefined) {
         return undefined;
       }
       return resolveProteusValue(
-        value.children,
+        branch,
         data,
         parentPath,
         mapIndices,

--- a/packages/proteus/src/proteus-document/schemas.ts
+++ b/packages/proteus/src/proteus-document/schemas.ts
@@ -31,6 +31,7 @@ import type { ProteusActionProps } from "../proteus-action/ProteusAction";
 import type { ProteusBridgeProps } from "../proteus-bridge/ProteusBridge";
 import type { ProteusCardLinkProps } from "../proteus-card-link/ProteusCardLink";
 import type { ProteusChartProps } from "../proteus-chart/ProteusChart";
+import type { ProteusDataTableRowProps } from "../proteus-data-table-row/ProteusDataTableRow";
 import type { ProteusDataTableProps } from "../proteus-data-table/ProteusDataTable";
 import type { ProteusFederatedProps } from "../proteus-federated/ProteusFederated";
 import type { ProteusFileIconProps } from "../proteus-file-icon/ProteusFileIcon";
@@ -74,6 +75,7 @@ export type ProteusElement =
   | (ProteusCardLinkProps & { $type: "CardLink" })
   | (ProteusChartProps & { $type: "Chart" })
   | (ProteusDataTableProps & { $type: "DataTable" })
+  | (ProteusDataTableRowProps & { $type: "DataTableRow" })
   | (ProteusFederatedProps & { $type: "Federated" })
   | (ProteusFileIconProps & { $type: "FileIcon" })
   | (ProteusFileUploadProps & { $type: "FileUpload" })

--- a/packages/proteus/src/proteus-document/useResolveProteusValues.ts
+++ b/packages/proteus/src/proteus-document/useResolveProteusValues.ts
@@ -1,3 +1,4 @@
+import { useProteusDataTableRowContext } from "./ProteusDataTableRowContext";
 import { useProteusDocumentContext } from "./ProteusDocumentContext";
 import { useProteusDocumentPathContext } from "./ProteusDocumentPathContext";
 import { resolveProteusValue } from "./resolveProteusValue";
@@ -11,10 +12,19 @@ export function useResolveProteusValues(
   const { mapIndices, path: parentPath } = useProteusDocumentPathContext(
     "@optiaxiom/react/useResolveProteusValues",
   );
+  const { row: dataTableRow } = useProteusDataTableRowContext(
+    "@optiaxiom/react/useResolveProteusValues",
+  );
 
   const resolved: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(props)) {
-    resolved[key] = resolveProteusValue(value, data, parentPath, mapIndices);
+    resolved[key] = resolveProteusValue(
+      value,
+      data,
+      parentPath,
+      mapIndices,
+      dataTableRow,
+    );
   }
   return resolved;
 }

--- a/packages/proteus/src/proteus-element/ProteusElement.tsx
+++ b/packages/proteus/src/proteus-element/ProteusElement.tsx
@@ -24,8 +24,13 @@ import { type ComponentPropsWithoutRef, lazy, Suspense } from "react";
 import { ProteusAction } from "../proteus-action/ProteusAction";
 import { ProteusBridge } from "../proteus-bridge/ProteusBridge";
 import { ProteusCardLink } from "../proteus-card-link/ProteusCardLink";
+import { ProteusDataTableRow } from "../proteus-data-table-row/ProteusDataTableRow";
 import { ProteusDataTable } from "../proteus-data-table/ProteusDataTable";
 import { ProteusDateInput } from "../proteus-date-input/ProteusDateInput";
+import {
+  ProteusDataTableRowProvider,
+  useProteusDataTableRowContext,
+} from "../proteus-document/ProteusDataTableRowContext";
 import { useProteusDocumentContext } from "../proteus-document/ProteusDocumentContext";
 import { useProteusDocumentPathContext } from "../proteus-document/ProteusDocumentPathContext";
 import { resolveProteusProp } from "../proteus-document/resolveProteusProp";
@@ -71,6 +76,9 @@ export const ProteusElement = ({
   const { mapIndices, path: parentPath } = useProteusDocumentPathContext(
     "@optiaxiom/proteus/ProteusElement",
   );
+  const { row: dataTableRow } = useProteusDataTableRowContext(
+    "@optiaxiom/proteus/ProteusElement",
+  );
   if (!elementProp) {
     return null;
   } else if (
@@ -101,7 +109,13 @@ export const ProteusElement = ({
     const { $type: _$type, ...rest } = obj;
     const resolved: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(rest)) {
-      resolved[key] = resolveProteusProp(value, data, parentPath, mapIndices);
+      resolved[key] = resolveProteusProp(
+        value,
+        data,
+        parentPath,
+        mapIndices,
+        dataTableRow,
+      );
     }
     return resolved as Omit<T, "$type">;
   };
@@ -143,14 +157,16 @@ export const ProteusElement = ({
           />
         </Suspense>
       );
-    case "DataTable":
+    case "DataTable": {
+      const { columns, ...props } = resolve(
+        element,
+      ) as ComponentPropsWithoutRef<typeof ProteusDataTable>;
       return (
-        <ProteusDataTable
-          {...(resolve(element) as ComponentPropsWithoutRef<
-            typeof ProteusDataTable
-          >)}
-        />
+        <ProteusDataTable {...props} columns={wireCellTemplates(columns)} />
       );
+    }
+    case "DataTableRow":
+      return <ProteusDataTableRow {...resolve(element)} />;
     case "DateInput":
       return <ProteusDateInput {...resolve(element)} />;
     case "Disclosure":
@@ -284,3 +300,28 @@ export const ProteusElement = ({
 };
 
 ProteusElement.displayName = "@optiaxiom/proteus/ProteusElement";
+
+/**
+ * Turns each column's raw `cell` template into a render function that renders it
+ * (via `ProteusElement`) with the row exposed through context, so `DataTableRow`
+ * can read the row. Keeps `ProteusDataTable` free of any `ProteusElement`
+ * dependency (avoids bundling the whole element graph into its chunk).
+ */
+function wireCellTemplates(
+  columns: ComponentPropsWithoutRef<typeof ProteusDataTable>["columns"],
+) {
+  return columns?.map((column) => {
+    const cell = (column as { cell?: unknown }).cell;
+    if (cell == null) {
+      return column;
+    }
+    return {
+      ...column,
+      cell: (row: Record<string, unknown>) => (
+        <ProteusDataTableRowProvider row={row}>
+          <ProteusElement element={cell} />
+        </ProteusDataTableRowProvider>
+      ),
+    };
+  });
+}

--- a/packages/proteus/src/proteus-script/useProteusScripts.ts
+++ b/packages/proteus/src/proteus-script/useProteusScripts.ts
@@ -56,6 +56,10 @@ export function useProteusScripts({
 }: UseProteusScriptsOptions) {
   const dataRef = useRef(data);
   dataRef.current = data;
+  // The data as of mount, used to seed watcher baselines — so a data change the
+  // user made before the worker finished registering its watchers still reads as
+  // an edge once the watcher subscribes (rather than being silently absorbed).
+  const initialDataRef = useRef(data);
 
   const emit = useEffectEvent(onEmit);
 
@@ -88,6 +92,39 @@ export function useProteusScripts({
     lastEval.current = watchedPaths.current.map((path) =>
       JSON.stringify(getByPointer(data, path) ?? null),
     );
+  });
+
+  /**
+   * Compare each watched path in `data` against its `lastEval` baseline and post
+   * `runWatcher` for any that changed, advancing the baseline. Shared by the
+   * data-change effect and the `watchers` message handler (so a watcher that
+   * registers after the user already changed data still catches that edge).
+   */
+  const runEdgeDetect = useEffectEvent((data: Record<string, unknown>) => {
+    const worker = workerRef.current;
+    if (!worker) {
+      return;
+    }
+    watchedPaths.current.forEach((path, watchId) => {
+      const current = getByPointer(data, path) ?? null;
+      const serialized = JSON.stringify(current);
+      const prevSerialized = lastEval.current[watchId];
+      if (serialized !== prevSerialized) {
+        lastEval.current[watchId] = serialized;
+        // Hand the watcher both sides of the edge. `previous` is parsed from the
+        // serialized baseline the edge-detector already keeps (undefined on the
+        // first change after seeding).
+        const previous =
+          prevSerialized === undefined ? undefined : JSON.parse(prevSerialized);
+        worker.postMessage({
+          current,
+          data,
+          previous,
+          type: "runWatcher",
+          watchId,
+        });
+      }
+    });
   });
 
   /** Resolve a pending run (if still pending) and clear its timeout. */
@@ -136,9 +173,12 @@ export function useProteusScripts({
           settle(msg.invokeId, msg.result);
         } else if (msg.type === "watchers") {
           watchedPaths.current = msg.paths;
-          // Seed from current data so pre-existing values are not treated as a
-          // change on mount — a watcher fires on the first edge after load.
-          seedWatchers(dataRef.current);
+          // Seed baselines from the mount-time data, then edge-detect against the
+          // current data. If nothing changed before the watcher registered this
+          // is a no-op; if the user already toggled something during the async
+          // worker handshake, that edge fires now instead of being swallowed.
+          seedWatchers(initialDataRef.current);
+          runEdgeDetect(dataRef.current);
         }
       },
     );
@@ -177,8 +217,7 @@ export function useProteusScripts({
   // Edge-detect watched paths on every data change and run the ones that
   // changed — unless the change was caused by a script's own emit.
   useEffect(() => {
-    const worker = workerRef.current;
-    if (!worker || watchedPaths.current.length === 0) {
+    if (!workerRef.current || watchedPaths.current.length === 0) {
       return;
     }
     if (emitDepth.current > 0) {
@@ -186,26 +225,7 @@ export function useProteusScripts({
       seedWatchers(data);
       return;
     }
-    watchedPaths.current.forEach((path, watchId) => {
-      const current = getByPointer(data, path) ?? null;
-      const serialized = JSON.stringify(current);
-      const prevSerialized = lastEval.current[watchId];
-      if (serialized !== prevSerialized) {
-        lastEval.current[watchId] = serialized;
-        // Hand the watcher both sides of the edge. `previous` is parsed from the
-        // serialized baseline the edge-detector already keeps (undefined on the
-        // first change after seeding).
-        const previous =
-          prevSerialized === undefined ? undefined : JSON.parse(prevSerialized);
-        worker.postMessage({
-          current,
-          data,
-          previous,
-          type: "runWatcher",
-          watchId,
-        });
-      }
-    });
+    runEdgeDetect(data);
   }, [data]);
 
   return useEffectEvent(

--- a/packages/proteus/src/proteus-show/ProteusShow.tsx
+++ b/packages/proteus/src/proteus-show/ProteusShow.tsx
@@ -11,13 +11,21 @@ import {
 export type ProteusShowProps = {
   children?: ReactNode;
   /**
+   * Content to render when the condition is false. Omitting it renders nothing.
+   */
+  else?: ReactNode;
+  /**
    * Single condition or array of conditions (AND logic). Each condition is an
    * object with one operator key.
    */
   when: ProteusCondition;
 };
 
-export function ProteusShow({ children, when }: ProteusShowProps) {
+export function ProteusShow({
+  children,
+  else: fallback,
+  when,
+}: ProteusShowProps) {
   const { data } = useProteusDocumentContext("@optiaxiom/proteus/ProteusShow");
   const { mapIndices, path: parentPath } = useProteusDocumentPathContext(
     "@optiaxiom/proteus/ProteusShow",
@@ -32,11 +40,7 @@ export function ProteusShow({ children, when }: ProteusShowProps) {
     evaluateCondition(condition, data, parentPath, mapIndices, dataTableRow),
   );
 
-  if (!shouldShow) {
-    return null;
-  }
-
-  return <>{children}</>;
+  return <>{shouldShow ? children : fallback}</>;
 }
 
 ProteusShow.displayName = "@optiaxiom/proteus/ProteusShow";

--- a/packages/proteus/src/proteus-show/ProteusShow.tsx
+++ b/packages/proteus/src/proteus-show/ProteusShow.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 
+import { useProteusDataTableRowContext } from "../proteus-document/ProteusDataTableRowContext";
 import { useProteusDocumentContext } from "../proteus-document/ProteusDocumentContext";
 import { useProteusDocumentPathContext } from "../proteus-document/ProteusDocumentPathContext";
 import {
@@ -21,11 +22,14 @@ export function ProteusShow({ children, when }: ProteusShowProps) {
   const { mapIndices, path: parentPath } = useProteusDocumentPathContext(
     "@optiaxiom/proteus/ProteusShow",
   );
+  const { row: dataTableRow } = useProteusDataTableRowContext(
+    "@optiaxiom/proteus/ProteusShow",
+  );
 
   const conditions = Array.isArray(when) ? when : [when];
   // All conditions must be true (AND logic)
   const shouldShow = conditions.every((condition) =>
-    evaluateCondition(condition, data, parentPath, mapIndices),
+    evaluateCondition(condition, data, parentPath, mapIndices, dataTableRow),
   );
 
   if (!shouldShow) {

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -4722,6 +4722,10 @@
           "$ref": "#/definitions/ProteusNode",
           "description": "Content to show when condition is true"
         },
+        "else": {
+          "$ref": "#/definitions/ProteusNode",
+          "description": "Content to render when the condition is false. Omitting it renders nothing. Chain nested Show/else to express multi-way choices (e.g. mapping a value to one of several outputs)."
+        },
         "when": {
           "anyOf": [
             { "$ref": "#/definitions/ProteusCondition" },

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -934,6 +934,7 @@
                   { "type": "number" },
                   { "type": "boolean" },
                   { "type": "null" },
+                  { "$ref": "#/definitions/ProteusDataTableRow" },
                   { "$ref": "#/definitions/ProteusLength" },
                   { "$ref": "#/definitions/ProteusMapIndex" },
                   { "$ref": "#/definitions/ProteusValue" }
@@ -958,6 +959,7 @@
                   { "type": "number" },
                   { "type": "boolean" },
                   { "type": "null" },
+                  { "$ref": "#/definitions/ProteusDataTableRow" },
                   { "$ref": "#/definitions/ProteusLength" },
                   { "$ref": "#/definitions/ProteusMapIndex" },
                   { "$ref": "#/definitions/ProteusValue" }
@@ -982,6 +984,7 @@
                   { "type": "number" },
                   { "type": "boolean" },
                   { "type": "null" },
+                  { "$ref": "#/definitions/ProteusDataTableRow" },
                   { "$ref": "#/definitions/ProteusLength" },
                   { "$ref": "#/definitions/ProteusMapIndex" },
                   { "$ref": "#/definitions/ProteusValue" }
@@ -1006,6 +1009,7 @@
                   { "type": "number" },
                   { "type": "boolean" },
                   { "type": "null" },
+                  { "$ref": "#/definitions/ProteusDataTableRow" },
                   { "$ref": "#/definitions/ProteusLength" },
                   { "$ref": "#/definitions/ProteusMapIndex" },
                   { "$ref": "#/definitions/ProteusValue" }
@@ -1030,6 +1034,7 @@
                   { "type": "number" },
                   { "type": "boolean" },
                   { "type": "null" },
+                  { "$ref": "#/definitions/ProteusDataTableRow" },
                   { "$ref": "#/definitions/ProteusLength" },
                   { "$ref": "#/definitions/ProteusMapIndex" },
                   { "$ref": "#/definitions/ProteusValue" }
@@ -1054,6 +1059,7 @@
                   { "type": "number" },
                   { "type": "boolean" },
                   { "type": "null" },
+                  { "$ref": "#/definitions/ProteusDataTableRow" },
                   { "$ref": "#/definitions/ProteusLength" },
                   { "$ref": "#/definitions/ProteusMapIndex" },
                   { "$ref": "#/definitions/ProteusValue" }
@@ -1076,6 +1082,7 @@
                 { "type": "number" },
                 { "type": "boolean" },
                 { "type": "null" },
+                { "$ref": "#/definitions/ProteusDataTableRow" },
                 { "$ref": "#/definitions/ProteusLength" },
                 { "$ref": "#/definitions/ProteusMapIndex" },
                 { "$ref": "#/definitions/ProteusValue" }
@@ -1095,6 +1102,7 @@
                 { "type": "number" },
                 { "type": "boolean" },
                 { "type": "null" },
+                { "$ref": "#/definitions/ProteusDataTableRow" },
                 { "$ref": "#/definitions/ProteusLength" },
                 { "$ref": "#/definitions/ProteusMapIndex" },
                 { "$ref": "#/definitions/ProteusValue" }
@@ -1370,6 +1378,7 @@
         { "$ref": "#/definitions/ProteusChart" },
         { "$ref": "#/definitions/ProteusConcat" },
         { "$ref": "#/definitions/ProteusDataTable" },
+        { "$ref": "#/definitions/ProteusDataTableRow" },
         { "$ref": "#/definitions/ProteusDateInput" },
         { "$ref": "#/definitions/ProteusDisclosure" },
         { "$ref": "#/definitions/ProteusDisclosureContent" },
@@ -1581,6 +1590,7 @@
     },
     "ProteusExpression": {
       "anyOf": [
+        { "$ref": "#/definitions/ProteusDataTableRow" },
         { "$ref": "#/definitions/ProteusLength" },
         { "$ref": "#/definitions/ProteusMap" },
         { "$ref": "#/definitions/ProteusMapIndex" },
@@ -2708,6 +2718,10 @@
                     "description": "Key in data objects",
                     "type": "string"
                   },
+                  "cell": {
+                    "$ref": "#/definitions/ProteusNode",
+                    "description": "A Proteus node template rendered for each cell in this column. Read the current row with DataTableRow (e.g. { $type: 'DataTableRow', path: 'status' } reads the row's 'status', or omit 'path' for the whole row). Can be a single element or an array — use Show elements to conditionally render (e.g. a Badge whose intent depends on the row value). When set, takes precedence over 'format'."
+                  },
                   "format": {
                     "anyOf": [
                       { "description": "Formatter name", "type": "string" },
@@ -2747,6 +2761,19 @@
             { "$ref": "#/definitions/ProteusExpression" },
             { "$ref": "#/definitions/ProteusZip" }
           ]
+        }
+      },
+      "required": ["$type"],
+      "type": "object"
+    },
+    "ProteusDataTableRow": {
+      "additionalProperties": false,
+      "examples": [{ "$type": "DataTableRow", "path": "status" }],
+      "properties": {
+        "$type": { "const": "DataTableRow" },
+        "path": {
+          "description": "JSON pointer path to a field within the current row (e.g. 'status' or '/status'). When omitted, resolves to the whole row object. Only meaningful inside a DataTable column's `cell`.",
+          "type": "string"
         }
       },
       "required": ["$type"],

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -4650,6 +4650,10 @@
           "$ref": "#/definitions/ProteusNode",
           "description": "Content to show when condition is true"
         },
+        "else": {
+          "$ref": "#/definitions/ProteusNode",
+          "description": "Content to render when the condition is false. Omitting it renders nothing. Chain nested Show/else to express multi-way choices (e.g. mapping a value to one of several outputs)."
+        },
         "when": {
           "anyOf": [
             { "$ref": "#/definitions/ProteusCondition" },

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -933,6 +933,7 @@
                   { "type": "number" },
                   { "type": "boolean" },
                   { "type": "null" },
+                  { "$ref": "#/definitions/ProteusDataTableRow" },
                   { "$ref": "#/definitions/ProteusLength" },
                   { "$ref": "#/definitions/ProteusMapIndex" },
                   { "$ref": "#/definitions/ProteusValue" }
@@ -956,6 +957,7 @@
                   { "type": "number" },
                   { "type": "boolean" },
                   { "type": "null" },
+                  { "$ref": "#/definitions/ProteusDataTableRow" },
                   { "$ref": "#/definitions/ProteusLength" },
                   { "$ref": "#/definitions/ProteusMapIndex" },
                   { "$ref": "#/definitions/ProteusValue" }
@@ -979,6 +981,7 @@
                   { "type": "number" },
                   { "type": "boolean" },
                   { "type": "null" },
+                  { "$ref": "#/definitions/ProteusDataTableRow" },
                   { "$ref": "#/definitions/ProteusLength" },
                   { "$ref": "#/definitions/ProteusMapIndex" },
                   { "$ref": "#/definitions/ProteusValue" }
@@ -1002,6 +1005,7 @@
                   { "type": "number" },
                   { "type": "boolean" },
                   { "type": "null" },
+                  { "$ref": "#/definitions/ProteusDataTableRow" },
                   { "$ref": "#/definitions/ProteusLength" },
                   { "$ref": "#/definitions/ProteusMapIndex" },
                   { "$ref": "#/definitions/ProteusValue" }
@@ -1025,6 +1029,7 @@
                   { "type": "number" },
                   { "type": "boolean" },
                   { "type": "null" },
+                  { "$ref": "#/definitions/ProteusDataTableRow" },
                   { "$ref": "#/definitions/ProteusLength" },
                   { "$ref": "#/definitions/ProteusMapIndex" },
                   { "$ref": "#/definitions/ProteusValue" }
@@ -1048,6 +1053,7 @@
                   { "type": "number" },
                   { "type": "boolean" },
                   { "type": "null" },
+                  { "$ref": "#/definitions/ProteusDataTableRow" },
                   { "$ref": "#/definitions/ProteusLength" },
                   { "$ref": "#/definitions/ProteusMapIndex" },
                   { "$ref": "#/definitions/ProteusValue" }
@@ -1069,6 +1075,7 @@
                 { "type": "number" },
                 { "type": "boolean" },
                 { "type": "null" },
+                { "$ref": "#/definitions/ProteusDataTableRow" },
                 { "$ref": "#/definitions/ProteusLength" },
                 { "$ref": "#/definitions/ProteusMapIndex" },
                 { "$ref": "#/definitions/ProteusValue" }
@@ -1087,6 +1094,7 @@
                 { "type": "number" },
                 { "type": "boolean" },
                 { "type": "null" },
+                { "$ref": "#/definitions/ProteusDataTableRow" },
                 { "$ref": "#/definitions/ProteusLength" },
                 { "$ref": "#/definitions/ProteusMapIndex" },
                 { "$ref": "#/definitions/ProteusValue" }
@@ -1359,6 +1367,7 @@
         { "$ref": "#/definitions/ProteusChart" },
         { "$ref": "#/definitions/ProteusConcat" },
         { "$ref": "#/definitions/ProteusDataTable" },
+        { "$ref": "#/definitions/ProteusDataTableRow" },
         { "$ref": "#/definitions/ProteusDateInput" },
         { "$ref": "#/definitions/ProteusDisclosure" },
         { "$ref": "#/definitions/ProteusDisclosureContent" },
@@ -1561,6 +1570,7 @@
     },
     "ProteusExpression": {
       "anyOf": [
+        { "$ref": "#/definitions/ProteusDataTableRow" },
         { "$ref": "#/definitions/ProteusLength" },
         { "$ref": "#/definitions/ProteusMap" },
         { "$ref": "#/definitions/ProteusMapIndex" },
@@ -2669,6 +2679,10 @@
                     "description": "Key in data objects",
                     "type": "string"
                   },
+                  "cell": {
+                    "$ref": "#/definitions/ProteusNode",
+                    "description": "A Proteus node template rendered for each cell in this column. Read the current row with DataTableRow (e.g. { $type: 'DataTableRow', path: 'status' } reads the row's 'status', or omit 'path' for the whole row). Can be a single element or an array — use Show elements to conditionally render (e.g. a Badge whose intent depends on the row value). When set, takes precedence over 'format'."
+                  },
                   "format": {
                     "anyOf": [
                       { "description": "Formatter name", "type": "string" },
@@ -2708,6 +2722,18 @@
             { "$ref": "#/definitions/ProteusExpression" },
             { "$ref": "#/definitions/ProteusZip" }
           ]
+        }
+      },
+      "required": ["$type"],
+      "type": "object"
+    },
+    "ProteusDataTableRow": {
+      "examples": [{ "$type": "DataTableRow", "path": "status" }],
+      "properties": {
+        "$type": { "const": "DataTableRow" },
+        "path": {
+          "description": "JSON pointer path to a field within the current row (e.g. 'status' or '/status'). When omitted, resolves to the whole row object. Only meaningful inside a DataTable column's `cell`.",
+          "type": "string"
         }
       },
       "required": ["$type"],


### PR DESCRIPTION
## Summary

Adds custom cell rendering to Proteus `DataTable`, plus two small general-purpose primitive additions that make it ergonomic:

- **`cell`** on a column — render a Proteus node template instead of plain text.
- **`DataTableRow`** — a new element/expression (like `MapIndex`) that reads the current row *inside* a cell: `{ $type: "DataTableRow", path: "status" }` reads a field, or omit `path` for the whole row.
- **`else`** on `Show` — renders a fallback when the condition is false. Chaining `Show`/`else` expresses a multi-way choice in a single expression.

Together these make rich table cells (badges, icons, links, conditional content) authorable in pure JSON over the generic `DataTable` — no dedicated element type needed. The change-history / diff view from [#1731](https://github.com/optimizely-axiom/optiaxiom/pull/1731) becomes a single `Badge` in a `DataTable` cell:

```jsonc
{
  "accessorKey": "type",
  "header": "Change",
  "cell": {
    "$type": "Badge",
    "children": { "$type": "DataTableRow", "path": "type" },
    "intent": {
      "$type": "Show", "when": { "==": [{ "$type": "DataTableRow", "path": "type" }, "added"] },
      "children": "success",
      "else": {
        "$type": "Show", "when": { "==": [{ "$type": "DataTableRow", "path": "type" }, "removed"] },
        "children": "danger", "else": "warning"
      }
    }
  }
}
```

## Architecture notes

- **Cell wiring lives in `ProteusElement`, not `ProteusDataTable`.** `ProteusElement` preprocesses a `DataTable`'s `columns`, turning each raw `cell` template into a render function that renders it (via `ProteusElement`) wrapped in a row-scoped context. `ProteusDataTable` stays a dumb renderer with no `ProteusElement` dependency — this keeps its bundle chunk at ~1.2 kB (an earlier approach that imported `ProteusElement` there pulled the whole element graph into the DataTable chunk) and avoids a circular import.
- Row scope is carried by a dedicated **`ProteusDataTableRowContext`**. `DataTableRow` / `else` are threaded through the value resolvers (`resolveProteusValue` / `resolveProteusProp` / `evaluateCondition`) and through `ProteusShow` + `useResolveProteusValues`, so they resolve in `Show` conditions and action params as well as when rendered directly.
- `Value` is unchanged — it still resolves against the document root. Row access is exclusively via `DataTableRow`. `Show` without an `else` is unchanged (false → nothing).

Backwards-compatible: outside a cell `dataTableRow` is `undefined` and `else` is absent, so existing documents behave exactly as before (verified against `ExploreResources` and `FormWithInputs`).

## Commits

1. **feat(proteus): add cell templates + DataTableRow to DataTable**
2. **docs(proteus): document 3.1.0 features** — scripting (`register`/`watch`), `setValue`, and the `Icon` URL fallback.
3. **feat(proteus): add else branch to Show**

## Test plan

- [x] `pnpm -F @optiaxiom/proteus build` — schema regenerated, no drift, TypeScript compiles
- [x] `tsgo --noEmit` passes for `@optiaxiom/proteus`, `storybook`, and `docs`
- [x] `ProteusDataTable.js` chunk stays ~1.2 kB (no element-graph bloat)
- [x] `WithDataTableCell` renders correctly-colored badges via `DataTableRow` + `Show`/`else`, no overflow in the 600px shell
- [x] No regression: `ExploreResources` / `FormWithInputs` (Show/Badge/Map) still render
- [ ] Review the 3.1.0 + Show `else` docs demos render in the docs app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
