### PR TITLE
feat(proteus): add requestModal action variant + onRequestModal handler

### DIFF
--- a/.changeset/proteus-request-modal-action.md
+++ b/.changeset/proteus-request-modal-action.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": minor
+---
+
+Added a `requestModal` client-side `Action.onClick` variant and matching `onRequestModal({ resource, params })` handler on `ProteusDocumentShell` / `ProteusDocumentRenderer` so hosts can open a modal rendering a named `ui://...` resource.

--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -147,6 +147,27 @@ Actions can also edit form data directly, without a round-trip to your server. `
 
 <Demo component="proteus/action-set-value" />
 
+### Modal handler
+
+Opens a modal on the host that renders a named UI resource of the same tool provider — useful when a compact card should link to a fuller detail view of the same data. Fire `{ action: "requestModal", resource, params }` from any `onClick`: `resource` is a bare `ui://...` URI, and `params` is an opaque render-context object that becomes the modal's `data`. Values inside `params` are resolved through the usual expression pipeline before dispatch, so `Value` bindings resolve against the current card's data.
+
+```json
+{
+  "$type": "Action",
+  "appearance": "primary",
+  "children": "Open results",
+  "onClick": {
+    "action": "requestModal",
+    "resource": "ui://experiment-results",
+    "params": {
+      "experimentId": { "$type": "Value", "path": "/experimentId" }
+    }
+  }
+}
+```
+
+The host wires this via the `onRequestModal({ resource, params })` prop on `ProteusDocumentRenderer` — the library is agnostic about how the modal itself is rendered. Federated remotes can also fire the event by calling `onEvent({ action: "requestModal", ... })` directly.
+
 ## Scripting
 
 ### Scripts

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -19,6 +19,7 @@ export default {
     onInteraction: action("onInteraction"),
     onMessage: action("onMessage"),
     onPreview: action("onPreview"),
+    onRequestModal: action("onRequestModal"),
     strict: true,
   },
   component: ProteusDocumentRenderer,
@@ -342,6 +343,58 @@ export const WithExternalLink: Story = {
       ],
       title:
         "Version 2.2 Performance Optimization | StellarEdge Outdoor Equipment",
+    },
+  },
+};
+
+export const WithRequestModal: Story = {
+  args: {
+    data: {
+      experimentId: "exp_9d21",
+      experimentName: "Checkout Flow V2",
+    },
+    element: {
+      $type: "Document",
+      actions: [
+        {
+          $type: "Action",
+          appearance: "primary",
+          children: "Open results",
+          onClick: {
+            action: "requestModal",
+            params: {
+              experimentId: { $type: "Value", path: "/experimentId" },
+              range: "last_30_days",
+            },
+            resource: "ui://experiment-results",
+          },
+        },
+      ],
+      appName: "Experiments",
+      body: [
+        {
+          $type: "Group",
+          children: [
+            {
+              $type: "Heading",
+              children: {
+                $type: "Value",
+                path: "/experimentName",
+              },
+              level: "3",
+            },
+            {
+              $type: "Text",
+              children:
+                "Click below to open the detailed results view. The host receives `{ resource, params }` via `onRequestModal` — check the Actions panel.",
+            },
+          ],
+          flexDirection: "column",
+          gap: "8",
+          p: "16",
+        },
+      ],
+      title: "Experiment Summary",
     },
   },
 };

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -957,6 +957,31 @@ function generateSpec(additionalProperties = false) {
             {
               ...(additionalProperties ? {} : { additionalProperties: false }),
               description:
+                "Client-side component action - opens a canvas-style modal on the host that renders a named UI resource of the same tool provider. The host derives the fetch URL from the current card's resource URL; `params` is the render data context passed to the resource template (not forwarded to the provider).",
+              properties: {
+                action: {
+                  const: "requestModal",
+                  description: "The action type",
+                  type: "string",
+                },
+                params: {
+                  additionalProperties: {},
+                  description:
+                    "Render data context passed to the resource template (opaque to the provider).",
+                  type: "object",
+                },
+                resource: {
+                  description:
+                    "Bare `ui://...` URI of a named resource of the same tool provider.",
+                  type: "string",
+                },
+              },
+              required: ["action", "resource"],
+              type: "object",
+            },
+            {
+              ...(additionalProperties ? {} : { additionalProperties: false }),
+              description:
                 "Runtime data operation - appends `value` to the array at `path` in form data. Path resolves like `Value` (absolute `/x`, relative to current parentPath, or `''` for parentPath itself).",
               properties: {
                 action: {

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -95,6 +95,24 @@ export type ProteusDocumentShellProps = {
    */
   onPreview?: (file: ProteusPreviewFile) => Promise<void> | void;
   /**
+   * Callback when a card action fires `{ action: "requestModal" }`. The host
+   * opens a canvas-style modal that renders the named `resource` (a bare
+   * `ui://...` URI of the same tool provider) with `params` as the render
+   * data context. `params` is opaque to the provider — it is used only on
+   * the client to render the resource template.
+   */
+  onRequestModal?: (payload: {
+    /**
+     * Render data context passed to the resource template. Values are already
+     * resolved through the usual ProteusExpression pipeline before dispatch.
+     */
+    params?: Record<string, unknown>;
+    /**
+     * Bare `ui://...` URI of a named resource of the same tool provider.
+     */
+    resource: string;
+  }) => Promise<void> | void;
+  /**
    * Callback when an analytics event is fired
    */
   onTrack?: (event: string, properties: Record<string, string>) => void;
@@ -158,6 +176,7 @@ export function ProteusDocumentShell({
   onMessage,
   onOpenChange,
   onPreview,
+  onRequestModal,
   onTrack,
   onUpload,
   open: openProp,
@@ -249,6 +268,11 @@ export function ProteusDocumentShell({
       }
     } else if (event.action === "preview") {
       await onPreview?.(event.file);
+    } else if (event.action === "requestModal") {
+      await onRequestModal?.({
+        params: event.params,
+        resource: event.resource,
+      });
     } else if (event.action === "pushValue") {
       // `path` arrives already resolved to an absolute pointer by the
       // firing component (which owns the positional Map context).

--- a/packages/proteus/src/proteus-document/schemas.ts
+++ b/packages/proteus/src/proteus-document/schemas.ts
@@ -125,6 +125,11 @@ export type ProteusEventHandler =
       path: string;
     }
   | {
+      action: "requestModal";
+      params?: Record<string, unknown>;
+      resource: string;
+    }
+  | {
       action: "setValue";
       path: string;
       value?: unknown;

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -1531,6 +1531,28 @@
         },
         {
           "additionalProperties": false,
+          "description": "Client-side component action - opens a canvas-style modal on the host that renders a named UI resource of the same tool provider. The host derives the fetch URL from the current card's resource URL; `params` is the render data context passed to the resource template (not forwarded to the provider).",
+          "properties": {
+            "action": {
+              "const": "requestModal",
+              "description": "The action type",
+              "type": "string"
+            },
+            "params": {
+              "additionalProperties": {},
+              "description": "Render data context passed to the resource template (opaque to the provider).",
+              "type": "object"
+            },
+            "resource": {
+              "description": "Bare `ui://...` URI of a named resource of the same tool provider.",
+              "type": "string"
+            }
+          },
+          "required": ["action", "resource"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
           "description": "Runtime data operation - appends `value` to the array at `path` in form data. Path resolves like `Value` (absolute `/x`, relative to current parentPath, or `''` for parentPath itself).",
           "properties": {
             "action": {

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -1513,6 +1513,27 @@
           "type": "object"
         },
         {
+          "description": "Client-side component action - opens a canvas-style modal on the host that renders a named UI resource of the same tool provider. The host derives the fetch URL from the current card's resource URL; `params` is the render data context passed to the resource template (not forwarded to the provider).",
+          "properties": {
+            "action": {
+              "const": "requestModal",
+              "description": "The action type",
+              "type": "string"
+            },
+            "params": {
+              "additionalProperties": {},
+              "description": "Render data context passed to the resource template (opaque to the provider).",
+              "type": "object"
+            },
+            "resource": {
+              "description": "Bare `ui://...` URI of a named resource of the same tool provider.",
+              "type": "string"
+            }
+          },
+          "required": ["action", "resource"],
+          "type": "object"
+        },
+        {
           "description": "Runtime data operation - appends `value` to the array at `path` in form data. Path resolves like `Value` (absolute `/x`, relative to current parentPath, or `''` for parentPath itself).",
           "properties": {
             "action": {


### PR DESCRIPTION
## Summary

Adds a client-side action variant that cards can fire from any `onClick` to ask the host to render a named UI resource in a modal — useful for "detail view" flows where the card is a compact summary and the modal is the full page.

- **New `{ action: "requestModal", resource, params }` variant on `Action.onClick`.**
  - `resource` (required): bare `ui://...` URI of a named resource of the same tool provider.
  - `params` (optional): opaque render-context object. Values are resolved through the usual `ProteusExpression` pipeline (same as `openLink.url`) before dispatch, so the host receives evaluated primitives — no `{ $type: "Value", ... }` literals leak through.
- **New `onRequestModal?: ({ resource, params }) => void` callback** on `ProteusDocumentShell` / `ProteusDocumentRenderer`. Hosts implement it against whatever modal shell they use; the library is agnostic about how the modal is rendered.
- **Works from `ProteusFederated` too** — a federated remote can call `onEvent({ action: "requestModal", ... })` and reach the same host callback, without any extra plumbing.
- Runtime and public schemas regenerated via the generator plugin (variant added inside `ProteusEventHandler.anyOf`); TS discriminated-union updated in `schemas.ts`.
- Storybook demo (`WithRequestModal`) exercises the action end-to-end, including a `Value` binding inside `params` to verify resolution.

## Test plan

- [ ] \`pnpm -F @optiaxiom/proteus build\` — regenerated JSON schemas contain the \`requestModal\` variant (generator and JSONs stay in sync).
- [ ] \`pnpm changeset status\` — picks up \`.changeset/proteus-request-modal-action.md\` as a minor bump on \`@optiaxiom/proteus\`.
- [ ] Storybook: **ProteusDocumentRenderer → With Request Modal** — click "Open results", verify Actions panel logs \`onRequestModal { resource: "ui://experiment-results", params: { experimentId: "exp_9d21", range: "last_30_days" } }\`. Confirms the \`Value\` binding inside \`params\` gets resolved before dispatch.