### PR TITLE
feat(proteus): add requestSidebar action variant + onRequestSidebar handler

### DIFF
--- a/.changeset/proteus-request-sidebar-action.md
+++ b/.changeset/proteus-request-sidebar-action.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": minor
+---
+
+Added a `requestSidebar` client-side `Action.onClick` variant and matching `onRequestSidebar({ resource, params, title })` handler on `ProteusDocumentShell` / `ProteusDocumentRenderer` so hosts can dock a named `ui://...` resource in a side panel alongside the conversation instead of over it. The variant also accepts an optional `auto: { when }` describing when a host may fire the handler without a click — hosts that do not support it ignore the field.

--- a/apps/docs/app/(docs)/guides/proteus/page.mdx
+++ b/apps/docs/app/(docs)/guides/proteus/page.mdx
@@ -168,6 +168,43 @@ Opens a modal on the host that renders a named UI resource of the same tool prov
 
 The host wires this via the `onRequestModal({ resource, params })` prop on `ProteusDocumentRenderer` — the library is agnostic about how the modal itself is rendered. Federated remotes can also fire the event by calling `onEvent({ action: "requestModal", ... })` directly.
 
+### Sidebar handler
+
+`requestSidebar` carries the same payload as `requestModal` — only the surface differs. Where a modal covers the conversation, a sidebar docks beside it, so the user can keep reading the thread while a fuller view stays open. Prefer it when the panel is something to work alongside rather than a detour. An optional `title` sets the panel header, falling back to the target document's own `title`.
+
+```json
+{
+  "$type": "Action",
+  "appearance": "primary",
+  "children": "Open results",
+  "onClick": {
+    "action": "requestSidebar",
+    "resource": "ui://experiment-results",
+    "title": "Experiment results",
+    "params": {
+      "experiment": { "$type": "Value", "path": "/experiment" }
+    }
+  }
+}
+```
+
+Note that `params` is the panel's **entire** dataset — the host renders the target resource as a static template with `params` as its root `data`, and nothing else is fetched on the panel's behalf. Pass the data the panel needs, not just an id to expand.
+
+The host wires this via `onRequestSidebar({ resource, params, title })`. A host that does not implement the panel simply omits the prop, and the action becomes a no-op.
+
+The variant also accepts `auto: { when }`, using the same condition grammar as `Show`, to declare that a host may open the panel _without_ a click:
+
+```json
+"onClick": {
+  "action": "requestSidebar",
+  "resource": "ui://experiment-results",
+  "params": { "experiment": { "$type": "Value", "path": "/experiment" } },
+  "auto": { "when": { "==": [{ "$type": "Value", "path": "/is_ready" }, true] } }
+}
+```
+
+Because `auto` lives on the handler rather than on the document, a card that auto-opens always has a visible control to reopen the panel after the user closes it. Honouring `auto` is entirely at the host's discretion — hosts that ignore it lose nothing, since the click path is unchanged.
+
 ## Scripting
 
 ### Scripts

--- a/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
+++ b/apps/storybook/src/components/ProteusDocumentRenderer.stories.tsx
@@ -20,6 +20,7 @@ export default {
     onMessage: action("onMessage"),
     onPreview: action("onPreview"),
     onRequestModal: action("onRequestModal"),
+    onRequestSidebar: action("onRequestSidebar"),
     strict: true,
   },
   component: ProteusDocumentRenderer,
@@ -387,6 +388,66 @@ export const WithRequestModal: Story = {
               $type: "Text",
               children:
                 "Click below to open the detailed results view. The host receives `{ resource, params }` via `onRequestModal` — check the Actions panel.",
+            },
+          ],
+          flexDirection: "column",
+          gap: "8",
+          p: "16",
+        },
+      ],
+      title: "Experiment Summary",
+    },
+  },
+};
+
+export const WithRequestSidebar: Story = {
+  args: {
+    data: {
+      experiment: {
+        id: "exp_9d21",
+        name: "Checkout Flow V2",
+      },
+      isReady: true,
+    },
+    element: {
+      $type: "Document",
+      actions: [
+        {
+          $type: "Action",
+          appearance: "primary",
+          children: "Open results",
+          onClick: {
+            action: "requestSidebar",
+            // Hosts without auto-mode support ignore `auto` entirely; the
+            // click path is unaffected either way.
+            auto: {
+              when: { "==": [{ $type: "Value", path: "/isReady" }, true] },
+            },
+            params: {
+              experiment: { $type: "Value", path: "/experiment" },
+            },
+            resource: "ui://experiment-results",
+            title: "Experiment results",
+          },
+        },
+      ],
+      appName: "Experiments",
+      body: [
+        {
+          $type: "Group",
+          children: [
+            {
+              $type: "Heading",
+              children: {
+                $type: "Value",
+                path: "/experiment/name",
+              },
+              level: "3",
+            },
+            {
+              $type: "Text",
+              children:
+                "Click below to dock the detailed results beside the conversation. The host receives `{ resource, params, title }` via `onRequestSidebar` — check the Actions panel.",
             },
           ],
           flexDirection: "column",

--- a/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
+++ b/packages/proteus/plugins/rollup-plugin-generate-schema.mjs
@@ -982,6 +982,57 @@ function generateSpec(additionalProperties = false) {
             {
               ...(additionalProperties ? {} : { additionalProperties: false }),
               description:
+                "Client-side component action - opens a docked side panel on the host that renders a named UI resource of the same tool provider, alongside the conversation rather than over it. Same payload as `requestModal`; only the surface differs. The host derives the fetch URL from the current card's resource URL; `params` is the render data context passed to the resource template (not forwarded to the provider).",
+              properties: {
+                action: {
+                  const: "requestSidebar",
+                  description: "The action type",
+                  type: "string",
+                },
+                auto: {
+                  ...(additionalProperties
+                    ? {}
+                    : { additionalProperties: false }),
+                  description:
+                    "Fire this handler without a click. Hosts that support it evaluate `when` and open the panel unprompted, subject to their own policy; hosts that do not simply ignore the field and the click path is unaffected.",
+                  properties: {
+                    when: {
+                      anyOf: [
+                        { $ref: "#/definitions/ProteusCondition" },
+                        {
+                          items: { $ref: "#/definitions/ProteusCondition" },
+                          type: "array",
+                        },
+                      ],
+                      description:
+                        "Single condition or array of conditions (AND logic), same grammar as `Show.when`. Omitted means always.",
+                    },
+                  },
+                  type: "object",
+                },
+                params: {
+                  additionalProperties: {},
+                  description:
+                    "Render data context passed to the resource template (opaque to the provider).",
+                  type: "object",
+                },
+                resource: {
+                  description:
+                    "Bare `ui://...` URI of a named resource of the same tool provider.",
+                  type: "string",
+                },
+                title: {
+                  description:
+                    "Panel header. Falls back to the target document's own `title`.",
+                  type: "string",
+                },
+              },
+              required: ["action", "resource"],
+              type: "object",
+            },
+            {
+              ...(additionalProperties ? {} : { additionalProperties: false }),
+              description:
                 "Runtime data operation - appends `value` to the array at `path` in form data. Path resolves like `Value` (absolute `/x`, relative to current parentPath, or `''` for parentPath itself).",
               properties: {
                 action: {

--- a/packages/proteus/src/proteus-document/ProteusDocumentRenderer.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentRenderer.tsx
@@ -3,6 +3,7 @@ import { type ComponentPropsWithoutRef } from "react";
 import { ProteusElement } from "../proteus-element";
 import { ProteusDocumentShell } from "./ProteusDocumentShell";
 import { safeParseDocument } from "./schemas";
+import { useAutoSidebar } from "./useAutoSidebar";
 
 export type ProteusDocumentRendererProps = Omit<
   ComponentPropsWithoutRef<typeof ProteusDocumentShell>,
@@ -39,6 +40,15 @@ export function ProteusDocumentRenderer({
   ...props
 }: ProteusDocumentRendererProps) {
   const result = safeParseDocument(elementProp);
+
+  // Must run before the early return below so hook order stays stable across
+  // valid and invalid documents. Passing null simply disables it.
+  useAutoSidebar(
+    result.success ? (elementProp as unknown as Record<string, unknown>) : null,
+    props.data,
+    props.onRequestSidebar,
+  );
+
   if (!result.success) {
     if (strict) {
       throw new Error(`Invalid document: ${result.error.join("\n")}`);

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -113,6 +113,32 @@ export type ProteusDocumentShellProps = {
     resource: string;
   }) => Promise<void> | void;
   /**
+   * Callback when a card action fires `{ action: "requestSidebar" }`. Same
+   * payload as `onRequestModal`, but the host is asked to dock the resource
+   * in a side panel alongside the conversation rather than open it over the
+   * top. The library is agnostic about how the panel is rendered.
+   */
+  onRequestSidebar?: (payload: {
+    /**
+     * True when the handler fired via its `auto` declaration rather than a
+     * click, so the host can gate unprompted opens without gating clicks.
+     */
+    auto?: boolean;
+    /**
+     * Render data context passed to the resource template. Values are already
+     * resolved through the usual ProteusExpression pipeline before dispatch.
+     */
+    params?: Record<string, unknown>;
+    /**
+     * Bare `ui://...` URI of a named resource of the same tool provider.
+     */
+    resource: string;
+    /**
+     * Panel header. Falls back to the target document's own `title`.
+     */
+    title?: string;
+  }) => Promise<void> | void;
+  /**
    * Callback when an analytics event is fired
    */
   onTrack?: (event: string, properties: Record<string, string>) => void;
@@ -177,6 +203,7 @@ export function ProteusDocumentShell({
   onOpenChange,
   onPreview,
   onRequestModal,
+  onRequestSidebar,
   onTrack,
   onUpload,
   open: openProp,
@@ -272,6 +299,15 @@ export function ProteusDocumentShell({
       await onRequestModal?.({
         params: event.params,
         resource: event.resource,
+      });
+    } else if (event.action === "requestSidebar") {
+      // `auto` is intentionally not forwarded — it describes when the host
+      // may fire this handler unprompted, which is a decision the host makes
+      // before dispatch, not part of the dispatched payload.
+      await onRequestSidebar?.({
+        params: event.params,
+        resource: event.resource,
+        title: event.title,
       });
     } else if (event.action === "pushValue") {
       // `path` arrives already resolved to an absolute pointer by the

--- a/packages/proteus/src/proteus-document/schemas.ts
+++ b/packages/proteus/src/proteus-document/schemas.ts
@@ -50,6 +50,7 @@ import type { ProteusShowProps } from "../proteus-show/ProteusShow";
 import type { ProteusValueProps } from "../proteus-value/ProteusValue";
 import type { FileUploadMetadata } from "./ProteusDocumentContext";
 import type { ProteusDocumentShellProps } from "./ProteusDocumentShell";
+import type { ProteusCondition } from "./resolveProteusValue";
 
 import proteusDocumentSpec from "../schema/runtime-schema.json";
 
@@ -128,6 +129,13 @@ export type ProteusEventHandler =
       action: "requestModal";
       params?: Record<string, unknown>;
       resource: string;
+    }
+  | {
+      action: "requestSidebar";
+      auto?: { when?: ProteusCondition | ProteusCondition[] };
+      params?: Record<string, unknown>;
+      resource: string;
+      title?: string;
     }
   | {
       action: "setValue";

--- a/packages/proteus/src/proteus-document/useAutoSidebar.ts
+++ b/packages/proteus/src/proteus-document/useAutoSidebar.ts
@@ -1,0 +1,122 @@
+import { useEffect, useRef } from "react";
+
+import { evaluateCondition, resolveProteusValue } from "./resolveProteusValue";
+
+type AutoSidebarHandler = {
+  auto?: unknown;
+  params?: unknown;
+  resource: string;
+  title?: unknown;
+};
+
+type AutoSidebarPayload = {
+  /** Always true here — lets the host apply auto-specific policy. */
+  auto: true;
+  params?: Record<string, unknown>;
+  resource: string;
+  title?: string;
+};
+
+/**
+ * A `requestSidebar` handler may carry `auto: { when }`, declaring that the
+ * host MAY fire it without a click.
+ *
+ * The host cannot evaluate this itself — `when` and `params` contain
+ * ProteusExpressions and the expression engine lives here — so the renderer
+ * resolves them and hands the host a plain payload. Honouring it remains
+ * entirely the host's decision.
+ *
+ * Because `auto` lives on the handler rather than on the document, a card that
+ * auto-opens always has a visible control to reopen the panel after the user
+ * closes it. The trade-off is that the handler can be anywhere in the tree, so
+ * we walk it; if several match, **first in document order wins** and the rest
+ * keep working as ordinary click handlers.
+ *
+ * Edge-triggered on `when` going false → true, not fire-once-on-mount:
+ * fire-once cannot express "open the panel when the job finishes", which is
+ * the main use case. Matches `watch()` semantics.
+ */
+export function useAutoSidebar(
+  document: null | Record<string, unknown>,
+  data: Record<string, unknown> | undefined,
+  onAuto: ((payload: AutoSidebarPayload) => Promise<void> | void) | undefined,
+) {
+  const wasSatisfied = useRef(false);
+
+  const handler = document ? findAutoSidebarHandler(document) : null;
+  const resolvedData = data ?? {};
+
+  let satisfied = false;
+  if (handler && onAuto) {
+    const when = (handler.auto as undefined | { when?: unknown })?.when;
+    if (when === undefined) {
+      satisfied = true;
+    } else {
+      const conditions = Array.isArray(when) ? when : [when];
+      satisfied = conditions.every((condition) =>
+        evaluateCondition(condition, resolvedData, "", []),
+      );
+    }
+  }
+
+  useEffect(() => {
+    if (!handler || !onAuto) {
+      return;
+    }
+    if (!satisfied) {
+      // Reset so a later false → true transition fires again.
+      wasSatisfied.current = false;
+      return;
+    }
+    if (wasSatisfied.current) {
+      return;
+    }
+    wasSatisfied.current = true;
+
+    const params = resolveProteusValue(handler.params, resolvedData, "", []) as
+      | Record<string, unknown>
+      | undefined;
+    const title = resolveProteusValue(handler.title, resolvedData, "", []) as
+      | string
+      | undefined;
+
+    void onAuto({ auto: true, params, resource: handler.resource, title });
+    // `resolvedData` is a fresh object each render; `satisfied` already
+    // captures the only thing about it that matters here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [satisfied, handler?.resource, onAuto]);
+}
+
+/** Depth-first walk; first `requestSidebar` handler carrying `auto` wins. */
+function findAutoSidebarHandler(node: unknown): AutoSidebarHandler | null {
+  if (!node || typeof node !== "object") {
+    return null;
+  }
+
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findAutoSidebarHandler(child);
+      if (found) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  const record = node as Record<string, unknown>;
+  if (
+    record.action === "requestSidebar" &&
+    record.auto &&
+    typeof record.resource === "string"
+  ) {
+    return record as AutoSidebarHandler;
+  }
+
+  for (const value of Object.values(record)) {
+    const found = findAutoSidebarHandler(value);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -1553,6 +1553,49 @@
         },
         {
           "additionalProperties": false,
+          "description": "Client-side component action - opens a docked side panel on the host that renders a named UI resource of the same tool provider, alongside the conversation rather than over it. Same payload as `requestModal`; only the surface differs. The host derives the fetch URL from the current card's resource URL; `params` is the render data context passed to the resource template (not forwarded to the provider).",
+          "properties": {
+            "action": {
+              "const": "requestSidebar",
+              "description": "The action type",
+              "type": "string"
+            },
+            "auto": {
+              "additionalProperties": false,
+              "description": "Fire this handler without a click. Hosts that support it evaluate `when` and open the panel unprompted, subject to their own policy; hosts that do not simply ignore the field and the click path is unaffected.",
+              "properties": {
+                "when": {
+                  "anyOf": [
+                    { "$ref": "#/definitions/ProteusCondition" },
+                    {
+                      "items": { "$ref": "#/definitions/ProteusCondition" },
+                      "type": "array"
+                    }
+                  ],
+                  "description": "Single condition or array of conditions (AND logic), same grammar as `Show.when`. Omitted means always."
+                }
+              },
+              "type": "object"
+            },
+            "params": {
+              "additionalProperties": {},
+              "description": "Render data context passed to the resource template (opaque to the provider).",
+              "type": "object"
+            },
+            "resource": {
+              "description": "Bare `ui://...` URI of a named resource of the same tool provider.",
+              "type": "string"
+            },
+            "title": {
+              "description": "Panel header. Falls back to the target document's own `title`.",
+              "type": "string"
+            }
+          },
+          "required": ["action", "resource"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
           "description": "Runtime data operation - appends `value` to the array at `path` in form data. Path resolves like `Value` (absolute `/x`, relative to current parentPath, or `''` for parentPath itself).",
           "properties": {
             "action": {

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -1534,6 +1534,47 @@
           "type": "object"
         },
         {
+          "description": "Client-side component action - opens a docked side panel on the host that renders a named UI resource of the same tool provider, alongside the conversation rather than over it. Same payload as `requestModal`; only the surface differs. The host derives the fetch URL from the current card's resource URL; `params` is the render data context passed to the resource template (not forwarded to the provider).",
+          "properties": {
+            "action": {
+              "const": "requestSidebar",
+              "description": "The action type",
+              "type": "string"
+            },
+            "auto": {
+              "description": "Fire this handler without a click. Hosts that support it evaluate `when` and open the panel unprompted, subject to their own policy; hosts that do not simply ignore the field and the click path is unaffected.",
+              "properties": {
+                "when": {
+                  "anyOf": [
+                    { "$ref": "#/definitions/ProteusCondition" },
+                    {
+                      "items": { "$ref": "#/definitions/ProteusCondition" },
+                      "type": "array"
+                    }
+                  ],
+                  "description": "Single condition or array of conditions (AND logic), same grammar as `Show.when`. Omitted means always."
+                }
+              },
+              "type": "object"
+            },
+            "params": {
+              "additionalProperties": {},
+              "description": "Render data context passed to the resource template (opaque to the provider).",
+              "type": "object"
+            },
+            "resource": {
+              "description": "Bare `ui://...` URI of a named resource of the same tool provider.",
+              "type": "string"
+            },
+            "title": {
+              "description": "Panel header. Falls back to the target document's own `title`.",
+              "type": "string"
+            }
+          },
+          "required": ["action", "resource"],
+          "type": "object"
+        },
+        {
           "description": "Runtime data operation - appends `value` to the array at `path` in form data. Path resolves like `Value` (absolute `/x`, relative to current parentPath, or `''` for parentPath itself).",
           "properties": {
             "action": {


### PR DESCRIPTION
Mirrors `requestModal` (d746979) file for file, and adds an optional `auto` declaration on the same handler.

## `requestSidebar`

Same payload as `requestModal` — only the surface differs. A modal covers the thread; a sidebar sits beside it, so the user can keep reading while a fuller view stays open. Prefer it when the panel is something to work *alongside* rather than a detour.

```jsonc
{
  "$type": "Action",
  "children": "Open results",
  "onClick": {
    "action": "requestSidebar",
    "resource": "ui://experiment-results",
    "title": "Experiment results",
    "params": { "experiment": { "$type": "Value", "path": "/experiment" } }
  }
}
```

`ProteusDocumentShell` gains `onRequestSidebar`; a host that doesn't implement the panel omits the prop and the action is a no-op. `params` needed no special handling — `ProteusAction` already runs the whole `onClick` through `useResolveProteusValues`, which recurses into plain objects (same reason the `requestModal` commit didn't touch it).

## `auto: { when }`

Declares that a host **may** fire the handler without a click, using the same condition grammar as `Show`.

Putting it on the handler rather than on the `Document` is deliberate: a card that auto-opens then always has a **visible control to reopen the panel** after the user closes it. A document-level property makes that dead end easy to ship by accident. The cost — `onClick` now names something that can fire without a click — is accepted for that guarantee.

### Why the renderer has to do the work

Hosts can't evaluate this themselves: `when` and `params` contain ProteusExpressions and the engine lives in this package. So `useAutoSidebar`:

- walks the document for a handler carrying `auto` — **first in document order wins**, and the losers keep working as ordinary click handlers;
- evaluates the condition and resolves `params`;
- hands the host a plain payload flagged **`auto: true`**, so a host can gate unprompted opens without gating clicks.

**Edge-triggered on `when` going false → true**, not fire-once-on-mount — matching `watch()` semantics. Fire-once can't express *"open the panel when the job finishes"*, which is the main use case.

`auto` itself is **not** forwarded to the callback: it describes when a host may fire the handler, which is decided *before* dispatch.

The hook runs before `ProteusDocumentRenderer`'s early return so hook order stays stable across valid and invalid documents.

## Checks

- `pnpm -F @optiaxiom/proteus build` — both `schema/*.json` regenerated by the generator plugin (not hand-edited)
- `pnpm lint` clean
- Changeset included (`minor`)
- Storybook story + a "Sidebar handler" section in the Proteus guide, matching the `requestModal` pair

Validated against the regenerated runtime and public schemas: a `requestSidebar` document with `auto`, `params` and `title` passes; the new prop type-checks from a consuming app.

## Unrelated pre-existing issue, noticed while testing

The `onClick` `anyOf` accepts almost anything — a `requestModal` missing its required `resource`, an unknown `action`, even `{}`. A permissive member swallows everything, so malformed handlers inside a document literal are caught by neither the JSON schema nor TypeScript (the `element` prop's nested types are loose); only renderer props are genuinely type-checked.

Combined with `ProteusDocumentRenderer` returning `null` *silently* on a document that fails validation, an authoring mistake presents as an empty render with no console error. Not touched here — happy to open a separate issue if useful.