### PR TITLE
docs(proteus): make message & interaction handler demos interactive

### DIFF
--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -110,7 +110,7 @@ Supported operators: `==`, `!=`, `<`, `<=`, `>`, `>=`, `!!` (truthy), `!` (falsy
 
 ### Interaction handler
 
-Sends the named interaction back to your server, where it can be handled and responded to:
+Sends the named interaction back to your server, where it can be handled and responded to. Because the handler owns the document's `data`, the response can meaningfully change what the card renders — here approving or requesting changes updates `status`, and `Show`/`Value` swap the actions for a resolved state:
 
 <Demo component="proteus/action-interaction" />
 

--- a/apps/docs/demos/proteus/action-interaction/App.tsx
+++ b/apps/docs/demos/proteus/action-interaction/App.tsx
@@ -2,26 +2,47 @@
 
 import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
 import { Box } from "@optiaxiom/react";
+import { useState } from "react";
 
 export function App() {
+  // The interaction handler owns the card's state. Each named interaction maps
+  // to a data update, and the document re-renders off that data via `Show` and
+  // `Value` — so clicking a button meaningfully changes what the card shows.
+  const [data, setData] = useState<Record<string, unknown>>({ status: "" });
+
   return (
     <Box maxW="md" w="full">
       <ProteusDocumentRenderer
+        data={data}
         element={{
           $type: "Document",
-          actions: [
-            {
+          // While the task is pending we show Approve / Request changes; once
+          // resolved (via `else`) we swap in a single Reopen action that clears
+          // the status and returns the card to its pending state.
+          actions: {
+            $type: "Show",
+            children: [
+              {
+                $type: "Action",
+                appearance: "danger",
+                children: "Request changes",
+                onClick: { interaction: "request_changes" },
+              },
+              {
+                $type: "Action",
+                appearance: "primary",
+                children: "Approve",
+                onClick: { interaction: "approve" },
+              },
+            ],
+            else: {
               $type: "Action",
-              children: "Comment",
-              onClick: { interaction: "comment_on_task" },
+              appearance: "subtle",
+              children: "Reopen",
+              onClick: { interaction: "reopen" },
             },
-            {
-              $type: "Action",
-              appearance: "primary",
-              children: "View task",
-              onClick: { interaction: "view_task" },
-            },
-          ],
+            when: { "!": { $type: "Value", path: "/status" } },
+          },
           appName: "Content Marketing Platform",
           body: [
             {
@@ -29,9 +50,38 @@ export function App() {
               children:
                 "Initial performance metrics reveal a 12% drop in user retention post-update.",
             },
+            {
+              $type: "Show",
+              children: {
+                $type: "Alert",
+                children: "Approved — the task has been moved to Done.",
+                intent: "success",
+              },
+              when: { "==": [{ $type: "Value", path: "/status" }, "approved"] },
+            },
+            {
+              $type: "Show",
+              children: {
+                $type: "Alert",
+                children: "Changes requested — sent back to the assignee.",
+                intent: "danger",
+              },
+              when: {
+                "==": [{ $type: "Value", path: "/status" }, "changes"],
+              },
+            },
           ],
           subtitle: "Android Scrum Campaign / TSK-98",
           title: "Version 2.2 Performance Optimization",
+        }}
+        onInteraction={(name) => {
+          if (name === "approve") {
+            setData({ status: "approved" });
+          } else if (name === "request_changes") {
+            setData({ status: "changes" });
+          } else if (name === "reopen") {
+            setData({ status: "" });
+          }
         }}
       />
     </Box>

--- a/apps/docs/demos/proteus/action-message/App.tsx
+++ b/apps/docs/demos/proteus/action-message/App.tsx
@@ -1,43 +1,181 @@
 "use client";
 
-import { ProteusDocumentRenderer } from "@optiaxiom/proteus";
-import { Box } from "@optiaxiom/react";
+import { IconArrowUp, IconPlus } from "@optiaxiom/icons";
+import {
+  ProteusDocumentRenderer,
+  type StructuredMessage,
+} from "@optiaxiom/proteus";
+import { Box, Button, Flex, Paper, Spinner, Text } from "@optiaxiom/react";
+import { useRef, useState } from "react";
+
+type Message = {
+  content: string;
+  role: "assistant" | "user";
+};
+
+// The message actions in the document send these strings back to the LLM. Each
+// preset user message maps to a canned assistant reply so the mock chat can
+// respond without a real backend.
+const replies: Record<string, string> = {
+  "I'd like to leave a comment on this task.":
+    "Sure — what would you like the comment to say? I'll post it to TSK-98 once you confirm.",
+  "Show me the full details for TSK-98.":
+    "TSK-98 tracks the 12% retention drop after v2.2. Root cause is a slower cold-start on Android; a fix is in review, targeted for v2.2.1.",
+};
+
+const messageToText = (message: string | StructuredMessage) =>
+  typeof message === "string"
+    ? message
+    : message.parts.map((part) => part.content).join("");
 
 export function App() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [pending, setPending] = useState(false);
+  const threadRef = useRef<HTMLDivElement | null>(null);
+
+  const onMessage = (message: string | StructuredMessage) => {
+    const text = messageToText(message);
+    setMessages((prev) => [...prev, { content: text, role: "user" }]);
+    setPending(true);
+    // A real app would stream the reply from the LLM here — we resolve a preset
+    // response after a short delay to mimic the round-trip.
+    setTimeout(() => {
+      setMessages((prev) => [
+        ...prev,
+        {
+          content:
+            replies[text] ??
+            "Got it — I'll take a look and get back to you shortly.",
+          role: "assistant",
+        },
+      ]);
+      setPending(false);
+      threadRef.current?.scrollTo({
+        behavior: "smooth",
+        top: threadRef.current.scrollHeight,
+      });
+    }, 600);
+  };
+
   return (
-    <Box maxW="md" w="full">
-      <ProteusDocumentRenderer
-        element={{
-          $type: "Document",
-          actions: [
-            {
-              $type: "Action",
-              children: "Comment",
-              onClick: {
-                message: "I'd like to leave a comment on this task.",
+    <Box
+      bg="bg.default"
+      border="1"
+      borderColor="border.secondary"
+      display="flex"
+      flexDirection="column"
+      maxW="md"
+      overflow="hidden"
+      rounded="lg"
+      w="full"
+    >
+      <Box
+        bg="bg.secondary"
+        borderB="1"
+        borderColor="border.secondary"
+        display="flex"
+        flexDirection="column"
+        p="16"
+      >
+        <Text fontWeight="600">New Chat</Text>
+        <Text color="fg.secondary" fontSize="sm">
+          How can I help you today?
+        </Text>
+      </Box>
+
+      <Flex gap="16" maxH="lg" overflow="auto" p="16" ref={threadRef}>
+        {/* The document is the assistant's opening message — the message actions
+            it declares push preset user messages into the thread below. */}
+        <ProteusDocumentRenderer
+          collapsible={false}
+          element={{
+            $type: "Document",
+            actions: [
+              {
+                $type: "Action",
+                children: "Comment",
+                onClick: {
+                  message: "I'd like to leave a comment on this task.",
+                },
               },
-            },
-            {
-              $type: "Action",
-              appearance: "primary",
-              children: "View task",
-              onClick: {
-                message: "Show me the full details for TSK-98.",
+              {
+                $type: "Action",
+                appearance: "primary",
+                children: "View task",
+                onClick: {
+                  message: "Show me the full details for TSK-98.",
+                },
               },
-            },
-          ],
-          appName: "Content Marketing Platform",
-          body: [
-            {
-              $type: "Text",
-              children:
-                "Initial performance metrics reveal a 12% drop in user retention post-update.",
-            },
-          ],
-          subtitle: "Android Scrum Campaign / TSK-98",
-          title: "Version 2.2 Performance Optimization",
-        }}
-      />
+            ],
+            appName: "Content Marketing Platform",
+            body: [
+              {
+                $type: "Text",
+                children:
+                  "Initial performance metrics reveal a 12% drop in user retention post-update.",
+              },
+            ],
+            subtitle: "Android Scrum Campaign / TSK-98",
+            title: "Version 2.2 Performance Optimization",
+          }}
+          onMessage={onMessage}
+        />
+
+        {messages.map((message, index) =>
+          message.role === "user" ? (
+            <Paper
+              alignSelf="end"
+              bg="bg.accent.subtle"
+              key={index}
+              px="16"
+              py="8"
+              w="3/4"
+            >
+              <Text fontSize="sm">{message.content}</Text>
+            </Paper>
+          ) : (
+            <Text alignSelf="start" fontSize="sm" key={index} w="3/4">
+              {message.content}
+            </Text>
+          ),
+        )}
+
+        {pending && (
+          <Flex alignSelf="start" flexDirection="row" gap="8">
+            <Spinner size="sm" />
+            <Text color="fg.tertiary" fontSize="sm">
+              Thinking…
+            </Text>
+          </Flex>
+        )}
+      </Flex>
+
+      {/* Prompt is disabled — this demo only sends the document's preset
+          messages, so there's nothing to type. */}
+      <Flex
+        borderColor="border.secondary"
+        borderT="1"
+        flexDirection="row"
+        gap="8"
+        p="12"
+      >
+        <Button aria-label="Add attachment" disabled icon={<IconPlus />} />
+        <Box
+          alignItems="center"
+          color="fg.tertiary"
+          display="flex"
+          flex="1"
+          fontSize="sm"
+        >
+          Press an action above to send a message
+        </Box>
+        <Button
+          appearance="primary"
+          aria-label="Send message"
+          disabled
+          icon={<IconArrowUp />}
+        />
+      </Flex>
     </Box>
   );
 }


### PR DESCRIPTION
## What

The Proteus guide's **Message handler** and **Interaction handler** demos previously rendered a card whose buttons fired into a no-op — nothing visibly happened, so the demos didn't show what the handlers actually do. This reworks both to be interactive.

### Message handler
A mock chat interface (the "chat" is a plain div — you can only send the document's preset messages):
- The Proteus card sits at the top of the thread; its `message` actions push a user bubble into the thread below.
- A canned assistant reply follows each preset message (short delay + spinner to mimic the round-trip).
- A disabled chat prompt at the bottom for context.

### Interaction handler
An approval flow that demonstrates the interaction handler owning the document's `data`:
- **Approve** / **Request changes** fire named interactions; the handler updates `status`.
- `Show`/`Value` swap the actions for a success/danger `Alert` once resolved.
- A **Reopen** action clears `status` and returns the card to its pending state.

The guide copy for the interaction handler was updated to explain that the handler owns `data`, so responses drive what the card renders.

## Testing
- `pnpm lint --filter=@optiaxiom/docs` (lint + typecheck) — clean.
- Drove both demos in the docs dev server: verified the message thread flow and the approve → reopen cycle.

## Changeset
None — docs-only, no published package affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
