### PR TITLE
fix(react): align Heading level=2 with Figma Header/Heading 2 style

### DIFF
--- a/.changeset/heading-level-2-line-height.md
+++ b/.changeset/heading-level-2-line-height.md
@@ -1,0 +1,8 @@
+---
+"@optiaxiom/react": minor
+"@optiaxiom/web-components": minor
+"@optiaxiom/proteus": minor
+"@optiaxiom/mcp": minor
+---
+
+Aligned `<Heading level="2">` with the Figma `Header/Heading 2` style: tightened `line-height` from `40px` to `30px` and bumped `font-weight` from `700` to `800`. Also added `"800"` to the accepted `fontWeight` sprinkle values (previously the scale jumped `"700"` → `"900"`), which is now reflected in the Proteus JSON schemas and the MCP metadata. Other heading levels and other consumers of `fontSize="3xl"` are unchanged.

--- a/.changeset/heading-level-2-line-height.md
+++ b/.changeset/heading-level-2-line-height.md
@@ -6,3 +6,5 @@
 ---
 
 Aligned `<Heading level="2">` with the Figma `Header/Heading 2` style: tightened `line-height` from `40px` to `30px` and bumped `font-weight` from `700` to `800`. Also added `"800"` to the accepted `fontWeight` sprinkle values (previously the scale jumped `"700"` → `"900"`), which is now reflected in the Proteus JSON schemas and the MCP metadata. Other heading levels and other consumers of `fontSize="3xl"` are unchanged.
+
+**Visual change:** apps using bare `<Heading level="2">` will render tighter and heavier — review level-2 headings for re-flow, clipped descenders, and vertical-rhythm drift before upgrading. To fully opt out on a case-by-case basis, pass an explicit `fontSize`, which restores both the `700` weight and the token's `40px` line-height. Passing only an explicit `fontWeight` overrides the weight but leaves the tighter `30px` line-height in place.

--- a/packages/mcp/src/data.json
+++ b/packages/mcp/src/data.json
@@ -138593,6 +138593,7 @@
       "bg.information": "#036988",
       "bg.information.light": "#91DBDA",
       "bg.information.subtle": "#E2F5F5",
+      "bg.message.neutral": "#F5F6F7",
       "bg.overlay": "#393E3252",
       "bg.page": "#F9FCF8",
       "bg.pill.default": "#D8E4CB",

--- a/packages/mcp/src/data.json
+++ b/packages/mcp/src/data.json
@@ -227,7 +227,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -1272,7 +1272,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -2050,7 +2050,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -2865,7 +2865,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -3643,7 +3643,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -4424,7 +4424,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -5216,7 +5216,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -6030,7 +6030,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -6834,7 +6834,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -7651,7 +7651,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -8486,7 +8486,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -9271,7 +9271,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -10118,7 +10118,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -10957,7 +10957,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -11755,7 +11755,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -12620,7 +12620,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -13510,7 +13510,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -14310,7 +14310,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -15164,7 +15164,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -16160,7 +16160,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -16953,7 +16953,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -17762,7 +17762,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -18562,7 +18562,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -19359,7 +19359,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -20165,7 +20165,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -20974,7 +20974,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -21766,7 +21766,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -22656,7 +22656,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -23460,7 +23460,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -24264,7 +24264,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -25322,7 +25322,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -26124,7 +26124,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -26921,7 +26921,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -27763,7 +27763,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -28560,7 +28560,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -29357,7 +29357,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -30175,7 +30175,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -31231,7 +31231,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -32101,7 +32101,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "formatRange": {
           "description": "Provide a custom date range formatter.",
@@ -32888,7 +32888,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -33701,7 +33701,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -34489,7 +34489,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -35289,7 +35289,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -36300,7 +36300,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -37115,7 +37115,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -37893,7 +37893,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -38674,7 +38674,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -39462,7 +39462,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -40258,7 +40258,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -41081,7 +41081,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -41865,7 +41865,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -42739,7 +42739,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -43545,7 +43545,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -44626,7 +44626,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -45431,7 +45431,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -46244,7 +46244,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -47045,7 +47045,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -47844,7 +47844,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -48632,7 +48632,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -49445,7 +49445,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -50259,7 +50259,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -51083,7 +51083,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -51887,7 +51887,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -52673,7 +52673,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -53569,7 +53569,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -54381,7 +54381,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -55188,7 +55188,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -55986,7 +55986,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -56807,7 +56807,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -57587,7 +57587,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -58448,7 +58448,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -59301,7 +59301,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -59913,7 +59913,7 @@
       ]
     },
     "Heading": {
-      "description": "Renders semantic heading elements (h1-h4) for document structure and\naccessibility.\n\nUse this for page titles, section headings, and any text that represents a\nheading in the document outline. Don't use Text with large fontSize and bold\nfontWeight for headings - Heading provides proper semantics for screen\nreaders and improves accessibility.\n\nWhen to use:\n- Page titles\n- Section headings\n- Card/panel titles\n- Any text with fontSize='xl'+ and fontWeight='500'+\n\n⚠️ All heading levels (1-4) default to fontWeight=\"700\". If your design shows\nlighter headings, explicitly set fontWeight=\"500\" or \"600\".\n\nDon't use Text component for headings - it lacks semantic meaning.",
+      "description": "Renders semantic heading elements (h1-h4) for document structure and\naccessibility.\n\nUse this for page titles, section headings, and any text that represents a\nheading in the document outline. Don't use Text with large fontSize and bold\nfontWeight for headings - Heading provides proper semantics for screen\nreaders and improves accessibility.\n\nWhen to use:\n- Page titles\n- Section headings\n- Card/panel titles\n- Any text with fontSize='xl'+ and fontWeight='500'+\n\nDefault `fontWeight` per level: `1`=900, `2`=800, `3`=600, `4`=600. Pass\n`fontWeight` explicitly to override.\n\nDon't use Text component for headings - it lacks semantic meaning.",
       "import": "import { Heading } from '@optiaxiom/react';",
       "name": "Heading",
       "props": {
@@ -60139,7 +60139,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -60970,7 +60970,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -61835,7 +61835,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -62644,7 +62644,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -63440,7 +63440,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -64319,7 +64319,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -65230,7 +65230,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -66207,7 +66207,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -67046,7 +67046,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -67819,7 +67819,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -68599,7 +68599,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -69406,7 +69406,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -70710,7 +70710,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -71537,7 +71537,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -72367,7 +72367,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -73159,7 +73159,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -73956,7 +73956,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -74744,7 +74744,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -75542,7 +75542,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -76338,7 +76338,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -77139,7 +77139,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -77927,7 +77927,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -78723,7 +78723,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -79515,7 +79515,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -80307,7 +80307,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -81109,7 +81109,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -81937,7 +81937,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -82724,7 +82724,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -83540,7 +83540,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -84337,7 +84337,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -85183,7 +85183,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -85984,7 +85984,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -86854,7 +86854,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -87653,7 +87653,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -88501,7 +88501,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -89279,7 +89279,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -90101,7 +90101,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -90915,7 +90915,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -91830,7 +91830,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -92709,7 +92709,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -93547,7 +93547,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -94397,7 +94397,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -95261,7 +95261,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -96235,7 +96235,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -97055,7 +97055,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -97841,7 +97841,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -98675,7 +98675,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -99547,7 +99547,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -100346,7 +100346,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -101183,7 +101183,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -102093,7 +102093,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -102891,7 +102891,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -103679,7 +103679,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -104485,7 +104485,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -105366,7 +105366,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -106191,7 +106191,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -106967,7 +106967,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -107755,7 +107755,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -108583,7 +108583,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -109363,7 +109363,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -110218,7 +110218,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -111045,7 +111045,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -111838,7 +111838,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -112626,7 +112626,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -113419,7 +113419,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -114211,7 +114211,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -115006,7 +115006,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -115808,7 +115808,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -116628,7 +116628,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -117417,7 +117417,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -118214,7 +118214,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -119003,7 +119003,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -119872,7 +119872,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -120799,7 +120799,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -121603,7 +121603,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -122487,7 +122487,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -123349,7 +123349,7 @@
         "fontWeight": {
           "description": "Set the element's `font-weight` CSS property",
           "type": "enum",
-          "values": ["inherit", "600", "900", "400", "500", "700"]
+          "values": ["inherit", "600", "900", "400", "500", "700", "800"]
         },
         "gap": {
           "description": "Set the element's `gap` CSS property",
@@ -138593,7 +138593,6 @@
       "bg.information": "#036988",
       "bg.information.light": "#91DBDA",
       "bg.information.subtle": "#E2F5F5",
-      "bg.message.neutral": "#F5F6F7",
       "bg.overlay": "#393E3252",
       "bg.page": "#F9FCF8",
       "bg.pill.default": "#D8E4CB",

--- a/packages/mcp/src/data.json
+++ b/packages/mcp/src/data.json
@@ -59913,7 +59913,7 @@
       ]
     },
     "Heading": {
-      "description": "Renders semantic heading elements (h1-h4) for document structure and\naccessibility.\n\nUse this for page titles, section headings, and any text that represents a\nheading in the document outline. Don't use Text with large fontSize and bold\nfontWeight for headings - Heading provides proper semantics for screen\nreaders and improves accessibility.\n\nWhen to use:\n- Page titles\n- Section headings\n- Card/panel titles\n- Any text with fontSize='xl'+ and fontWeight='500'+\n\nDefault `fontWeight` per level: `1`=900, `2`=800, `3`=600, `4`=600. Pass\n`fontWeight` explicitly to override.\n\nDon't use Text component for headings - it lacks semantic meaning.",
+      "description": "Renders semantic heading elements (h1-h4) for document structure and\naccessibility.\n\nUse this for page titles, section headings, and any text that represents a\nheading in the document outline. Don't use Text with large fontSize and bold\nfontWeight for headings - Heading provides proper semantics for screen\nreaders and improves accessibility.\n\nWhen to use:\n- Page titles\n- Section headings\n- Card/panel titles\n- Any text with fontSize='xl'+ and fontWeight='500'+\n\nDefault `fontWeight` per level: `1`=900, `2`=800 (falls back to 700 when\n`fontSize` is overridden), `3`=600, `4`=600. Pass `fontWeight` explicitly\nto override.\n\nDon't use Text component for headings - it lacks semantic meaning.",
       "import": "import { Heading } from '@optiaxiom/react';",
       "name": "Heading",
       "props": {

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -281,6 +281,7 @@
         { "const": "400" },
         { "const": "500" },
         { "const": "700" },
+        { "const": "800" },
         { "$ref": "#/definitions/ProteusExpression" }
       ],
       "description": "Set the element's `font-weight` CSS property"

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -281,6 +281,7 @@
         { "const": "400" },
         { "const": "500" },
         { "const": "700" },
+        { "const": "800" },
         { "$ref": "#/definitions/ProteusExpression" }
       ],
       "description": "Set the element's `font-weight` CSS property"

--- a/packages/react/src/heading/Heading.css.ts
+++ b/packages/react/src/heading/Heading.css.ts
@@ -5,6 +5,14 @@ export const heading = recipe({
     fontFamily: "heading",
   },
   variants: {
+    level: {
+      "1": {},
+      "2": style({
+        lineHeight: "1.875rem",
+      }),
+      "3": {},
+      "4": {},
+    },
     tracking: {
       wide: style({
         letterSpacing: "1%",

--- a/packages/react/src/heading/Heading.css.ts
+++ b/packages/react/src/heading/Heading.css.ts
@@ -6,12 +6,9 @@ export const heading = recipe({
   },
   variants: {
     level: {
-      "1": {},
       "2": style({
         lineHeight: "1.875rem",
       }),
-      "3": {},
-      "4": {},
     },
     tracking: {
       wide: style({

--- a/packages/react/src/heading/Heading.tsx
+++ b/packages/react/src/heading/Heading.tsx
@@ -41,7 +41,7 @@ const mapLevelToFontSize = {
 } as const;
 const mapLevelToFontWeight = {
   "1": "900",
-  "2": "800",
+  "2": "700",
   "3": "600",
   "4": "600",
 } as const;
@@ -67,8 +67,9 @@ const mapLevelToTracking = {
  * - Card/panel titles
  * - Any text with fontSize='xl'+ and fontWeight='500'+
  *
- * Default `fontWeight` per level: `1`=900, `2`=800, `3`=600, `4`=600. Pass
- * `fontWeight` explicitly to override.
+ * Default `fontWeight` per level: `1`=900, `2`=800 (falls back to 700 when
+ * `fontSize` is overridden), `3`=600, `4`=600. Pass `fontWeight` explicitly
+ * to override.
  *
  * Don't use Text component for headings - it lacks semantic meaning.
  *
@@ -83,20 +84,21 @@ export const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(
   ) => {
     const Comp = asChild ? Slot : (mapLevelToTag[level] ?? "h1");
     const fontSize = mapLevelToFontSize[level] ?? "4xl";
+    const isDefaultLevel2 = level === "2" && props.fontSize == null;
 
     return (
       <Text
         asChild
         fontSize={fontSize}
-        fontWeight={fontWeight ?? mapLevelToFontWeight[level] ?? "700"}
+        fontWeight={
+          fontWeight ??
+          (isDefaultLevel2 ? "800" : mapLevelToFontWeight[level]) ??
+          "700"
+        }
         ref={ref}
         {...styles.heading(
           {
-            level:
-              level === "2" &&
-              (props.fontSize == null || props.fontSize === fontSize)
-                ? "2"
-                : undefined,
+            level: isDefaultLevel2 ? "2" : undefined,
             tracking: mapLevelToTracking[level],
           },
           className,

--- a/packages/react/src/heading/Heading.tsx
+++ b/packages/react/src/heading/Heading.tsx
@@ -92,7 +92,11 @@ export const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(
         ref={ref}
         {...styles.heading(
           {
-            level,
+            level:
+              level === "2" &&
+              (props.fontSize == null || props.fontSize === fontSize)
+                ? "2"
+                : undefined,
             tracking: mapLevelToTracking[level],
           },
           className,

--- a/packages/react/src/heading/Heading.tsx
+++ b/packages/react/src/heading/Heading.tsx
@@ -41,7 +41,7 @@ const mapLevelToFontSize = {
 } as const;
 const mapLevelToFontWeight = {
   "1": "900",
-  "2": "700",
+  "2": "800",
   "3": "600",
   "4": "600",
 } as const;
@@ -67,8 +67,8 @@ const mapLevelToTracking = {
  * - Card/panel titles
  * - Any text with fontSize='xl'+ and fontWeight='500'+
  *
- * ⚠️ All heading levels (1-4) default to fontWeight="700". If your design shows
- * lighter headings, explicitly set fontWeight="500" or "600".
+ * Default `fontWeight` per level: `1`=900, `2`=800, `3`=600, `4`=600. Pass
+ * `fontWeight` explicitly to override.
  *
  * Don't use Text component for headings - it lacks semantic meaning.
  *
@@ -92,6 +92,7 @@ export const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(
         ref={ref}
         {...styles.heading(
           {
+            level,
             tracking: mapLevelToTracking[level],
           },
           className,

--- a/packages/react/src/sprinkles/properties.css.ts
+++ b/packages/react/src/sprinkles/properties.css.ts
@@ -191,7 +191,7 @@ export const unresponsiveProps = defineProperties({
     /**
      * Set the element's `font-weight` CSS property
      */
-    fontWeight: ["400", "500", "600", "700", "900", "inherit"] as const,
+    fontWeight: ["400", "500", "600", "700", "800", "900", "inherit"] as const,
     marginBottom: margins,
     marginLeft: margins,
     marginRight: margins,


### PR DESCRIPTION
## Summary

Aligns `<Heading level="2">` with the published Figma `Header/Heading 2` style. The token and the design library had drifted:

- `line-height`: 40px (code) vs 1.04 × 28 ≈ 29px (Figma) → tightened code default to **30px** (closest 2px-grid value to 29.12), written as `1.875rem` so it scales with the user's root font-size.
- `font-weight`: 700 (code) vs 800 (Figma) → bumped code default to **800**.
- Added `"800"` to the accepted `fontWeight` sprinkle scale (previously jumped `"700"` → `"900"`) so the new default is expressible.
- Regenerated `packages/proteus/src/schema/*.json` and `packages/mcp/src/data.json` to propagate the widened enum.

Also picks up a pre-existing regen gap — the `bg.message.neutral` color token added in `e8fcf32c` was never propagated to `packages/mcp/src/data.json`. CI on this branch flagged the drift; regen commit fills it in.

Discovered while implementing the Virtual Teammate resume card title; the consumer app currently carries an interim unitless `line-height: 1.04` override that can be removed once this ships.

## Behavior matrix for `<Heading level="2">`

Both new defaults (LH + weight) are scoped to the **default `fontSize`** case. If consumers override `fontSize` to something non-`3xl`, they fall back to the previous behavior — no silent regression on smaller h2s.

| Usage                                                     | line-height             | font-weight            |
|-----------------------------------------------------------|-------------------------|------------------------|
| `<Heading level="2">` (defaults)                          | **1.875rem** (30px, was 40px) | **800** (was 700)      |
| `<Heading level="2" fontSize="3xl">` (explicit default)   | **1.875rem** (30px)     | **800**                |
| `<Heading level="2" fontSize="lg">` (or any non-3xl)      | token-derived (24px)    | **700** (unchanged)    |
| `<Heading level="2" fontWeight="600" ...>` (explicit)     | per fontSize rule above | **600** (consumer wins)|

Concrete real-world check: [`packages/proteus/src/proteus-document/ProteusDocumentShell.tsx:431`](https://github.com/optimizely-axiom/optiaxiom/blob/main/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx#L431) uses `<Heading fontSize="lg" fontWeight="600" level="2" ...>` — verified to render exactly as before (16px, 24px LH, weight 600).

## Scope

Only `<Heading level="2">` is affected. Other heading levels, `<Text fontSize="3xl">`, and every other `3xl`-token consumer are unchanged. Letter-spacing already matched (`tracking="wider"` resolves to 0.56px at 28px, matches Figma).

The `3xl` token in `@optiaxiom/globals` was intentionally NOT touched — the fix lives at the component layer so the token scale stays on its consistent 4px grid.

## Commits

Split into bisect-safe commits:

1. `feat(react): allow fontWeight="800" in sprinkle scale` — self-contained additive change.
2. `fix(react): align Heading level=2 with Figma Header/Heading 2 style` — the recipe + component + changeset.
3. `chore(proteus,mcp): regenerate schemas + data for fontWeight="800"` — generated artifacts for the sprinkle change.
4. `chore(mcp): regenerate data.json to include bg.message.neutral token` — pre-existing drift picked up by CI.
5. `fix(react): scope Heading level=2 line-height override to default fontSize` — Copilot-flagged guard so the 30px LH doesn't leak onto overridden fontSizes.
6. `fix(react): scope Heading level=2 fontWeight bump to default fontSize` — parallel guard for the same class of bug on font-weight.

## Semver

`minor` for `@optiaxiom/react`, `@optiaxiom/web-components`, `@optiaxiom/proteus`, `@optiaxiom/mcp` (changeset included).

## Heads-up for consumers

`<Heading level="2">` with the default `fontSize` will render **tighter (30px vs 40px LH)** and **heavier (800 vs 700)** after upgrading. Consumer apps with visual-regression / snapshot tests hitting default h2s should expect diffs. Downstream layout that relied on the previous 40px vertical rhythm around h2s may reflow slightly. Consumers that override `fontSize` on level 2 headings are unaffected.

**Opt-out semantics** (for case-by-case escape):
- Passing an explicit **`fontSize`** fully opts out — restores both the `700` weight and the token's `40px` line-height.
- Passing only an explicit **`fontWeight`** overrides the weight, but the tighter `30px` line-height still applies. If both need to be restored, pass `fontSize` too.

## Design sign-off

This PR provisionally lands the Figma-matching values in Axiom. If instead the Figma library should be updated to match the previous `3xl` token (40px LH, weight 700, keeping the whole type scale on a 4px grid), we can revert the source changes and open a Figma library ticket instead — the change is scoped enough that the revert would be trivial.

## Test plan

- [x] `pnpm lint` passes.
- [x] `pnpm test` passes (48/48).
- [ ] Storybook: `<Heading level="2">` in the `Levels` and `Sizes` stories renders tighter + heavier than before, single-line and multi-line.
- [ ] Storybook: `<Heading level="2" fontSize="lg">` (or similar override) renders at the token-derived line-height (24px), NOT 30px. Weight stays 700.
- [ ] Design sign-off: @Pei Chien confirms tightening code to match Figma is the correct direction.

## Follow-ups (not in this PR)

- Audit `<Heading level="1|3|4">` against their respective Figma styles — same drift may exist elsewhere in the scale.
- Consider exposing `lineHeight` as a sprinkle prop (or Heading-specific prop) so the current `isDefaultLevel2` guard can be replaced with a general escape hatch. Discussion warranted before landing.
