### PR TITLE
feat(proteus): route bare href on CardLink through openLink event

### DIFF
--- a/.changeset/proteus-card-link-open-link.md
+++ b/.changeset/proteus-card-link-open-link.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/proteus": patch
+---
+
+`ProteusCardLink` now dispatches a bare `href` through the shell's event pipeline as an `{ action: "openLink", url }` event, so hosts that own link navigation via `onOpenLink` (added in the previous release: MCP Apps `app.openLink`, OpenAI Apps SDK `window.openai.openExternal`) receive href-only clicks the same as explicit `onClick` actions. Without this, `CardLink { href }` in sandboxed iframes without `allow-popups` fell through to the browser's blocked `target="_blank"` navigation, bypassing the host handler. Behaviour is unchanged when `onClick` is provided, and outside embedded shells the shell's `window.open(url, "_blank", "noopener,noreferrer")` fallback still runs — so this is a non-breaking addition.

--- a/packages/proteus/src/proteus-card-link/ProteusCardLink.tsx
+++ b/packages/proteus/src/proteus-card-link/ProteusCardLink.tsx
@@ -17,6 +17,7 @@ export type ProteusCardLinkProps = Omit<CardLinkProps, "onClick"> & {
 
 export function ProteusCardLink({
   children,
+  href,
   onClick,
   ...props
 }: ProteusCardLinkProps) {
@@ -29,18 +30,27 @@ export function ProteusCardLink({
 
   const [loading, setLoading] = useState(false);
 
+  // Route bare `href` through the shell's `openLink` event so sandboxed hosts (MCP Apps, OpenAI Apps SDK) — where the browser's `target="_blank"` fallback is blocked — can handle it via `onOpenLink`.
+  const hasHrefFallback = !onClick && typeof href === "string" && href !== "";
+  const eventToDispatch: ProteusEventHandler | undefined = onClick
+    ? resolvedOnClick
+    : hasHrefFallback
+      ? { action: "openLink", url: href }
+      : undefined;
+
   return (
     <CardLink
       aria-busy={loading || undefined}
+      href={href}
       onClick={
-        onClick
+        eventToDispatch
           ? async (event) => {
               event.preventDefault();
               if (loading) {
                 return;
               }
               setLoading(true);
-              await onEvent(resolvedOnClick);
+              await onEvent(eventToDispatch);
               setLoading(false);
             }
           : undefined


### PR DESCRIPTION
## Summary

`ProteusCardLink { href }` (no explicit `onClick`) previously fell through to the browser's `<a target=\"_blank\">` behavior. In sandboxed hosts — MCP Apps widgets, OpenAI Apps SDK iframes — those iframes are missing `allow-popups`, so the click is silently blocked (`Blocked opening '…' in a new window because the request was made in a sandboxed frame`).

3.6.0 shipped `onOpenLink` on `ProteusDocumentShell` ([PR #1757](https://github.com/optimizely-axiom/optiaxiom/pull/1757)) — hosts can now route `openLink` events to `app.openLink` / `window.openai.openExternal`. But that only helped templates that explicitly dispatched `{ action: \"openLink\", url }` from an `onClick` action. Every template with `CardLink { href }` (e.g. shamwow's `cmp-search-results.json`) still hit the blocked-anchor path.

This PR makes `ProteusCardLink` intercept clicks when `href` is set (and no `onClick`), dispatching `{ action: \"openLink\", url: href }` through `onEvent` so the shell — and the host — can handle it uniformly.

## Behaviour matrix

| \`onClick\` | \`href\` | Before | After |
|---|---|---|---|
| set | any | dispatch \`onClick\` via \`onEvent\` | ✅ unchanged |
| — | set | native \`<a target=\"_blank\">\` → **blocked in sandbox** | dispatch \`{action:\"openLink\", url}\` → \`onOpenLink\` → host |
| — | — | no click handler | ✅ unchanged |

Non-breaking: existing \`onClick\` behaviour is untouched; outside embedded shells, \`ProteusDocumentShell\`'s \`window.open(url, \"_blank\", \"noopener,noreferrer\")\` fallback still runs when no \`onOpenLink\` is provided.

## Test plan

- [x] \`pnpm -F @optiaxiom/proteus build\` — clean
- [x] \`pnpm lint\` — clean (oxlint, 2003 files)
- [x] \`pnpm test\` — 48/48 pass (proteus has no test project wired into CI; adding one for this component is a good follow-up)
- [ ] Verify in a sandboxed MCP host (Copilot mcpwidget) that a \`CardLink { href }\` click reaches \`app.openLink\` instead of the blocked \`window.open\` — smoke test with shamwow's cmp-search-results card after this ships + \`@optiaxiom/proteus\` bump lands in \`remote-mcp-server\`
- [ ] Verify browser-standalone (no host) still opens the link via the \`ProteusDocumentShell.window.open\` fallback

## Rollout notes

Consumer chain to actually see this in prod:
1. Merge + publish \`@optiaxiom/proteus\` (patch bump, changeset included)
2. Bump the version in \`remote-mcp-server/package.json\` + deploy
3. Flush \`compiled_html:*\` Redis keys in remote-mcp-server after deploy (per-widget entries live 30 min, system-renderer entry 24 h)