### PR TITLE
ci: upgrade to pnpm 11 to fix release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
           cache: pnpm
           node-version-file: .node-version
 
-      - run: npm install -g npm@latest
-
       - run: pnpm install
 
       - run: pnpm exec playwright install chromium

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optiaxiom",
-  "packageManager": "pnpm@10.13.1",
+  "packageManager": "pnpm@11.12.0",
   "private": true,
   "type": "module",
   "version": "0.0.0",
@@ -49,22 +49,5 @@
     "typescript": "^5.9.3",
     "vitest": "^4.1.10",
     "wait-on": "^9.0.10"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "edgedriver",
-      "esbuild",
-      "geckodriver",
-      "msw",
-      "sharp"
-    ],
-    "overrides": {
-      "@module-federation/enhanced": "^2.7.0"
-    },
-    "patchedDependencies": {
-      "@vanilla-extract/sprinkles": "patches/@vanilla-extract__sprinkles.patch",
-      "nextra-theme-docs": "patches/nextra-theme-docs.patch",
-      "react-docgen-typescript": "patches/react-docgen-typescript.patch"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,18 @@
 packages:
   - apps/*
   - packages/*
+
+allowBuilds:
+  edgedriver: true
+  esbuild: true
+  geckodriver: true
+  msw: true
+  sharp: true
+
+overrides:
+  "@module-federation/enhanced": "^2.7.0"
+
+patchedDependencies:
+  "@vanilla-extract/sprinkles": patches/@vanilla-extract__sprinkles.patch
+  nextra-theme-docs: patches/nextra-theme-docs.patch
+  react-docgen-typescript: patches/react-docgen-typescript.patch


### PR DESCRIPTION
## Problem

The [release run](https://github.com/optimizely-axiom/optiaxiom/actions/runs/29267024296/job/86874971474) failed to publish **all 7 packages**:

```
npm error code EUNKNOWNCONFIG
npm error Unknown cli flag:
  - --git-checks
```

## Cause

`--git-checks` is a **pnpm-only** flag. pnpm 10's `publish` delegates to the npm CLI and forwards it. npm ≤11 tolerated the unknown flag (warned); **npm 12 turns it into a hard error** ([npm v12 changes](https://socket.dev/blog/npm-12)).

The release workflow's `npm install -g npm@latest` step (added for OIDC trusted publishing) pulled npm 12 — the trigger. The recent node bump to v22.23.1 set the stage.

## Fix

Upgrade to **pnpm 11**, which [publishes natively and no longer shells out to npm](https://pnpm.io/blog/releases/11.0), so `--git-checks` never reaches npm. The `npm install -g npm@latest` step is removed (npm is no longer used to publish).

- The pnpm 11 OIDC trusted-publishing regression ([#11513](https://github.com/pnpm/pnpm/issues/11513)) was fixed in [#11526](https://github.com/pnpm/pnpm/pull/11526) and is included in 11.12.0.
- pnpm 11 [drops the `pnpm` field in package.json](https://pnpm.io/settings); its settings move to `pnpm-workspace.yaml`:
  - `onlyBuiltDependencies` → `allowBuilds`
  - `overrides`, `patchedDependencies` → same shape, top-level

## Testing

Locally with pnpm 11.12.0:
- `pnpm install` — clean, no "ignored pnpm field" warning; patches + `@module-federation/enhanced@^2` override applied; lockfile unchanged (no dependency drift).
- `pnpm publish --dry-run --no-git-checks` — succeeds with **no** `EUNKNOWNCONFIG` (this is the exact call that failed in CI).

Full OIDC publish is only exercisable on `main`, but the OIDC path is confirmed fixed upstream.

No changeset — CI/infra only, no consumer-facing package change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)