### PR TITLE
feat(proteus): add row selection to DataTable

### DIFF
--- a/.changeset/proteus-datatable-row-selection.md
+++ b/.changeset/proteus-datatable-row-selection.md
@@ -2,4 +2,7 @@
 "@optiaxiom/proteus": minor
 ---
 
-Add `rowSelection` prop to the `DataTable` element. Pointing it at a data path (e.g. `"/selection"`) renders a select-all header checkbox and a per-row checkbox column, and writes the selected row objects as an array to that path so an action can read them via `Value`.
+Add checkbox support to Proteus:
+
+- Add a `Checkbox` element (a boolean form control bound to a data path via `name`, mirroring `Switch`).
+- Add a `rowSelection` prop to the `DataTable` element. Pointing it at a data path (e.g. `"/selection"`) renders a select-all header checkbox and a per-row checkbox column, and writes the selected row objects as an array to that path so an action can read them via `Value`.

--- a/.changeset/proteus-datatable-row-selection.md
+++ b/.changeset/proteus-datatable-row-selection.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": minor
+---
+
+Add `rowSelection` prop to the `DataTable` element. Pointing it at a data path (e.g. `"/selection"`) renders a select-all header checkbox and a per-row checkbox column, and writes the selected row objects as an array to that path so an action can read them via `Value`.

--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -48,9 +48,24 @@ By default a `DataTable` column renders its value as text. Give a column a `cell
 
 <Demo component="proteus/data-table-cell" />
 
+#### Row selection
+
+Give a `DataTable` a `rowSelection` prop — a JSON pointer such as `"/selection"` — to add a select-all header checkbox and a per-row checkbox column. As rows are toggled, the selected row objects are written as an array to that pointer, so an action can read them back with `Value`:
+
+```json
+{
+  "$type": "DataTable",
+  "rowSelection": "/selection",
+  "columns": [{ "accessorKey": "name", "header": "Task Name" }],
+  "data": { "$type": "Value", "path": "/tasks" }
+}
+```
+
+An action can then read the selection via `{ "$type": "Value", "path": "/selection" }` — for example to send the selected rows to an interaction, or to disable a submit button until at least one row is selected.
+
 ### Form controls
 
-Wrap inputs with `Field` to add a label. Available inputs include `Input`, `Textarea`, `Select` (composed from `SelectTrigger` and `SelectContent`), `Switch`, `Range`, and `Question` (a multi-question dynamic form).
+Wrap inputs with `Field` to add a label. Available inputs include `Input`, `Textarea`, `Select` (composed from `SelectTrigger` and `SelectContent`), `Switch`, `Checkbox`, `Range`, and `Question` (a multi-question dynamic form). `Switch` and `Checkbox` are boolean controls bound to a data path via `name`.
 
 <Demo component="proteus/form-controls" />
 
@@ -318,6 +333,10 @@ The [Proteus Designer](/guides/proteus-designer) is a visual editor for building
 #### Switch
 
 <ProteusElementRef type="Switch" />
+
+#### Checkbox
+
+<ProteusElementRef type="Checkbox" />
 
 #### Range
 

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -2969,6 +2969,170 @@ export const CreateMeetingEvent: Story = {
   },
 };
 
+// Stands in for the server handler behind the `create_tasks` interaction: takes
+// the current document data and returns the next data. Turns the selected rows
+// into created tasks (with real refs + links), appends them to `/created`,
+// removes them from the pending `/tasks`, and clears the selection.
+function createTasks(data: Record<string, unknown>): Record<string, unknown> {
+  const selection = Array.isArray(data.selection)
+    ? (data.selection as Array<Record<string, unknown>>)
+    : [];
+  const base = (data.nextRef as number) ?? 47;
+  const created = selection.map(
+    (row, index): Record<string, unknown> => ({
+      ...row,
+      ref: `TSK-${base + index}`,
+      url: `https://cmp.example.com/tasks/TSK-${base + index}`,
+    }),
+  );
+  const createdNames = new Set(created.map((row) => row.name));
+  const tasks = Array.isArray(data.tasks)
+    ? (data.tasks as Array<Record<string, unknown>>)
+    : [];
+  return {
+    ...data,
+    created: [...(Array.isArray(data.created) ? data.created : []), ...created],
+    nextRef: base + created.length,
+    selection: [],
+    tasks: tasks.filter((task) => !createdNames.has(task.name)),
+  };
+}
+
+// Action card for creating multiple tasks in one shot (CCP-17176). The input
+// table uses the `DataTable` `rowSelection` prop — pointing it at `/selection`
+// gives a select-all header checkbox + per-row checkboxes for free, and writes
+// the selected row objects there. `Create` reads `/selection` via the
+// interaction handler, appends the created tasks (with real refs + links) to
+// `/created`, and clears the selection so the user can pick and create more.
+export const CreateTasks: Story = {
+  args: {
+    element: {
+      $type: "Document",
+      // Hide the Create button once every task has been created.
+      actions: {
+        $type: "Show",
+        children: {
+          $type: "Action",
+          appearance: "primary",
+          children: "Create",
+          // Disabled until at least one row is selected.
+          disabled: {
+            $type: "Show",
+            children: true,
+            else: false,
+            when: { "!": { $type: "Value", path: "/selection/0" } },
+          },
+          onClick: { interaction: "create_tasks" },
+        },
+        when: { "!!": { $type: "Value", path: "/tasks/0" } },
+      },
+      appName: "Content Marketing Platform",
+      body: [
+        // Pending section — only while there are tasks left to create.
+        {
+          $type: "Show",
+          children: {
+            $type: "Group",
+            children: [
+              {
+                $type: "Text",
+                children:
+                  "Here are your suggested tasks. Select all you would like to create.",
+                color: "fg.secondary",
+                fontSize: "md",
+              },
+              {
+                $type: "DataTable",
+                columns: [{ accessorKey: "name", header: "Task Name" }],
+                data: { $type: "Value", path: "/tasks" },
+                rowSelection: "/selection",
+              },
+            ],
+            flexDirection: "column",
+            gap: "16",
+          },
+          when: { "!!": { $type: "Value", path: "/tasks/0" } },
+        },
+        // Output section — appears once the first batch is created and grows
+        // with each subsequent Create.
+        {
+          $type: "Show",
+          children: {
+            $type: "Group",
+            children: [
+              {
+                $type: "Badge",
+                alignSelf: "start",
+                children: [
+                  { $type: "Length", path: "/created" },
+                  " tasks created",
+                ],
+                intent: "success",
+              },
+              {
+                $type: "DataTable",
+                columns: [
+                  {
+                    accessorKey: "ref",
+                    cell: {
+                      $type: "Badge",
+                      children: { $type: "DataTableRow", path: "ref" },
+                      intent: "neutral",
+                    },
+                    header: "Ref",
+                    size: 40,
+                  },
+                  {
+                    accessorKey: "name",
+                    cell: {
+                      $type: "CardLink",
+                      children: { $type: "DataTableRow", path: "name" },
+                      href: { $type: "DataTableRow", path: "url" },
+                    },
+                    header: "Task Name",
+                  },
+                ],
+                data: { $type: "Value", path: "/created" },
+              },
+            ],
+            flexDirection: "column",
+            gap: "16",
+          },
+          when: { "!!": { $type: "Value", path: "/created/0" } },
+        },
+      ],
+      title: "Create Tasks",
+    },
+  },
+  render: function Render(args) {
+    const [data, setData] = useState<Record<string, unknown>>({
+      created: [],
+      nextRef: 47,
+      selection: [],
+      tasks: [
+        { name: "Write blog post about Q2 product updates" },
+        { name: "Schedule design review for new dashboard" },
+        { name: "Update project roadmap in Confluence" },
+        { name: "Send stakeholder comms for March release" },
+      ],
+    });
+
+    return (
+      <ProteusDocumentRenderer
+        {...args}
+        data={data}
+        onDataChange={setData}
+        onInteraction={(name): void => {
+          action(name)();
+          if (name === "create_tasks") {
+            setData(createTasks(data));
+          }
+        }}
+      />
+    );
+  },
+};
+
 export const PartialRendering: Story = {
   args: {
     element: {

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -775,6 +775,13 @@ export const AskAgentInput: Story = {
           type: "boolean",
           value: null,
         },
+        {
+          description: "Confirm you have permission to run this campaign",
+          name: "Confirm Permission",
+          required: true,
+          type: "checkbox",
+          value: null,
+        },
       ],
     },
     element: {
@@ -861,6 +868,18 @@ export const AskAgentInput: Story = {
               },
               when: {
                 "==": [{ $type: "Value", path: "type" }, "boolean"],
+              },
+            },
+            {
+              $type: "Show",
+              children: {
+                $type: "Checkbox",
+                children: { $type: "Value", path: "name" },
+                description: { $type: "Value", path: "description" },
+                name: { $type: "Value", path: "name" },
+              },
+              when: {
+                "==": [{ $type: "Value", path: "type" }, "checkbox"],
               },
             },
           ],

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -118,6 +118,10 @@ const PROTEUS_COMPONENT_CONFIG = {
     },
     extends: "Fragment",
   },
+  Checkbox: {
+    allowedProps: ["children", "description", "name", "required"],
+    example: { children: "I agree", name: "field_name" },
+  },
   Concat: {
     allowedProps: ["children"],
     extends: "Fragment",

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -123,7 +123,7 @@ const PROTEUS_COMPONENT_CONFIG = {
     extends: "Fragment",
   },
   DataTable: {
-    allowedProps: ["columns", "data"],
+    allowedProps: ["columns", "data", "rowSelection"],
     example: {
       columns: [{ accessorKey: "name", header: "Name" }],
       data: [{ name: "Alice" }],
@@ -1308,6 +1308,11 @@ function getPropTypeOverrides(additionalProperties = false) {
           { $ref: "#/definitions/ProteusExpression" },
           { $ref: "#/definitions/ProteusZip" },
         ],
+      },
+      rowSelection: {
+        description:
+          "JSON pointer where the selected rows are stored (e.g. '/selection'). When set, the table renders a select-all header checkbox and a per-row checkbox column, and writes the selected row objects as an array to this pointer so an action can read them via Value.",
+        type: "string",
       },
     },
     DataTableRow: {

--- a/packages/proteus/src/proteus-checkbox/ProteusCheckbox.tsx
+++ b/packages/proteus/src/proteus-checkbox/ProteusCheckbox.tsx
@@ -1,0 +1,31 @@
+import { Checkbox, type CheckboxProps } from "@optiaxiom/react";
+
+import { useProteusDocumentContext } from "../proteus-document/ProteusDocumentContext";
+import { useProteusDocumentPathContext } from "../proteus-document/ProteusDocumentPathContext";
+import { useProteusValue } from "../use-proteus-value";
+
+export function ProteusCheckbox(props: CheckboxProps) {
+  const { onDataChange, readOnly } = useProteusDocumentContext(
+    "@optiaxiom/proteus/ProteusCheckbox",
+  );
+  const { path: parentPath } = useProteusDocumentPathContext(
+    "@optiaxiom/proteus/ProteusCheckbox",
+  );
+
+  const dataValue = useProteusValue({ path: props.name ?? "" });
+
+  return (
+    <Checkbox
+      {...props}
+      checked={props.name ? Boolean(dataValue) : false}
+      disabled={readOnly}
+      onChange={(event) => {
+        if (props.name) {
+          onDataChange?.(`${parentPath}/${props.name}`, event.target.checked);
+        }
+      }}
+    />
+  );
+}
+
+ProteusCheckbox.displayName = "@optiaxiom/proteus/ProteusCheckbox";

--- a/packages/proteus/src/proteus-data-table/ProteusDataTable.tsx
+++ b/packages/proteus/src/proteus-data-table/ProteusDataTable.tsx
@@ -1,13 +1,22 @@
-import { DataTable, DataTableBody } from "@optiaxiom/react";
+import {
+  Cover,
+  DataTable,
+  DataTableBody,
+  DataTableCheckbox,
+} from "@optiaxiom/react";
 import {
   createColumnHelper,
   getCoreRowModel,
+  type RowSelectionState,
   useReactTable,
 } from "@tanstack/react-table";
 import { get } from "jsonpointer";
-import { type ReactNode } from "react";
+import { type ReactNode, useMemo } from "react";
 
 import { applyFormatter } from "../proteus-document/getProteusValue";
+import { useProteusDocumentContext } from "../proteus-document/ProteusDocumentContext";
+import { useProteusDocumentPathContext } from "../proteus-document/ProteusDocumentPathContext";
+import { useProteusValue } from "../use-proteus-value";
 
 export type ProteusDataTableProps = {
   /**
@@ -18,6 +27,13 @@ export type ProteusDataTableProps = {
    * Column data
    */
   data?: Record<string, unknown>[];
+  /**
+   * JSON pointer where the selected rows are stored (e.g. `/selection`). When
+   * set, the table renders a select-all header checkbox and a per-row checkbox
+   * column, and writes the selected row objects as an array to this pointer so
+   * an action can read them via `Value`.
+   */
+  rowSelection?: string;
 };
 
 type ColumnDef = {
@@ -33,32 +49,112 @@ type ColumnDef = {
   size?: number;
 };
 
-export const ProteusDataTable = ({ columns, data }: ProteusDataTableProps) => {
-  const tableData = data as Record<string, unknown>[];
+export const ProteusDataTable = ({
+  columns,
+  data,
+  rowSelection,
+}: ProteusDataTableProps) => {
+  const { onDataChange, readOnly } = useProteusDocumentContext(
+    "@optiaxiom/proteus/ProteusDataTable",
+  );
+  const { path: parentPath } = useProteusDocumentPathContext(
+    "@optiaxiom/proteus/ProteusDataTable",
+  );
+
+  const tableData = (data ?? []) as Record<string, unknown>[];
 
   const columnHelper = createColumnHelper<Record<string, unknown>>();
-  const columnDefs = (columns || []).map((col) => {
-    return columnHelper.accessor(
-      (row) => {
-        const value = get(row, "/" + col.accessorKey);
-        return col.format ? String(applyFormatter(value, col.format)) : value;
-      },
-      {
-        header: col.header,
-        id: col.accessorKey,
-        size: col.size,
-        ...(col.cell && {
-          cell: ({ row }) => col.cell?.(row.original),
-        }),
-      },
-    );
-  });
+  const columnDefs = useMemo(() => {
+    const defs = (columns || []).map((col) => {
+      return columnHelper.accessor(
+        (row) => {
+          const value = get(row, "/" + col.accessorKey);
+          return col.format ? String(applyFormatter(value, col.format)) : value;
+        },
+        {
+          header: col.header,
+          id: col.accessorKey,
+          size: col.size,
+          ...(col.cell && {
+            cell: ({ row }) => col.cell?.(row.original),
+          }),
+        },
+      );
+    });
+
+    if (rowSelection === undefined) {
+      return defs;
+    }
+
+    return [
+      columnHelper.display({
+        cell: () => (
+          <Cover asChild>
+            <DataTableCheckbox disabled={readOnly} />
+          </Cover>
+        ),
+        header: () => (
+          <Cover asChild>
+            <DataTableCheckbox disabled={readOnly} />
+          </Cover>
+        ),
+        id: "select",
+        size: 20,
+      }),
+      ...defs,
+    ];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [columns, rowSelection, readOnly]);
+
+  // Bridge the stored array of selected rows to/from TanStack's index-keyed
+  // `rowSelection` state.
+  const selectedRows = useProteusValue({ path: rowSelection ?? "" });
+  const selectedSerialized = JSON.stringify(
+    Array.isArray(selectedRows) ? selectedRows : [],
+  );
+  const rowSelectionState = useMemo<RowSelectionState>(() => {
+    if (rowSelection === undefined) {
+      return {};
+    }
+    const selected = JSON.parse(selectedSerialized) as Record<
+      string,
+      unknown
+    >[];
+    const selectedKeys = new Set(selected.map((row) => JSON.stringify(row)));
+    const state: RowSelectionState = {};
+    tableData.forEach((row, index) => {
+      if (selectedKeys.has(JSON.stringify(row))) {
+        state[index] = true;
+      }
+    });
+    return state;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rowSelection, selectedSerialized, JSON.stringify(tableData)]);
+
+  const resolvedSelectionPath =
+    rowSelection === undefined
+      ? undefined
+      : rowSelection.startsWith("/")
+        ? rowSelection
+        : `${parentPath}/${rowSelection}`;
 
   const table = useReactTable({
     columns: columnDefs,
     data: tableData,
+    enableRowSelection: rowSelection !== undefined && !readOnly,
     enableSorting: false,
     getCoreRowModel: getCoreRowModel(),
+    ...(rowSelection !== undefined && {
+      onRowSelectionChange: (updater) => {
+        const next =
+          typeof updater === "function" ? updater(rowSelectionState) : updater;
+        const rows = tableData.filter((_, index) => next[index]);
+        if (resolvedSelectionPath) {
+          onDataChange?.(resolvedSelectionPath, rows);
+        }
+      },
+      state: { rowSelection: rowSelectionState },
+    }),
   });
 
   return (

--- a/packages/proteus/src/proteus-data-table/ProteusDataTable.tsx
+++ b/packages/proteus/src/proteus-data-table/ProteusDataTable.tsx
@@ -3,6 +3,7 @@ import {
   DataTable,
   DataTableBody,
   DataTableCheckbox,
+  DataTableLabel,
 } from "@optiaxiom/react";
 import {
   createColumnHelper,
@@ -65,7 +66,17 @@ export const ProteusDataTable = ({
 
   const columnHelper = createColumnHelper<Record<string, unknown>>();
   const columnDefs = useMemo(() => {
-    const defs = (columns || []).map((col) => {
+    const selectable = rowSelection !== undefined;
+    const defs = (columns || []).map((col, index) => {
+      // When the table is selectable, wrap the first column's content in
+      // `DataTableLabel` so each row checkbox has an accessible name (the
+      // checkbox references the label via `aria-labelledby`).
+      const withLabel = (content: ReactNode) =>
+        selectable && index === 0 ? (
+          <DataTableLabel>{content}</DataTableLabel>
+        ) : (
+          content
+        );
       return columnHelper.accessor(
         (row) => {
           const value = get(row, "/" + col.accessorKey);
@@ -75,14 +86,17 @@ export const ProteusDataTable = ({
           header: col.header,
           id: col.accessorKey,
           size: col.size,
-          ...(col.cell && {
-            cell: ({ row }) => col.cell?.(row.original),
+          ...((col.cell || (selectable && index === 0)) && {
+            cell: ({ getValue, row }) =>
+              withLabel(
+                col.cell ? col.cell(row.original) : (getValue() as ReactNode),
+              ),
           }),
         },
       );
     });
 
-    if (rowSelection === undefined) {
+    if (!selectable) {
       return defs;
     }
 

--- a/packages/proteus/src/proteus-document/schemas.ts
+++ b/packages/proteus/src/proteus-document/schemas.ts
@@ -6,6 +6,7 @@ import type {
   BoxProps,
   CardHeaderProps,
   CardProps,
+  CheckboxProps,
   DateInputProps,
   DisclosureContentProps,
   DisclosureProps,
@@ -60,6 +61,7 @@ export type ProteusElement =
   | (BoxProps & { $type: "Icon"; filled?: boolean; name: string })
   | (CardHeaderProps & { $type: "CardHeader" })
   | (CardProps & { $type: "Card" })
+  | (CheckboxProps & { $type: "Checkbox" })
   | (DateInputProps & { $type: "DateInput" })
   | (DisclosureContentProps & { $type: "DisclosureContent" })
   | (DisclosureProps & { $type: "Disclosure" })

--- a/packages/proteus/src/proteus-element/ProteusElement.tsx
+++ b/packages/proteus/src/proteus-element/ProteusElement.tsx
@@ -24,6 +24,7 @@ import { type ComponentPropsWithoutRef, lazy, Suspense } from "react";
 import { ProteusAction } from "../proteus-action/ProteusAction";
 import { ProteusBridge } from "../proteus-bridge/ProteusBridge";
 import { ProteusCardLink } from "../proteus-card-link/ProteusCardLink";
+import { ProteusCheckbox } from "../proteus-checkbox/ProteusCheckbox";
 import { ProteusDataTableRow } from "../proteus-data-table-row/ProteusDataTableRow";
 import { ProteusDataTable } from "../proteus-data-table/ProteusDataTable";
 import { ProteusDateInput } from "../proteus-date-input/ProteusDateInput";
@@ -157,6 +158,8 @@ export const ProteusElement = ({
           />
         </Suspense>
       );
+    case "Checkbox":
+      return <ProteusCheckbox {...resolve(element)} />;
     case "DataTable": {
       const { columns, ...props } = resolve(
         element,

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -2761,6 +2761,10 @@
             { "$ref": "#/definitions/ProteusExpression" },
             { "$ref": "#/definitions/ProteusZip" }
           ]
+        },
+        "rowSelection": {
+          "description": "JSON pointer where the selected rows are stored (e.g. '/selection'). When set, the table renders a select-all header checkbox and a per-row checkbox column, and writes the selected row objects as an array to this pointer so an action can read them via Value.",
+          "type": "string"
         }
       },
       "required": ["$type"],

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -1376,6 +1376,7 @@
         { "$ref": "#/definitions/ProteusCardHeader" },
         { "$ref": "#/definitions/ProteusCardLink" },
         { "$ref": "#/definitions/ProteusChart" },
+        { "$ref": "#/definitions/ProteusCheckbox" },
         { "$ref": "#/definitions/ProteusConcat" },
         { "$ref": "#/definitions/ProteusDataTable" },
         { "$ref": "#/definitions/ProteusDataTableRow" },
@@ -2674,6 +2675,100 @@
           "description": "Key in data records for x-axis labels",
           "type": "string"
         }
+      },
+      "required": ["$type"],
+      "type": "object"
+    },
+    "ProteusCheckbox": {
+      "additionalProperties": false,
+      "examples": [
+        { "$type": "Checkbox", "children": "I agree", "name": "field_name" }
+      ],
+      "properties": {
+        "$type": { "const": "Checkbox" },
+        "alignItems": { "$ref": "#/definitions/SprinkleProp_alignItems" },
+        "alignSelf": { "$ref": "#/definitions/SprinkleProp_alignSelf" },
+        "animation": { "$ref": "#/definitions/SprinkleProp_animation" },
+        "backgroundImage": {
+          "$ref": "#/definitions/SprinkleProp_backgroundImage"
+        },
+        "bg": { "$ref": "#/definitions/SprinkleProp_bg" },
+        "border": { "$ref": "#/definitions/SprinkleProp_border" },
+        "borderB": { "$ref": "#/definitions/SprinkleProp_borderB" },
+        "borderColor": { "$ref": "#/definitions/SprinkleProp_borderColor" },
+        "borderL": { "$ref": "#/definitions/SprinkleProp_borderL" },
+        "borderR": { "$ref": "#/definitions/SprinkleProp_borderR" },
+        "borderT": { "$ref": "#/definitions/SprinkleProp_borderT" },
+        "children": { "$ref": "#/definitions/ProteusNode" },
+        "color": { "$ref": "#/definitions/SprinkleProp_color" },
+        "cursor": { "$ref": "#/definitions/SprinkleProp_cursor" },
+        "description": {
+          "$ref": "#/definitions/ProteusNode",
+          "description": "Add secondary text after the label."
+        },
+        "display": { "$ref": "#/definitions/SprinkleProp_display" },
+        "flex": { "$ref": "#/definitions/SprinkleProp_flex" },
+        "flexDirection": { "$ref": "#/definitions/SprinkleProp_flexDirection" },
+        "flexWrap": { "$ref": "#/definitions/SprinkleProp_flexWrap" },
+        "fontFamily": { "$ref": "#/definitions/SprinkleProp_fontFamily" },
+        "fontSize": { "$ref": "#/definitions/SprinkleProp_fontSize" },
+        "fontWeight": { "$ref": "#/definitions/SprinkleProp_fontWeight" },
+        "gap": { "$ref": "#/definitions/SprinkleProp_gap" },
+        "gridAutoRows": { "$ref": "#/definitions/SprinkleProp_gridAutoRows" },
+        "gridColumn": { "$ref": "#/definitions/SprinkleProp_gridColumn" },
+        "gridTemplateColumns": {
+          "$ref": "#/definitions/SprinkleProp_gridTemplateColumns"
+        },
+        "h": { "$ref": "#/definitions/SprinkleProp_h" },
+        "justifyContent": {
+          "$ref": "#/definitions/SprinkleProp_justifyContent"
+        },
+        "justifyItems": { "$ref": "#/definitions/SprinkleProp_justifyItems" },
+        "m": { "$ref": "#/definitions/SprinkleProp_m" },
+        "maxH": { "$ref": "#/definitions/SprinkleProp_maxH" },
+        "maxW": { "$ref": "#/definitions/SprinkleProp_maxW" },
+        "mb": { "$ref": "#/definitions/SprinkleProp_mb" },
+        "ml": { "$ref": "#/definitions/SprinkleProp_ml" },
+        "mr": { "$ref": "#/definitions/SprinkleProp_mr" },
+        "mt": { "$ref": "#/definitions/SprinkleProp_mt" },
+        "mx": { "$ref": "#/definitions/SprinkleProp_mx" },
+        "my": { "$ref": "#/definitions/SprinkleProp_my" },
+        "name": {
+          "anyOf": [
+            { "type": "string" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "The name of the form control element."
+        },
+        "objectFit": { "$ref": "#/definitions/SprinkleProp_objectFit" },
+        "overflow": { "$ref": "#/definitions/SprinkleProp_overflow" },
+        "overflowX": { "$ref": "#/definitions/SprinkleProp_overflowX" },
+        "overflowY": { "$ref": "#/definitions/SprinkleProp_overflowY" },
+        "p": { "$ref": "#/definitions/SprinkleProp_p" },
+        "pb": { "$ref": "#/definitions/SprinkleProp_pb" },
+        "pl": { "$ref": "#/definitions/SprinkleProp_pl" },
+        "placeItems": { "$ref": "#/definitions/SprinkleProp_placeItems" },
+        "pointerEvents": { "$ref": "#/definitions/SprinkleProp_pointerEvents" },
+        "pr": { "$ref": "#/definitions/SprinkleProp_pr" },
+        "pt": { "$ref": "#/definitions/SprinkleProp_pt" },
+        "px": { "$ref": "#/definitions/SprinkleProp_px" },
+        "py": { "$ref": "#/definitions/SprinkleProp_py" },
+        "required": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "Whether selecting this input is required."
+        },
+        "rounded": { "$ref": "#/definitions/SprinkleProp_rounded" },
+        "shadow": { "$ref": "#/definitions/SprinkleProp_shadow" },
+        "size": { "$ref": "#/definitions/SprinkleProp_size" },
+        "textAlign": { "$ref": "#/definitions/SprinkleProp_textAlign" },
+        "textTransform": { "$ref": "#/definitions/SprinkleProp_textTransform" },
+        "transition": { "$ref": "#/definitions/SprinkleProp_transition" },
+        "w": { "$ref": "#/definitions/SprinkleProp_w" },
+        "whiteSpace": { "$ref": "#/definitions/SprinkleProp_whiteSpace" },
+        "z": { "$ref": "#/definitions/SprinkleProp_z" }
       },
       "required": ["$type"],
       "type": "object"

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -2722,6 +2722,10 @@
             { "$ref": "#/definitions/ProteusExpression" },
             { "$ref": "#/definitions/ProteusZip" }
           ]
+        },
+        "rowSelection": {
+          "description": "JSON pointer where the selected rows are stored (e.g. '/selection'). When set, the table renders a select-all header checkbox and a per-row checkbox column, and writes the selected row objects as an array to this pointer so an action can read them via Value.",
+          "type": "string"
         }
       },
       "required": ["$type"],

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -1365,6 +1365,7 @@
         { "$ref": "#/definitions/ProteusCardHeader" },
         { "$ref": "#/definitions/ProteusCardLink" },
         { "$ref": "#/definitions/ProteusChart" },
+        { "$ref": "#/definitions/ProteusCheckbox" },
         { "$ref": "#/definitions/ProteusConcat" },
         { "$ref": "#/definitions/ProteusDataTable" },
         { "$ref": "#/definitions/ProteusDataTableRow" },
@@ -2638,6 +2639,99 @@
           "description": "Key in data records for x-axis labels",
           "type": "string"
         }
+      },
+      "required": ["$type"],
+      "type": "object"
+    },
+    "ProteusCheckbox": {
+      "examples": [
+        { "$type": "Checkbox", "children": "I agree", "name": "field_name" }
+      ],
+      "properties": {
+        "$type": { "const": "Checkbox" },
+        "alignItems": { "$ref": "#/definitions/SprinkleProp_alignItems" },
+        "alignSelf": { "$ref": "#/definitions/SprinkleProp_alignSelf" },
+        "animation": { "$ref": "#/definitions/SprinkleProp_animation" },
+        "backgroundImage": {
+          "$ref": "#/definitions/SprinkleProp_backgroundImage"
+        },
+        "bg": { "$ref": "#/definitions/SprinkleProp_bg" },
+        "border": { "$ref": "#/definitions/SprinkleProp_border" },
+        "borderB": { "$ref": "#/definitions/SprinkleProp_borderB" },
+        "borderColor": { "$ref": "#/definitions/SprinkleProp_borderColor" },
+        "borderL": { "$ref": "#/definitions/SprinkleProp_borderL" },
+        "borderR": { "$ref": "#/definitions/SprinkleProp_borderR" },
+        "borderT": { "$ref": "#/definitions/SprinkleProp_borderT" },
+        "children": { "$ref": "#/definitions/ProteusNode" },
+        "color": { "$ref": "#/definitions/SprinkleProp_color" },
+        "cursor": { "$ref": "#/definitions/SprinkleProp_cursor" },
+        "description": {
+          "$ref": "#/definitions/ProteusNode",
+          "description": "Add secondary text after the label."
+        },
+        "display": { "$ref": "#/definitions/SprinkleProp_display" },
+        "flex": { "$ref": "#/definitions/SprinkleProp_flex" },
+        "flexDirection": { "$ref": "#/definitions/SprinkleProp_flexDirection" },
+        "flexWrap": { "$ref": "#/definitions/SprinkleProp_flexWrap" },
+        "fontFamily": { "$ref": "#/definitions/SprinkleProp_fontFamily" },
+        "fontSize": { "$ref": "#/definitions/SprinkleProp_fontSize" },
+        "fontWeight": { "$ref": "#/definitions/SprinkleProp_fontWeight" },
+        "gap": { "$ref": "#/definitions/SprinkleProp_gap" },
+        "gridAutoRows": { "$ref": "#/definitions/SprinkleProp_gridAutoRows" },
+        "gridColumn": { "$ref": "#/definitions/SprinkleProp_gridColumn" },
+        "gridTemplateColumns": {
+          "$ref": "#/definitions/SprinkleProp_gridTemplateColumns"
+        },
+        "h": { "$ref": "#/definitions/SprinkleProp_h" },
+        "justifyContent": {
+          "$ref": "#/definitions/SprinkleProp_justifyContent"
+        },
+        "justifyItems": { "$ref": "#/definitions/SprinkleProp_justifyItems" },
+        "m": { "$ref": "#/definitions/SprinkleProp_m" },
+        "maxH": { "$ref": "#/definitions/SprinkleProp_maxH" },
+        "maxW": { "$ref": "#/definitions/SprinkleProp_maxW" },
+        "mb": { "$ref": "#/definitions/SprinkleProp_mb" },
+        "ml": { "$ref": "#/definitions/SprinkleProp_ml" },
+        "mr": { "$ref": "#/definitions/SprinkleProp_mr" },
+        "mt": { "$ref": "#/definitions/SprinkleProp_mt" },
+        "mx": { "$ref": "#/definitions/SprinkleProp_mx" },
+        "my": { "$ref": "#/definitions/SprinkleProp_my" },
+        "name": {
+          "anyOf": [
+            { "type": "string" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "The name of the form control element."
+        },
+        "objectFit": { "$ref": "#/definitions/SprinkleProp_objectFit" },
+        "overflow": { "$ref": "#/definitions/SprinkleProp_overflow" },
+        "overflowX": { "$ref": "#/definitions/SprinkleProp_overflowX" },
+        "overflowY": { "$ref": "#/definitions/SprinkleProp_overflowY" },
+        "p": { "$ref": "#/definitions/SprinkleProp_p" },
+        "pb": { "$ref": "#/definitions/SprinkleProp_pb" },
+        "pl": { "$ref": "#/definitions/SprinkleProp_pl" },
+        "placeItems": { "$ref": "#/definitions/SprinkleProp_placeItems" },
+        "pointerEvents": { "$ref": "#/definitions/SprinkleProp_pointerEvents" },
+        "pr": { "$ref": "#/definitions/SprinkleProp_pr" },
+        "pt": { "$ref": "#/definitions/SprinkleProp_pt" },
+        "px": { "$ref": "#/definitions/SprinkleProp_px" },
+        "py": { "$ref": "#/definitions/SprinkleProp_py" },
+        "required": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "$ref": "#/definitions/ProteusExpression" }
+          ],
+          "description": "Whether selecting this input is required."
+        },
+        "rounded": { "$ref": "#/definitions/SprinkleProp_rounded" },
+        "shadow": { "$ref": "#/definitions/SprinkleProp_shadow" },
+        "size": { "$ref": "#/definitions/SprinkleProp_size" },
+        "textAlign": { "$ref": "#/definitions/SprinkleProp_textAlign" },
+        "textTransform": { "$ref": "#/definitions/SprinkleProp_textTransform" },
+        "transition": { "$ref": "#/definitions/SprinkleProp_transition" },
+        "w": { "$ref": "#/definitions/SprinkleProp_w" },
+        "whiteSpace": { "$ref": "#/definitions/SprinkleProp_whiteSpace" },
+        "z": { "$ref": "#/definitions/SprinkleProp_z" }
       },
       "required": ["$type"],
       "type": "object"


### PR DESCRIPTION
## What

Adds a `rowSelection` prop to the Proteus `DataTable` element. Pointing it at a data path (e.g. `"/selection"`) renders a **select-all header checkbox** and a **per-row checkbox column**, and writes the selected row objects as an array to that path so an action can read them via `Value`.

Nothing new was needed in `@optiaxiom/react` — this reuses the existing `Checkbox` / `DataTableCheckbox` (select-all + indeterminate, TanStack-wired), the same recipe as the `data-table/row-selection-usage` demo. `DataTable` injects the select column, enables row selection, and bridges TanStack's index-keyed state to/from the array of selected row objects via `onDataChange` / `useProteusValue`.

```jsonc
{
  "$type": "DataTable",
  "rowSelection": "/selection",
  "columns": [{ "accessorKey": "name", "header": "Task Name" }],
  "data": { "$type": "Value", "path": "/tasks" }
}
// an action then reads { "$type": "Value", "path": "/selection" }
```

Implements the action-card pattern from [CCP-17176](https://optimizely-ext.atlassian.net/browse/CCP-17176).

## Story

Adds a `CreateTasks` story to `ProteusDocumentRenderer.stories.tsx`: pick suggested tasks, click **Create**, and the created tasks (with `TSK-XX` refs + links) move to the output table and out of the pending table; the "N tasks created" badge updates. Repeatable until the pending table is empty, at which point it and the Create button hide.

## Changes

- `packages/proteus/src/proteus-data-table/ProteusDataTable.tsx` — `rowSelection` prop + checkbox column + data bridge
- `packages/proteus/plugins/rollup-plugin-generate-schema.mjs` — `rowSelection` in `DataTable` allowedProps + schema override
- `packages/proteus/src/schema/{public,runtime}-schema.json` — regenerated
- `apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx` — `CreateTasks` story
- Changeset: `@optiaxiom/proteus` minor. MCP `data.json` unaffected (proteus-only), so no mcp changeset.

## Verification

- Verified end-to-end in Storybook: select-all cycles none → indeterminate → all; per-row toggles update `/selection`; Create disabled with 0 selected; created rows move to output and out of pending; refs increment across batches; empty pending hides the table + button.
- `pnpm lint` clean; proteus schema regenerated (git-diff clean after commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also: `Checkbox` element (second commit)

Adds a standalone `Checkbox` element mirroring `Switch` — a boolean form control bound to a data path via `name`. Demonstrated in the `AskAgentInput` story via a new `checkbox`-typed parameter.

```jsonc
{ "$type": "Checkbox", "name": "agree", "children": "I agree" }
```
