### PR TITLE
feat(globals): add bg.message.neutral color token

### DIFF
--- a/.changeset/bg-message-neutral-token.md
+++ b/.changeset/bg-message-neutral-token.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/globals": minor
+---
+
+Added `bg.message.neutral` color token (`#F5F6F7` light / `#3C3D40` dark) for neutral message surfaces.

--- a/packages/globals/src/tokens.spec.ts
+++ b/packages/globals/src/tokens.spec.ts
@@ -49,7 +49,7 @@ describe("tokens", () => {
       count: Object.keys(tokens.colors).length,
       keys: Object.keys(tokens.colors),
     }).toEqual({
-      count: 87,
+      count: 88,
       keys: [
         "bg.accent",
         "bg.accent.hovered",
@@ -73,6 +73,7 @@ describe("tokens", () => {
         "bg.information",
         "bg.information.light",
         "bg.information.subtle",
+        "bg.message.neutral",
         "bg.overlay",
         "bg.page",
         "bg.pill.default",

--- a/packages/globals/src/tokens/colors.ts
+++ b/packages/globals/src/tokens/colors.ts
@@ -88,6 +88,9 @@ const palette = {
   "neutral.1050": "#252825" as const,
   "neutral.1100": "#202320" as const,
 
+  "neutral.cool.50": "#F5F6F7" as const,
+  "neutral.cool.900": "#3C3D40" as const,
+
   "neutral.50/6": "#DDE9D20D" as const,
   "neutral.50/12": "#DDE9D21F" as const,
   "neutral.50/18": "#DDE9D224" as const,
@@ -179,6 +182,10 @@ export const colors = {
   "bg.information": ld(palette["blue.600"], palette["blue.600"]),
   "bg.information.light": ld(palette["blue.200"], palette["blue.800"]),
   "bg.information.subtle": ld(palette["blue.100"], palette["blue.dark.900"]),
+  "bg.message.neutral": ld(
+    palette["neutral.cool.50"],
+    palette["neutral.cool.900"],
+  ),
   "bg.overlay": ld(palette["neutral.1200/32"], palette["neutral.1200/32"]),
   "bg.page": ld(palette["neutral.25"], palette["neutral.1050"]),
   "bg.pill.default": ld(palette["neutral.150"], palette["neutral.800"]),


### PR DESCRIPTION
## Summary
- Adds `bg.message.neutral` semantic color token (`#F5F6F7` light / `#3C3D40` dark) for neutral message surfaces.
- Introduces new `neutral.cool.50` / `neutral.cool.900` palette entries backing it, since the requested hex values are cool greys that don't match the existing warm-tinted `neutral.*` scale.
- Updates `tokens.spec.ts` (count 87 → 88, keys list) and adds a `minor` changeset for `@optiaxiom/globals`.

## Test plan
- [ ] `pnpm -F @optiaxiom/globals test` passes
- [ ] Token resolves in a consumer via `theme.colors["bg.message.neutral"]` and renders correct light/dark values