### PR TITLE
fix(react): tighten Heading line height to match Figma type styles

### DIFF
--- a/.changeset/dialog-details-header-align.md
+++ b/.changeset/dialog-details-header-align.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/react": patch
+---
+
+`DialogHeader` and `DetailsPanelHeader` now vertically center their title against the close button and action addons (`alignItems: "center"`), fixing a latent misalignment that the tighter `Heading` line height made visible.

--- a/.changeset/heading-line-height-figma.md
+++ b/.changeset/heading-line-height-figma.md
@@ -1,0 +1,7 @@
+---
+"@optiaxiom/react": patch
+"@optiaxiom/web-components": patch
+"@optiaxiom/proteus": patch
+---
+
+`Heading` now sets font size and a tighter line height together per level to match the Figma type styles (1: 50px/1.04, 2: 28px/1.04, 3: 20px/1.1, 4: 16px/1.3). To render a level's size under a different tag, use `level` with `asChild` instead of overriding `fontSize`.

--- a/.changeset/heading-line-height-mcp.md
+++ b/.changeset/heading-line-height-mcp.md
@@ -1,0 +1,5 @@
+---
+"@optiaxiom/mcp": patch
+---
+
+Regenerated the embedded metadata for the updated `Heading` `level` documentation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,9 @@ incomplete. This is the most commonly missed step — check for it on every revi
   `major` = breaking changes.
 - Write the summary for **consumers**, present tense and specific ("added `X` to `Y` via `prop`"),
   not a description of the code change.
+- **Keep it concise — never verbose.** Aim for one sentence; two only when a behavioral caveat
+  genuinely needs it. State what changed and, if non-obvious, why. Don't pad with restated context,
+  migration essays, or defensive "this is non-breaking" prose.
 - A follow-up to a feature that hasn't been released yet may not need its own changeset.
 
 ## Component conventions

--- a/packages/mcp/src/data.json
+++ b/packages/mcp/src/data.json
@@ -60236,7 +60236,7 @@
           "values": ["stretch", "center", "end", "start", "normal"]
         },
         "level": {
-          "description": "Heading level (1-4) that controls both the semantic HTML tag and font size.\n- `level=\"1\"`: renders `<h1>` with `fontSize=\"4xl\"` (default)\n- `level=\"2\"`: renders `<h2>` with `fontSize=\"3xl\"`\n- `level=\"3\"`: renders `<h3>` with `fontSize=\"2xl\"`\n- `level=\"4\"`: renders `<h4>` with `fontSize=\"xl\"`\n\nUse `asChild` to decouple the semantic level from visual appearance.",
+          "description": "Heading level (1-4) that controls the semantic HTML tag, font size, and\nline height together (the sizes come from the design library, so don't\noverride `fontSize` directly).\n- `level=\"1\"`: renders `<h1>` at 50px/1.04 (default)\n- `level=\"2\"`: renders `<h2>` at 28px/1.04\n- `level=\"3\"`: renders `<h3>` at 20px/1.1\n- `level=\"4\"`: renders `<h4>` at 16px/1.3\n\nTo use a level's visual size under a different semantic tag, combine\n`level` with `asChild` (e.g. `<Heading asChild level=\"4\"><h2>…`).",
           "type": "enum",
           "values": ["2", "1", "3", "4"],
           "default": "1"

--- a/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
+++ b/packages/proteus/src/proteus-document/ProteusDocumentShell.tsx
@@ -446,8 +446,8 @@ export function ProteusDocumentShell({
                 </Group>
               )}
               <Group flex="1" flexDirection="column" gap="4">
-                <Heading fontSize="lg" fontWeight="600" level="2" lineClamp="2">
-                  {element.title}
+                <Heading asChild level="4" lineClamp="2">
+                  <h2>{element.title}</h2>
                 </Heading>
                 {!!element.subtitle && (
                   <Tooltip auto content={element.subtitle}>

--- a/packages/proteus/src/schema/public-schema.json
+++ b/packages/proteus/src/schema/public-schema.json
@@ -3637,7 +3637,7 @@
             { "const": "4" },
             { "$ref": "#/definitions/ProteusExpression" }
           ],
-          "description": "Heading level (1-4) that controls both the semantic HTML tag and font size.\n- `level=\"1\"`: renders `<h1>` with `fontSize=\"4xl\"` (default)\n- `level=\"2\"`: renders `<h2>` with `fontSize=\"3xl\"`\n- `level=\"3\"`: renders `<h3>` with `fontSize=\"2xl\"`\n- `level=\"4\"`: renders `<h4>` with `fontSize=\"xl\"`\n\nUse `asChild` to decouple the semantic level from visual appearance."
+          "description": "Heading level (1-4) that controls the semantic HTML tag, font size, and\nline height together (the sizes come from the design library, so don't\noverride `fontSize` directly).\n- `level=\"1\"`: renders `<h1>` at 50px/1.04 (default)\n- `level=\"2\"`: renders `<h2>` at 28px/1.04\n- `level=\"3\"`: renders `<h3>` at 20px/1.1\n- `level=\"4\"`: renders `<h4>` at 16px/1.3\n\nTo use a level's visual size under a different semantic tag, combine\n`level` with `asChild` (e.g. `<Heading asChild level=\"4\"><h2>…`)."
         },
         "m": { "$ref": "#/definitions/SprinkleProp_m" },
         "maxH": { "$ref": "#/definitions/SprinkleProp_maxH" },

--- a/packages/proteus/src/schema/runtime-schema.json
+++ b/packages/proteus/src/schema/runtime-schema.json
@@ -3585,7 +3585,7 @@
             { "const": "4" },
             { "$ref": "#/definitions/ProteusExpression" }
           ],
-          "description": "Heading level (1-4) that controls both the semantic HTML tag and font size.\n- `level=\"1\"`: renders `<h1>` with `fontSize=\"4xl\"` (default)\n- `level=\"2\"`: renders `<h2>` with `fontSize=\"3xl\"`\n- `level=\"3\"`: renders `<h3>` with `fontSize=\"2xl\"`\n- `level=\"4\"`: renders `<h4>` with `fontSize=\"xl\"`\n\nUse `asChild` to decouple the semantic level from visual appearance."
+          "description": "Heading level (1-4) that controls the semantic HTML tag, font size, and\nline height together (the sizes come from the design library, so don't\noverride `fontSize` directly).\n- `level=\"1\"`: renders `<h1>` at 50px/1.04 (default)\n- `level=\"2\"`: renders `<h2>` at 28px/1.04\n- `level=\"3\"`: renders `<h3>` at 20px/1.1\n- `level=\"4\"`: renders `<h4>` at 16px/1.3\n\nTo use a level's visual size under a different semantic tag, combine\n`level` with `asChild` (e.g. `<Heading asChild level=\"4\"><h2>…`)."
         },
         "m": { "$ref": "#/definitions/SprinkleProp_m" },
         "maxH": { "$ref": "#/definitions/SprinkleProp_maxH" },

--- a/packages/react/src/details-panel/DetailsPanelHeader.css.ts
+++ b/packages/react/src/details-panel/DetailsPanelHeader.css.ts
@@ -3,6 +3,7 @@ import { recipe, style } from "../vanilla-extract";
 export const header = recipe({
   base: [
     {
+      alignItems: "center",
       bg: "bg.default",
       display: "flex",
       flexWrap: "wrap",

--- a/packages/react/src/details-panel/DetailsPanelHeader.tsx
+++ b/packages/react/src/details-panel/DetailsPanelHeader.tsx
@@ -47,14 +47,8 @@ export const DetailsPanelHeader = forwardRef<
         <Box ref={ref} {...styles.header({}, className)} {...props}>
           {addonBefore && <Group gap="8">{addonBefore}</Group>}
 
-          <Heading
-            flex="1"
-            fontSize="lg"
-            fontWeight="600"
-            id={labelId}
-            level="2"
-          >
-            {children}
+          <Heading asChild flex="1" level="4">
+            <h2 id={labelId}>{children}</h2>
           </Heading>
 
           {addonAfter && <Group gap="8">{addonAfter}</Group>}

--- a/packages/react/src/dialog/DialogHeader.css.ts
+++ b/packages/react/src/dialog/DialogHeader.css.ts
@@ -3,6 +3,7 @@ import { recipe, style } from "../vanilla-extract";
 export const header = recipe({
   base: [
     {
+      alignItems: "center",
       bg: "bg.default",
       display: "flex",
       flexWrap: "wrap",

--- a/packages/react/src/heading/Heading.css.ts
+++ b/packages/react/src/heading/Heading.css.ts
@@ -1,3 +1,5 @@
+import { theme } from "@optiaxiom/globals";
+
 import { recipe, style } from "../vanilla-extract";
 
 export const heading = recipe({
@@ -5,6 +7,24 @@ export const heading = recipe({
     fontFamily: "heading",
   },
   variants: {
+    level: {
+      "1": style({
+        fontSize: theme.fontSize["4xl"].fontSize,
+        lineHeight: 1.04,
+      }),
+      "2": style({
+        fontSize: theme.fontSize["3xl"].fontSize,
+        lineHeight: 1.04,
+      }),
+      "3": style({
+        fontSize: theme.fontSize.xl.fontSize,
+        lineHeight: 1.1,
+      }),
+      "4": style({
+        fontSize: theme.fontSize.lg.fontSize,
+        lineHeight: 1.3,
+      }),
+    },
     tracking: {
       wide: style({
         letterSpacing: "1%",

--- a/packages/react/src/heading/Heading.tsx
+++ b/packages/react/src/heading/Heading.tsx
@@ -13,13 +13,16 @@ export type HeadingProps<T extends ElementType = "h1", P = unknown> = TextProps<
   ExtendProps<
     {
       /**
-       * Heading level (1-4) that controls both the semantic HTML tag and font size.
-       * - `level="1"`: renders `<h1>` with `fontSize="4xl"` (default)
-       * - `level="2"`: renders `<h2>` with `fontSize="3xl"`
-       * - `level="3"`: renders `<h3>` with `fontSize="2xl"`
-       * - `level="4"`: renders `<h4>` with `fontSize="xl"`
+       * Heading level (1-4) that controls the semantic HTML tag, font size, and
+       * line height together (the sizes come from the design library, so don't
+       * override `fontSize` directly).
+       * - `level="1"`: renders `<h1>` at 50px/1.04 (default)
+       * - `level="2"`: renders `<h2>` at 28px/1.04
+       * - `level="3"`: renders `<h3>` at 20px/1.1
+       * - `level="4"`: renders `<h4>` at 16px/1.3
        *
-       * Use `asChild` to decouple the semantic level from visual appearance.
+       * To use a level's visual size under a different semantic tag, combine
+       * `level` with `asChild` (e.g. `<Heading asChild level="4"><h2>…`).
        */
       level?: keyof typeof mapLevelToTag;
     },
@@ -32,12 +35,6 @@ const mapLevelToTag = {
   "2": "h2",
   "3": "h3",
   "4": "h4",
-} as const;
-const mapLevelToFontSize = {
-  "1": "4xl",
-  "2": "3xl",
-  "3": "xl",
-  "4": "lg",
 } as const;
 const mapLevelToFontWeight = {
   "1": "900",
@@ -82,16 +79,15 @@ export const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(
     ref,
   ) => {
     const Comp = asChild ? Slot : (mapLevelToTag[level] ?? "h1");
-    const fontSize = mapLevelToFontSize[level] ?? "4xl";
 
     return (
       <Text
         asChild
-        fontSize={fontSize}
         fontWeight={fontWeight ?? mapLevelToFontWeight[level] ?? "700"}
         ref={ref}
         {...styles.heading(
           {
+            level,
             tracking: mapLevelToTracking[level],
           },
           className,


### PR DESCRIPTION
## What

`Heading` inherited the loose line height paired with each `fontSize` token. Most visibly, `<Heading level="2">` (28px) rendered a **40px / 1.43** line height where the published Figma **Header/Heading 2** style is **1.04** — ~11px looser per line, compounding on multi-line titles (2 lines = 80px in code vs 58px in Figma). Flagged by Maurice Cruz.

## Change

The `Heading` recipe now sets **font size and line height together per level**, using the Figma type-style ratios, instead of relying on the `fontSize` sprinkle (which pairs a looser line height with each token):

| level | font size | line height |
|-------|-----------|-------------|
| 1 | 50px | 1.04 |
| 2 | 28px | 1.04 |
| 3 | 20px | 1.1 |
| 4 | 16px | 1.3 |

Verified in Storybook — computed line heights now render 52 / 29.12 / 22 / 20.8px respectively.

### Why the recipe (not the token)

The `fontSize` sprinkle emits `line-height` alongside `font-size`, and sprinkle styles sit directly in the `optiaxiom` layer, which outranks the sub-layer recipe styles. So a recipe line-height can't override the sprinkle's while `Heading` still passes `fontSize`. Dropping the `fontSize` prop and letting the recipe own both sidesteps the conflict without retuning the shared `fontSize` tokens (which `Button`, `Avatar`, `RichTextEditor`, etc. also consume).

An explicit `<Heading fontSize="...">` still works — the sprinkle wins over the recipe — so components that borrow a non-level size (e.g. `CardHeader` at `md`) are unaffected.

### Header alignment fix (surfaced by this change)

The tighter heading box exposed a **pre-existing** misalignment. `DialogHeader` and `DetailsPanelHeader` place the title in a flex row next to the close button / action addons but never set `alignItems` — they only *looked* centered because the old heading line height happened to roughly match the control height (e.g. level-3 was 28px vs a 32px close button). With the tighter line height the gap is obvious.

Both header recipes now set `alignItems: center`. Verified in Storybook: title and controls are now geometrically centered (matching row centers). `flexWrap: wrap` means this only affects the title/controls row; the full-width description still wraps below.

### Consumer updates

`DetailsPanelHeader` and the `ProteusDocumentShell` title previously did `<Heading level="2" fontSize="lg">` to get level-4 visuals under an `<h2>`. They now use `level="4"` + `asChild` with an explicit `<h2>`, the sanctioned way to decouple semantic level from visual size. Rendered output unchanged (16px / 1.3 / weight 600, `<h2>`).

## Housekeeping

- Fixed the stale level→size mapping in the `Heading` JSDoc.
- Regenerated `packages/proteus/src/schema/*.json` and `packages/mcp/src/data.json` (they embed the JSDoc).
- Added a changeset-conciseness note to `CLAUDE.md`.

Changesets: `@optiaxiom/react` (Heading + header alignment), `@optiaxiom/web-components`, `@optiaxiom/proteus`, `@optiaxiom/mcp` (all patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)